### PR TITLE
SONARHTML-73 extend list of source file extension

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/HtmlConstants.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/HtmlConstants.java
@@ -26,8 +26,7 @@ public class HtmlConstants {
   // ================ Plugin properties ================
 
   public static final String FILE_EXTENSIONS_PROP_KEY = "sonar.html.file.suffixes";
-  public static final String FILE_EXTENSIONS_DEF_VALUE = ".html,.xhtml,.rhtml,.shtml";
-
+  public static final String FILE_EXTENSIONS_DEF_VALUE = ".html,.xhtml,.jspf,.jspx,.cshtml,.vbhtml,.aspx,.ascx,.rhtml,.erb,.shtm,.shtml";
   private HtmlConstants() {
   }
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlSensor.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlSensor.java
@@ -57,7 +57,7 @@ import org.sonar.plugins.html.visitor.NoSonarScanner;
 
 public final class HtmlSensor implements Sensor {
   private static final Logger LOG = Loggers.get(HtmlSensor.class);
-  private static final String[] PHP_FILE_SUFFIXES = {"php", "php3", "php4", "php5", "phtml", "inc"};
+  private static final String[] OTHER_FILE_SUFFIXES = {"php", "php3", "php4", "php5", "phtml", "inc", "jsp"};
 
   private final NoSonarFilter noSonarFilter;
   private final Checks<Object> checks;
@@ -92,7 +92,7 @@ public final class HtmlSensor implements Sensor {
         predicates.hasType(InputFile.Type.MAIN),
         predicates.or(
           predicates.hasLanguage(HtmlConstants.LANGUAGE_KEY),
-          predicates.or(Stream.of(PHP_FILE_SUFFIXES).map(predicates::hasExtension).toArray(FilePredicate[]::new))
+          predicates.or(Stream.of(OTHER_FILE_SUFFIXES).map(predicates::hasExtension).toArray(FilePredicate[]::new))
           )
     ));
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/HtmlSourceCode.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/HtmlSourceCode.java
@@ -78,8 +78,8 @@ public class HtmlSourceCode {
   }
 
   public boolean shouldComputeMetric() {
-    // if input file has language php, then we should not compute metrics for this file as they will be computed by php plugin
-    return !"php".equals(inputFile.language());
+    // if input file has a language other than html, then we should not compute metrics for this file as we assume they will be computed by another plugin
+    return inputFile.language() == null || "html".equals(inputFile.language());
   }
 
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/analyzers/PageCountLinesTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/analyzers/PageCountLinesTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.internal.google.common.io.Files;
 import org.sonar.api.measures.CoreMetrics;
+import org.sonar.plugins.html.api.HtmlConstants;
 import org.sonar.plugins.html.lex.PageLexer;
 import org.sonar.plugins.html.node.Node;
 import org.sonar.plugins.html.visitor.HtmlAstScanner;
@@ -54,9 +55,7 @@ public class PageCountLinesTest {
     List<Node> nodeList = lexer.parse(readFile("src/main/webapp/user-properties.jsp"));
     assertThat(nodeList.size()).isGreaterThan(100);
 
-    //  new File("test", "user-properties.jsp");
-    String relativePath = "test/user-properties.jsp";
-    HtmlSourceCode htmlSourceCode = new HtmlSourceCode(new TestInputFileBuilder("key", relativePath).setModuleBaseDir(new File(".").toPath()).build());
+    HtmlSourceCode htmlSourceCode = createHtmlSourceCode("test/user-properties.jsp");
     scanner.scan(nodeList, htmlSourceCode, Charsets.UTF_8);
 
     assertThat(htmlSourceCode.getMeasure(CoreMetrics.NCLOC)).isEqualTo(224);
@@ -68,8 +67,7 @@ public class PageCountLinesTest {
   public void testCountLinesHtmlFile() {
     List<Node> nodeList = lexer.parse(readFile("checks/AvoidHtmlCommentCheck/document.html"));
 
-    String relativePath = "test/document.html";
-    HtmlSourceCode htmlSourceCode = new HtmlSourceCode(new TestInputFileBuilder("key", relativePath).setModuleBaseDir(new File(".").toPath()).build());
+    HtmlSourceCode htmlSourceCode = createHtmlSourceCode("test/document.html");
     scanner.scan(nodeList, htmlSourceCode, Charsets.UTF_8);
 
     assertThat(htmlSourceCode.getMeasure(CoreMetrics.NCLOC)).isEqualTo(8);
@@ -81,13 +79,16 @@ public class PageCountLinesTest {
   public void testCountLinesJspFile() {
     List<Node> nodeList = lexer.parse(readFile("checks/AvoidHtmlCommentCheck/document.jsp"));
 
-    String relativePath = "testdocument.jsp";
-    HtmlSourceCode htmlSourceCode = new HtmlSourceCode(new TestInputFileBuilder("key", relativePath).setModuleBaseDir(new File(".").toPath()).build());
+    HtmlSourceCode htmlSourceCode = new HtmlSourceCode(new TestInputFileBuilder("key", "testdocument.jsp").setModuleBaseDir(new File(".").toPath()).build());
     scanner.scan(nodeList, htmlSourceCode, Charsets.UTF_8);
 
     assertThat(htmlSourceCode.getMeasure(CoreMetrics.NCLOC)).isEqualTo(2);
     assertThat(htmlSourceCode.getDetailedLinesOfCode()).containsOnly(1, 3);
     assertThat(htmlSourceCode.getMeasure(CoreMetrics.COMMENT_LINES)).isEqualTo(6);
+  }
+
+  private HtmlSourceCode createHtmlSourceCode(String relativePath) {
+    return new HtmlSourceCode(new TestInputFileBuilder("key", relativePath).setLanguage(HtmlConstants.LANGUAGE_KEY).setModuleBaseDir(new File(".").toPath()).build());
   }
 
   private Reader readFile(String fileName) {

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlTest.java
@@ -30,7 +30,7 @@ public class HtmlTest {
     MapSettings settings = new MapSettings();
     settings.setProperty(HtmlConstants.FILE_EXTENSIONS_PROP_KEY, HtmlConstants.FILE_EXTENSIONS_DEF_VALUE);
     Html html = new Html(settings.asConfig());
-    assertThat(html.getFileSuffixes()).containsOnly(".html", ".xhtml", ".rhtml", ".shtml");
+    assertThat(html.getFileSuffixes()).containsOnly(".html", ".xhtml", ".jspf", ".jspx", ".cshtml", ".vbhtml", ".aspx", ".ascx", ".rhtml", ".erb", ".shtm", ".shtml");
   }
 
   @Test


### PR DESCRIPTION
JSP is handled as php files because spotbugs plugin defines a JSP language