### PR TITLE
new rule template for detecting a regular expression pattern on a single line

### DIFF
--- a/sonar-web-plugin/src/main/java/org/sonar/plugins/web/checks/coding/RegularExpressionNotAllowedOnLineCheck.java
+++ b/sonar-web-plugin/src/main/java/org/sonar/plugins/web/checks/coding/RegularExpressionNotAllowedOnLineCheck.java
@@ -1,0 +1,77 @@
+/*
+ * SonarSource :: Web :: Sonar Plugin
+ * Copyright (c) 2010-2016 SonarSource SA and Matthijs Galesloot
+ * sonarqube@googlegroups.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sonar.plugins.web.checks.coding;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.List;
+
+import org.sonar.api.utils.SonarException;
+import org.sonar.check.Priority;
+import org.sonar.check.Rule;
+import org.sonar.check.RuleProperty;
+import org.sonar.plugins.web.checks.AbstractPageCheck;
+import org.sonar.plugins.web.checks.RuleTags;
+import org.sonar.plugins.web.node.Node;
+import org.sonar.plugins.web.visitor.CharsetAwareVisitor;
+import org.sonar.squidbridge.annotations.NoSqale;
+import org.sonar.squidbridge.annotations.RuleTemplate;
+
+import com.google.common.io.Files;
+
+@Rule(
+  key = "RegularExpressionNotAllowedOnLineCheck", 
+  name = "Regular expression \"regex\" not allowed on web page",
+  priority = Priority.MAJOR, tags = {
+  RuleTags.CONVENTION })
+@RuleTemplate
+@NoSqale
+public final class RegularExpressionNotAllowedOnLineCheck extends AbstractPageCheck implements CharsetAwareVisitor {
+
+	@RuleProperty(
+      key = "regex", 
+      description = "Single line regular expression to prohibit on web pages")
+	public String regex = "";
+	
+	private Charset charset;
+
+	@Override
+	public void setCharset(Charset charset) {
+	   this.charset = charset;
+	}
+
+	@Override
+	public void startDocument(List<Node> nodes) {
+		// if user forgot to enter a regular expression, don't throw a violation on every line
+		if (! regex.isEmpty()) {
+			List<String> lines;
+			try {
+				lines = Files.readLines(getWebSourceCode().inputFile().file(), charset);
+			} catch (IOException e) {
+				throw new SonarException(e);
+			}
+			for (int i = 0; i < lines.size(); i++) {
+				// only support matching text within a single line to facilitate identifying line number
+				if (lines.get(i).matches("^.*" + regex + ".*$")) {
+					createViolation(i + 1, "Replace all instances of regular expression: " + regex);
+				}
+			}
+		}
+	}
+
+}

--- a/sonar-web-plugin/src/main/java/org/sonar/plugins/web/rules/CheckClasses.java
+++ b/sonar-web-plugin/src/main/java/org/sonar/plugins/web/rules/CheckClasses.java
@@ -27,6 +27,7 @@ import org.sonar.plugins.web.checks.coding.DoubleQuotesCheck;
 import org.sonar.plugins.web.checks.coding.FileLengthCheck;
 import org.sonar.plugins.web.checks.coding.InternationalizationCheck;
 import org.sonar.plugins.web.checks.coding.MaxLineLengthCheck;
+import org.sonar.plugins.web.checks.coding.RegularExpressionNotAllowedOnLineCheck;
 import org.sonar.plugins.web.checks.coding.UnclosedTagCheck;
 import org.sonar.plugins.web.checks.comments.AvoidCommentedOutCodeCheck;
 import org.sonar.plugins.web.checks.comments.AvoidHtmlCommentCheck;
@@ -131,6 +132,7 @@ public final class CheckClasses {
     PageWithoutFaviconCheck.class,
     ElementWithGivenIdPresentCheck.class,
     PasswordAutocompleteCheck.class,
+    RegularExpressionNotAllowedOnLineCheck.class
   };
 
   private CheckClasses() {

--- a/sonar-web-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/RegularExpressionNotAllowedOnLineCheck.html
+++ b/sonar-web-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/RegularExpressionNotAllowedOnLineCheck.html
@@ -1,0 +1,5 @@
+<p>
+This rule allows you make sure a specified regular expression does not occur on any lines of the file.
+It is useful when the string you are looking for does not represent a HTML element. For example, checking
+for a string within attributes, tags, comments or tags.
+</p>

--- a/sonar-web-plugin/src/test/java/org/sonar/plugins/web/checks/coding/RegularExpressionNotAllowedOnLineCheckTest.java
+++ b/sonar-web-plugin/src/test/java/org/sonar/plugins/web/checks/coding/RegularExpressionNotAllowedOnLineCheckTest.java
@@ -1,0 +1,70 @@
+/*
+ * SonarSource :: Web :: Sonar Plugin
+ * Copyright (c) 2010-2016 SonarSource SA and Matthijs Galesloot
+ * sonarqube@googlegroups.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sonar.plugins.web.checks.coding;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.io.File;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.sonar.plugins.web.checks.CheckMessagesVerifierRule;
+import org.sonar.plugins.web.checks.TestHelper;
+import org.sonar.plugins.web.visitor.WebSourceCode;
+
+public class RegularExpressionNotAllowedOnLineCheckTest {
+
+  @Rule
+  public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
+
+  @Test
+  public void detected() {
+    assertThat(new RegularExpressionNotAllowedOnLineCheck().regex).isEmpty();
+  }
+
+  @Test
+  public void custom() {
+	RegularExpressionNotAllowedOnLineCheck check = new RegularExpressionNotAllowedOnLineCheck();
+    check.regex = "Tester";
+
+    WebSourceCode sourceCode = TestHelper.scan(new File("src/test/resources/checks/RegularExpressionNotAllowedOnLineCheck.html"), check);
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+        .next().atLine(3).withMessage("Replace all instances of regular expression: Tester");
+  }
+  
+  @Test
+  public void skipsCheckIfNoRegExpSpecified() {
+	RegularExpressionNotAllowedOnLineCheck check = new RegularExpressionNotAllowedOnLineCheck();
+
+    WebSourceCode sourceCode = TestHelper.scan(new File("src/test/resources/checks/RegularExpressionNotAllowedOnLineCheck.html"), check);
+
+    checkMessagesVerifier.verify(sourceCode.getIssues());
+  }
+
+  @Test
+  public void custom_ok() {
+	RegularExpressionNotAllowedOnLineCheck check = new RegularExpressionNotAllowedOnLineCheck();
+    check.regex = "Not Found";
+
+    WebSourceCode sourceCode = TestHelper.scan(new File("src/test/resources/checks/RegularExpressionNotAllowedOnLineCheck.html"), check);
+
+    checkMessagesVerifier.verify(sourceCode.getIssues());
+  }
+
+}

--- a/sonar-web-plugin/src/test/resources/checks/RegularExpressionNotAllowedOnLineCheck.html
+++ b/sonar-web-plugin/src/test/resources/checks/RegularExpressionNotAllowedOnLineCheck.html
@@ -1,0 +1,5 @@
+<html>
+<head>
+  <title>Regular Expression Tester</title>
+</head>
+</html>


### PR DESCRIPTION
I needed a rule that checks web files for arbitrary strings on a line. They could be anywhere in the file and a substring of attributes, character data, etc.  I described the use case in [my blog](https://www.selikoff.net/2016/05/29/sonar-plugins-and-why-i-had-to-fork-the-sonar-web-plugin-to-add-a-rule/). Since the rule has to be in the web plugin (based on file type and not being able to extend the web plugin externally), I forked to add the rule template. I made it a rule template to make it more generic.

Submitting a pull request in case you are interested in incorporating this rule template in the actual sonar web plugin.
