### PR TITLE
Add rule to check nested script nodes.

### DIFF
--- a/its/plugin/src/test/resources/com/sonar/it/web/backup.xml
+++ b/its/plugin/src/test/resources/com/sonar/it/web/backup.xml
@@ -79,6 +79,11 @@
     </rule>
     <rule>
       <repositoryKey>Web</repositoryKey>
+      <key>NestedJavaScriptCheck</key>
+      <priority>CRITICAL</priority>
+    </rule>
+    <rule>
+      <repositoryKey>Web</repositoryKey>
       <key>MultiplePageDirectivesCheck</key>
       <priority>MINOR</priority>
     </rule>

--- a/sonar-web-plugin/src/main/java/org/sonar/plugins/web/checks/scripting/NestedJavaScriptCheck.java
+++ b/sonar-web-plugin/src/main/java/org/sonar/plugins/web/checks/scripting/NestedJavaScriptCheck.java
@@ -1,0 +1,48 @@
+/*
+ * SonarWeb :: SonarQube Plugin
+ * Copyright (c) 2010-2018 SonarSource SA and Matthijs Galesloot
+ * sonarqube@googlegroups.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sonar.plugins.web.checks.scripting;
+
+import org.sonar.check.Rule;
+import org.sonar.plugins.web.checks.AbstractPageCheck;
+import org.sonar.plugins.web.node.TagNode;
+
+@Rule(key = "NestedJavaScriptCheck")
+public class NestedJavaScriptCheck extends AbstractPageCheck {
+
+  private boolean insideScriptElement;
+  
+  @Override
+  public void startElement(TagNode element) {
+    if (element.equalsElementName("script")) {
+      insideScriptElement = true;
+    }
+  }
+  
+  @Override
+  public void endElement(TagNode element) {
+    if (element.equalsElementName("script")) {
+      if (!insideScriptElement) {
+        createViolation(element.getEndLinePosition(),
+            "A </script> was found without an opening tag. This may be caused by nested script tags." +
+            "Avoid nested script tags as they are not supported by the browsers.");
+      }
+      insideScriptElement = false;
+    }
+  }
+
+}

--- a/sonar-web-plugin/src/main/java/org/sonar/plugins/web/rules/CheckClasses.java
+++ b/sonar-web-plugin/src/main/java/org/sonar/plugins/web/rules/CheckClasses.java
@@ -37,6 +37,7 @@ import org.sonar.plugins.web.checks.header.HeaderCheck;
 import org.sonar.plugins.web.checks.header.MultiplePageDirectivesCheck;
 import org.sonar.plugins.web.checks.scripting.JspScriptletCheck;
 import org.sonar.plugins.web.checks.scripting.LongJavaScriptCheck;
+import org.sonar.plugins.web.checks.scripting.NestedJavaScriptCheck;
 import org.sonar.plugins.web.checks.scripting.UnifiedExpressionCheck;
 import org.sonar.plugins.web.checks.sonar.AbsoluteURICheck;
 import org.sonar.plugins.web.checks.sonar.BoldAndItalicTagsCheck;
@@ -92,6 +93,7 @@ public final class CheckClasses {
     JspScriptletCheck.class,
     LibraryDependencyCheck.class,
     LongJavaScriptCheck.class,
+    NestedJavaScriptCheck.class,
     MaxLineLengthCheck.class,
     ParentElementIllegalCheck.class,
     ParentElementRequiredCheck.class,

--- a/sonar-web-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/NestedJavaScriptCheck.html
+++ b/sonar-web-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/NestedJavaScriptCheck.html
@@ -1,0 +1,33 @@
+<p>When parsing a script node, the browser treats its contents as plain text, and immediately finishes parsing when it finds the first closing <code>&lt;/script&gt;</code> character sequence.
+As a consequence, nested script nodes are not possible, because all opening <code>&lt;script&gt;</code> tags found along the way are ignored. In this case, the browsers, just as this rule, see one script node, and a mismatched ending <code>&lt;/script&gt;</code> tag:
+<pre>
+&lt;script type="text/template"&gt;  &lt;!-- Start of script node --&gt;
+  &lt;script type="text/javascript"&gt;
+  &lt;/script&gt;  &lt;!-- End of script node --&gt;
+&lt;/script&gt;  &lt;!-- Dangling "&lt;/script&gt;" tag, results in a violation. --&gt;
+</pre>
+Avoid nested script nodes as they are not supported by the browsers, and make sure to correctly match the opening and the closing script tags.</p>
+<h2>Noncompliant Code Example</h2>
+<pre>
+&lt;script type="text/template"&gt;
+  &lt;div&gt;
+    Hello!
+  &lt;/div&gt;
+  &lt;script type="text/javascript"&gt;  &lt;!-- Noncompliant --&gt;
+    alert("Hi!");
+  &lt;/script&gt;
+&lt;/script&gt;
+</pre>
+<h2>Compliant Solution</h2>
+<pre>
+&lt;script type="text/javascript"&gt;
+  alert("Hi!");
+&lt;/script&gt;
+
+&lt;script type="text/template"&gt;
+  &lt;div&gt;
+    Hello!
+  &lt;/div&gt;
+&lt;/script&gt;
+</pre>
+

--- a/sonar-web-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/NestedJavaScriptCheck.json
+++ b/sonar-web-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/NestedJavaScriptCheck.json
@@ -1,0 +1,9 @@
+{
+  "title": "Script tags should not be nested",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "tags": [
+  ],
+  "defaultSeverity": "Major",
+  "sqKey": "NestedJavaScriptCheck"
+}

--- a/sonar-web-plugin/src/test/java/org/sonar/plugins/web/checks/scripting/NestedJavaScriptCheckTest.java
+++ b/sonar-web-plugin/src/test/java/org/sonar/plugins/web/checks/scripting/NestedJavaScriptCheckTest.java
@@ -1,0 +1,64 @@
+/*
+ * SonarWeb :: SonarQube Plugin
+ * Copyright (c) 2010-2018 SonarSource SA and Matthijs Galesloot
+ * sonarqube@googlegroups.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sonar.plugins.web.checks.scripting;
+
+import java.io.File;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.sonar.plugins.web.checks.CheckMessagesVerifierRule;
+import org.sonar.plugins.web.checks.TestHelper;
+import org.sonar.plugins.web.visitor.WebSourceCode;
+
+public class NestedJavaScriptCheckTest {
+
+  @Rule
+  public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
+
+  @Test
+  public void no_violations_should_be_reported_for_correct_script_tags() {
+    NestedJavaScriptCheck check = new NestedJavaScriptCheck();
+    
+    WebSourceCode sourceCode = TestHelper.scan(new File("src/test/resources/checks/NestedJavaScriptCheck/CorrectScriptTags.html"), check);
+    
+    checkMessagesVerifier.verify(sourceCode.getIssues()).noMore();
+  }
+  
+  @Test
+  public void dangling_script_end_tag_should_result_in_a_violation() {
+    NestedJavaScriptCheck check = new NestedJavaScriptCheck();
+    
+    WebSourceCode sourceCode = TestHelper.scan(new File("src/test/resources/checks/NestedJavaScriptCheck/DanglingScriptEndTag.html"), check);
+    
+    checkMessagesVerifier.verify(sourceCode.getIssues()).next().atLine(4).noMore();
+  }
+  
+  @Test
+  public void nested_script_node_should_result_in_a_violation() {
+    NestedJavaScriptCheck check = new NestedJavaScriptCheck();
+    
+    WebSourceCode sourceCode = TestHelper.scan(new File("src/test/resources/checks/NestedJavaScriptCheck/NestedScriptNodes.html"), check);
+    
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(8)
+      .next().atLine(16)
+      .next().atLine(25)
+      .noMore();
+  }
+
+}

--- a/sonar-web-plugin/src/test/resources/checks/NestedJavaScriptCheck/CorrectScriptTags.html
+++ b/sonar-web-plugin/src/test/resources/checks/NestedJavaScriptCheck/CorrectScriptTags.html
@@ -1,0 +1,19 @@
+<script type="text/javascript">
+  function foo() {
+    alert('Hi!');
+  }
+</script>
+
+<script type="text/template">
+  <div>This is a template</div>
+</script>
+
+<script type="text/template">
+  var scriptTag = document.createElement('script');
+  scriptTag.setAttribute('type', 'text/javascript');
+  document.head.appendChild(scriptTag);
+</script>
+
+<script type="text/template">
+  document.write('<script type="text/javascript">alert('Hi!');<\/script>');
+</script>

--- a/sonar-web-plugin/src/test/resources/checks/NestedJavaScriptCheck/DanglingScriptEndTag.html
+++ b/sonar-web-plugin/src/test/resources/checks/NestedJavaScriptCheck/DanglingScriptEndTag.html
@@ -1,0 +1,4 @@
+<div>
+  Test
+</div>
+</script>

--- a/sonar-web-plugin/src/test/resources/checks/NestedJavaScriptCheck/NestedScriptNodes.html
+++ b/sonar-web-plugin/src/test/resources/checks/NestedJavaScriptCheck/NestedScriptNodes.html
@@ -1,0 +1,25 @@
+<script type="text/template">
+  <div>
+    Hello!
+  </div>
+  <script type="text/javascript">
+    alert("Hi!");
+  </script>
+</script>
+
+<script type="text/javascript">
+  alert("Bye!");
+</script>
+
+<script type="text/javascript">
+  document.write('<script type="text/javascript">alert("Hi!");</script>');
+</script>
+
+<script type="text/template">
+  <div>
+    <script>Hello!</script>
+    <script type="text/javascript">
+      alert("Hi!");
+    </script>
+  </div>
+</script>


### PR DESCRIPTION
This rule attempts to find nested script tags in the HTML code. Nested script tags are problematic,
because the browsers does not support them, treating the contents of the tag as plain text, and closing it at the first occurrencce of the `</script>` charcter sequence.

Please see these SO entries for more examples:

- https://stackoverflow.com/questions/6322541/nested-javascript-templates-is-this-possible-valid
- https://stackoverflow.com/questions/31773709/nested-script-tags-comparison-of-2-approaches
- https://stackoverflow.com/questions/12500613/in-html5-spec-it-seems-the-nested-script-tags-are-supported-so-what-does-a-rea

`ChildElementIllegalCheck` can't be parameterized to detect nested script nodes,
as the contents of a script node is interpreted as text (so there are no child nodes from Sonar Web model point of view).
And even if it would notice the child nodes in scripts, the ChildElementIllegalCheck only check immediete child nodes,
so it would not create violations for `script > div > script` hierarchies.
