### PR TITLE
InlineStyleCheck: The compliant solution was non-compliant

### DIFF
--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/InlineStyleCheck.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/InlineStyleCheck.html
@@ -15,6 +15,6 @@ styling into classes makes it easier to read, understand and maintain.</p>
   &lt;/style&gt;
 &lt;/head&gt;
 &lt;body&gt;
-  &lt;h1 style="color: blue;"&gt;Hello World!&lt;/h1&gt;
+  &lt;h1&gt;Hello World!&lt;/h1&gt;
 </pre>
 


### PR DESCRIPTION
The compliant solution still used the `style` attribute.