### PR TITLE
Correcting inline style attribute check

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/style/InlineStyleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/style/InlineStyleCheck.java
@@ -35,7 +35,8 @@ public class InlineStyleCheck extends AbstractPageCheck {
   @Override
   public void startElement(TagNode element) {
 
-    if ("style".equalsIgnoreCase(element.getNodeName())) {
+    if ("style".equalsIgnoreCase(element.getNodeName()) ||
+        element.getProperty("style") != null) {
       createViolation(element.getStartLinePosition(), "Use CSS classes instead.");
     }
   }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/style/InlineStyleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/style/InlineStyleCheck.java
@@ -17,10 +17,8 @@
  */
 package org.sonar.plugins.html.checks.style;
 
-import org.apache.commons.lang.StringUtils;
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
-import org.sonar.plugins.html.node.Attribute;
 import org.sonar.plugins.html.node.TagNode;
 
 /**
@@ -36,10 +34,8 @@ public class InlineStyleCheck extends AbstractPageCheck {
 
   @Override
   public void startElement(TagNode element) {
-    for (Attribute a : element.getAttributes()) {
-      if (StringUtils.startsWithIgnoreCase(a.getName(), "style")) {
-        createViolation(element.getStartLinePosition(), "Use CSS classes instead.");
-      }
+    if (element.getAttribute("style") != null) {
+      createViolation(element.getStartLinePosition(), "Use CSS classes instead.");
     }
   }
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/style/InlineStyleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/style/InlineStyleCheck.java
@@ -17,8 +17,10 @@
  */
 package org.sonar.plugins.html.checks.style;
 
+import org.apache.commons.lang.StringUtils;
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
+import org.sonar.plugins.html.node.Attribute;
 import org.sonar.plugins.html.node.TagNode;
 
 /**
@@ -32,12 +34,11 @@ import org.sonar.plugins.html.node.TagNode;
 @Rule(key = "InlineStyleCheck")
 public class InlineStyleCheck extends AbstractPageCheck {
 
-  @Override
   public void startElement(TagNode element) {
-
-    if ("style".equalsIgnoreCase(element.getNodeName()) ||
-        element.getProperty("style") != null) {
-      createViolation(element.getStartLinePosition(), "Use CSS classes instead.");
+    for (Attribute a : element.getAttributes()) {
+      if (StringUtils.startsWithIgnoreCase(a.getName(), "style")) {
+        createViolation(element.getStartLinePosition(), "Use CSS classes instead.");
+      }
     }
   }
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/style/InlineStyleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/style/InlineStyleCheck.java
@@ -34,6 +34,7 @@ import org.sonar.plugins.html.node.TagNode;
 @Rule(key = "InlineStyleCheck")
 public class InlineStyleCheck extends AbstractPageCheck {
 
+  @Override
   public void startElement(TagNode element) {
     for (Attribute a : element.getAttributes()) {
       if (StringUtils.startsWithIgnoreCase(a.getName(), "style")) {

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/style/InlineStyleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/style/InlineStyleCheckTest.java
@@ -41,4 +41,12 @@ public class InlineStyleCheckTest {
       .next().atLine(1).withMessage("Use CSS classes instead.");
   }
 
+  @Test
+  public void inline_Style_As_Property_Should_Fail() throws Exception {
+    HtmlSourceCode sourceCode = TestHelper.scan(new File("src/test/resources/checks/inlinePropertyStyleCheck.html"), new InlineStyleCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(1).withMessage("Use CSS classes instead.");
+  }
+
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/style/InlineStyleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/style/InlineStyleCheckTest.java
@@ -38,15 +38,6 @@ public class InlineStyleCheckTest {
     HtmlSourceCode sourceCode = TestHelper.scan(new File("src/test/resources/checks/inlineStyleCheck.html"), new InlineStyleCheck());
 
     checkMessagesVerifier.verify(sourceCode.getIssues())
-      .next().atLine(1).withMessage("Use CSS classes instead.");
+      .next().atLine(4).withMessage("Use CSS classes instead.");
   }
-
-  @Test
-  public void inline_Style_As_Property_Should_Fail() throws Exception {
-    HtmlSourceCode sourceCode = TestHelper.scan(new File("src/test/resources/checks/inlinePropertyStyleCheck.html"), new InlineStyleCheck());
-
-    checkMessagesVerifier.verify(sourceCode.getIssues())
-      .next().atLine(1).withMessage("Use CSS classes instead.");
-  }
-
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlSensorTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlSensorTest.java
@@ -104,7 +104,7 @@ public class HtmlSensorTest {
     assertThat(tester.highlightingTypeAt(componentKey, 29, 17)).containsOnly(TypeOfText.STRING);
     assertThat(tester.highlightingTypeAt(componentKey, 29, 0)).containsOnly(TypeOfText.KEYWORD);
 
-    assertThat(tester.allIssues()).hasSize(84);
+    assertThat(tester.allIssues()).hasSize(95);
     assertThat(tester.allAnalysisErrors()).isEmpty();
   }
 

--- a/sonar-html-plugin/src/test/resources/checks/inlinePropertyStyleCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/inlinePropertyStyleCheck.html
@@ -1,0 +1,1 @@
+<div style="background:green;"></div>

--- a/sonar-html-plugin/src/test/resources/checks/inlinePropertyStyleCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/inlinePropertyStyleCheck.html
@@ -1,1 +1,0 @@
-<div style="background:green;"></div>

--- a/sonar-html-plugin/src/test/resources/checks/inlineStyleCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/inlineStyleCheck.html
@@ -1,4 +1,4 @@
 <head><style>nadadana</style></head>
 
 <head:style src="path/style-sheet.css" />
-<div style="color:blue" ></div>
+<div class="test" style="color:blue" ></div>

--- a/sonar-html-plugin/src/test/resources/checks/inlineStyleCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/inlineStyleCheck.html
@@ -1,3 +1,4 @@
 <head><style>nadadana</style></head>
 
 <head:style src="path/style-sheet.css" />
+<div style="color:blue" ></div>


### PR DESCRIPTION
The check is only failing on nodes named "<style>" in markup instead of styles inline as attribute as the rule specifically says it is checking.  This update repairs the check to look for an attribute and not a node name.

As the explanation says:
Noncompliant Code Example
< body >
  < h1 style="color: blue;" >Hello World!< /h1 >  <!-- Noncompliant -->