### PR TITLE
SONARHTML-98 Rule S5255: "aria-label" or "aria-labelledby" attributes…

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/IndistinguishableSimilarElementsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/IndistinguishableSimilarElementsCheck.java
@@ -81,7 +81,7 @@ public class IndistinguishableSimilarElementsCheck extends AbstractPageCheck {
     Map<String, List<TagNode>> matched = nodes.stream().collect(Collectors.groupingBy(node -> node.getAttribute("ROLE").toUpperCase(Locale.ROOT)));
     for (List<TagNode> matches : matched.values()) {
       List<TagNode> labeless = matches.stream().filter(match -> !hasAriaLabel(match)).collect(Collectors.toList());
-      if (labeless.size() > 1) {
+      if (labeless.size() > 1 || (!labeless.isEmpty() && labeless.size() != matches.size())) {
         for (TagNode node : labeless) {
           createViolation(node.getStartLinePosition(), "Add an \"aria-label\" or \"aria-labbelledby\" attribute to this element.");
         }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/IndistinguishableSimilarElementsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/IndistinguishableSimilarElementsCheck.java
@@ -1,0 +1,107 @@
+/*
+ * SonarHTML :: SonarQube Plugin
+ * Copyright (c) 2010-2019 SonarSource SA and Matthijs Galesloot
+ * sonarqube@googlegroups.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sonar.plugins.html.checks.sonar;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.sonar.check.Rule;
+import org.sonar.plugins.html.checks.AbstractPageCheck;
+import org.sonar.plugins.html.node.Node;
+import org.sonar.plugins.html.node.TagNode;
+
+@Rule(key = "S5255")
+public class IndistinguishableSimilarElementsCheck extends AbstractPageCheck {
+
+  private static final List<String> LANDMARK_ROLES = Arrays.asList(
+    "BANNER", "COMPLEMENTARY", "CONTENTINFO", "FORM", "MAIN", "NAVIGATION", "SEARCH", "APPLICATION"
+  );
+
+  private List<TagNode> navs = new LinkedList<>();
+  private List<TagNode> asides = new LinkedList<>();
+  private List<TagNode> elements = new LinkedList<>();
+
+  @Override
+  public void startDocument(List<Node> nodes) {
+    navs.clear();
+    asides.clear();
+    elements.clear();
+  }
+
+  @Override
+  public void endDocument() {
+    raiseViolationOnMissingAriaLabel(navs);
+    navs.clear();
+
+    raiseViolationOnMissingAriaLabel(asides);
+    asides.clear();
+
+    raiseViolationOnDuplicateLandmarkRole(elements);
+    elements.clear();
+  }
+
+  @Override
+  public void startElement(TagNode node) {
+    if (isNav(node)) {
+      navs.add(node);
+    } else if (isAside(node)) {
+      asides.add(node);
+    } else if (hasLandmarkRole(node)) {
+      elements.add(node);
+    }
+  }
+
+  private void raiseViolationOnMissingAriaLabel(List<TagNode> nodes) {
+    List<TagNode> matches = nodes.stream().filter(node -> !hasAriaLabel(node)).collect(Collectors.toList());
+    raiseViolationOnSize(matches);
+  }
+
+  private void raiseViolationOnDuplicateLandmarkRole(List<TagNode> nodes) {
+    Map<String, List<TagNode>> matched = nodes.stream().collect(Collectors.groupingBy(node -> node.getAttribute("role")));
+    for (List<TagNode> matches : matched.values()) {
+      raiseViolationOnSize(matches);
+    }
+  }
+
+  private void raiseViolationOnSize(List<TagNode> nodes) {
+    if (nodes.size() > 1) {
+      for (TagNode node : nodes) {
+        createViolation(node.getStartLinePosition(), "Add an \"aria-label\" or \"aria-labbelledby\" attribute to this element.");
+      }
+    }
+  }
+
+  private static boolean isNav(TagNode node) {
+    return "NAV".equalsIgnoreCase(node.getNodeName());
+  }
+
+  private static boolean isAside(TagNode node) {
+    return "ASIDE".equalsIgnoreCase(node.getNodeName());
+  }
+
+  private static boolean hasLandmarkRole(TagNode node) {
+    return LANDMARK_ROLES.stream().anyMatch(role -> role.equalsIgnoreCase(node.getPropertyValue("ROLE")));
+  }
+
+  private static boolean hasAriaLabel(TagNode node) {
+    return node.hasProperty("ARIA-LABEL") || node.hasProperty("ARIA-LABELLEDBY");
+  }
+}

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/IndistinguishableSimilarElementsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/IndistinguishableSimilarElementsCheck.java
@@ -81,7 +81,7 @@ public class IndistinguishableSimilarElementsCheck extends AbstractPageCheck {
     Map<String, List<TagNode>> matched = nodes.stream().collect(Collectors.groupingBy(node -> node.getAttribute("ROLE").toUpperCase(Locale.ROOT)));
     for (List<TagNode> matches : matched.values()) {
       List<TagNode> labeless = matches.stream().filter(match -> !hasAriaLabel(match)).collect(Collectors.toList());
-      if (labeless.size() > 1 || (!labeless.isEmpty() && labeless.size() != matches.size())) {
+      if (labeless.size() > 1 || matches.size() > 1) {
         for (TagNode node : labeless) {
           createViolation(node.getStartLinePosition(), "Add an \"aria-label\" or \"aria-labbelledby\" attribute to this element.");
         }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/CheckClasses.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/CheckClasses.java
@@ -51,6 +51,7 @@ import org.sonar.plugins.html.checks.sonar.FlashUsesBothObjectAndEmbedCheck;
 import org.sonar.plugins.html.checks.sonar.FrameWithoutTitleCheck;
 import org.sonar.plugins.html.checks.sonar.ImgWithoutAltCheck;
 import org.sonar.plugins.html.checks.sonar.ImgWithoutWidthOrHeightCheck;
+import org.sonar.plugins.html.checks.sonar.IndistinguishableSimilarElementsCheck;
 import org.sonar.plugins.html.checks.sonar.InputWithoutLabelCheck;
 import org.sonar.plugins.html.checks.sonar.ItemTagNotWithinContainerTagCheck;
 import org.sonar.plugins.html.checks.sonar.LangAttributeCheck;
@@ -144,7 +145,8 @@ public final class CheckClasses {
     LayoutTableWithSemanticMarkupCheck.class,
     TableWithoutHeaderCheck.class,
     LangAttributeCheck.class,
-    ObjectWithAlternativeContentCheck.class
+    ObjectWithAlternativeContentCheck.class,
+    IndistinguishableSimilarElementsCheck.class
   );
 
   private CheckClasses() {

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S5255.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S5255.html
@@ -1,0 +1,73 @@
+<p>If a page contains multiple <code>&lt;nav&gt;</code>&nbsp;or <code>&lt;aside&gt;</code> elements, each one should have an <code>aria-label</code>
+or <code>aria-labelledby</code> attribute so that they can be differentiated. The same rule applies when multiple elements have
+a&nbsp;<code>role</code> attribute with the same "landmark" value.</p>
+<p>Landmark roles are: <code>banner</code>, <code>complementary</code>, <code>contentinfo</code>, <code>form</code>, <code>main</code>,
+<code>navigation</code>, <code>search</code>, <code>application</code>.&nbsp;</p>
+<p>The use of ARIA markup helps users of&nbsp;screen readers navigate across blocks of content. For example it makes groups of links easier to locate
+or skip.</p>
+<h2>Noncompliant Code Example</h2>
+<p>Multiple <code>&lt;nav&gt;</code> element</p>
+<pre>
+&lt;nav&gt; &lt;!-- Noncompliant --&gt;
+    &lt;ul&gt;
+        &lt;li&gt;A list of navigation links&lt;/li&gt;
+    &lt;/ul&gt;
+&lt;/nav&gt;
+
+&lt;article&gt;
+    &lt;nav&gt; &lt;!-- Noncompliant --&gt;
+        Another list of navigation links
+    &lt;/nav&gt;
+&lt;/article&gt;
+</pre>
+<p>Repeated "landmark" role <code>"navigation"</code></p>
+<pre>
+&lt;div id="mainnav" role="navigation"&gt; &lt;!-- Noncompliant --&gt;
+    &lt;h2 id="mainnavheading"&gt;Site Navigation&lt;/h2&gt;
+    &lt;ul&gt;
+       &lt;li&gt;List of links&lt;/li&gt;
+    &lt;/ul&gt;
+&lt;/div&gt;
+&lt;div id="secondarynav" role="navigation"&gt; &lt;!-- Noncompliant --&gt;
+    &lt;h2 id="secondarynavheading"&gt;Related links&lt;/h2&gt;
+    &lt;ul&gt;
+       &lt;li&gt;List of links&lt;/li&gt;
+    &lt;/ul&gt;
+&lt;/div&gt;
+</pre>
+<h2>Compliant Solution</h2>
+<pre>
+&lt;nav aria-label="Site menu"&gt;
+    &lt;ul&gt;
+        &lt;li&gt;A list of navigation links&lt;/li&gt;
+    &lt;/ul&gt;
+&lt;/nav&gt;
+
+&lt;article&gt;
+    &lt;nav aria-label="Related links"&gt;
+        Another list of navigation links
+    &lt;/nav&gt;
+&lt;/article&gt;
+</pre>
+<pre>
+&lt;div id="mainnav" role="navigation" aria-labelledby="mainnavheading"&gt;
+    &lt;h2 id="mainnavheading"&gt;Site Navigation&lt;/h2&gt;
+    &lt;ul&gt;
+       &lt;li&gt;List of links&lt;/li&gt;
+    &lt;/ul&gt;
+&lt;/div&gt;
+&lt;div id="secondarynav" role="navigation" aria-labelledby="secondarynavheading"&gt;
+    &lt;h2 id="secondarynavheading"&gt;Related links&lt;/h2&gt;
+    &lt;ul&gt;
+       &lt;li&gt;List of links&lt;/li&gt;
+    &lt;/ul&gt;
+&lt;/div&gt;
+</pre>
+<h2>See</h2>
+<ul>
+  <li> <a href="https://www.w3.org/TR/WCAG20-TECHS/ARIA11.html">WCAG2, ARIA11</a> - Using ARIA landmarks to identify regions of a page </li>
+  <li> <a href="https://www.w3.org/TR/WCAG20-TECHS/H97.html">WCAG2, H97</a> - Grouping related links using the nav element </li>
+  <li> <a href="https://www.w3.org/WAI/WCAG21/quickref/?versions=2.0&amp;showtechniques=131#qr-content-structure-separation-programmatic">WCAG2
+  1.3.1</a> Info and Relationships </li>
+</ul>
+

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S5255.json
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S5255.json
@@ -1,0 +1,13 @@
+{
+  "title": "\"aria-label\" or \"aria-labelledby\" attributes should be used to differentiate similar elements",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "tags": [
+    "accessibility",
+    "wcag2-a"
+  ],
+  "defaultSeverity": "Major",
+  "ruleSpecification": "RSPEC-5255",
+  "sqKey": "S5255",
+  "scope": "Main"
+}

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/Sonar_way_profile.json
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/Sonar_way_profile.json
@@ -18,10 +18,11 @@
     "S4084",
     "S4645",
     "S5256",
-    "S5257",
     "S5258",
     "S5254",
     "S5264",
+    "S5255",
+    "S5257",
     "ServerSideImageMapsCheck",
     "TableWithoutCaptionCheck",
     "UnsupportedTagsInHtml5Check"

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/IndistinguishableSimilarElementsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/IndistinguishableSimilarElementsCheckTest.java
@@ -1,0 +1,45 @@
+/*
+ * SonarHTML :: SonarQube Plugin
+ * Copyright (c) 2010-2019 SonarSource SA and Matthijs Galesloot
+ * sonarqube@googlegroups.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sonar.plugins.html.checks.sonar;
+
+import java.io.File;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.sonar.plugins.html.checks.CheckMessagesVerifierRule;
+import org.sonar.plugins.html.checks.TestHelper;
+import org.sonar.plugins.html.visitor.HtmlSourceCode;
+
+public class IndistinguishableSimilarElementsCheckTest {
+  
+  @Rule
+  public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
+
+  @Test
+  public void detected() throws Exception {
+    HtmlSourceCode sourceCode = TestHelper.scan(new File("src/test/resources/checks/IndistinguishableSimilarElementsCheck.html"), new IndistinguishableSimilarElementsCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+        .next().atLine(1).withMessage("Add an \"aria-label\" or \"aria-labbelledby\" attribute to this element.")
+        .next().atLine(4)
+        .next().atLine(13)
+        .next().atLine(16)
+        .next().atLine(25)
+        .next().atLine(28);
+  }
+}

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/IndistinguishableSimilarElementsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/IndistinguishableSimilarElementsCheckTest.java
@@ -48,6 +48,7 @@ public class IndistinguishableSimilarElementsCheckTest {
         .next().atLine(16)
         .next().atLine(25)
         .next().atLine(28)
-        .next().atLine(31);
+        .next().atLine(31)
+        .next().atLine(55);
   }
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/IndistinguishableSimilarElementsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/IndistinguishableSimilarElementsCheckTest.java
@@ -31,8 +31,15 @@ public class IndistinguishableSimilarElementsCheckTest {
   public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
 
   @Test
-  public void detected() throws Exception {
-    HtmlSourceCode sourceCode = TestHelper.scan(new File("src/test/resources/checks/IndistinguishableSimilarElementsCheck.html"), new IndistinguishableSimilarElementsCheck());
+  public void singleNavAside() throws Exception {
+    HtmlSourceCode sourceCode = TestHelper.scan(new File("src/test/resources/checks/IndistinguishableSimilarElementsCheck/SingleNavAside.html"), new IndistinguishableSimilarElementsCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues());
+  }
+
+  @Test
+  public void multipleNavAside() throws Exception {
+    HtmlSourceCode sourceCode = TestHelper.scan(new File("src/test/resources/checks/IndistinguishableSimilarElementsCheck/MultipleNavAside.html"), new IndistinguishableSimilarElementsCheck());
 
     checkMessagesVerifier.verify(sourceCode.getIssues())
         .next().atLine(1).withMessage("Add an \"aria-label\" or \"aria-labbelledby\" attribute to this element.")
@@ -40,6 +47,7 @@ public class IndistinguishableSimilarElementsCheckTest {
         .next().atLine(13)
         .next().atLine(16)
         .next().atLine(25)
-        .next().atLine(28);
+        .next().atLine(28)
+        .next().atLine(31);
   }
 }

--- a/sonar-html-plugin/src/test/resources/checks/IndistinguishableSimilarElementsCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/IndistinguishableSimilarElementsCheck.html
@@ -1,0 +1,54 @@
+<nav> <!-- Noncompliant -->
+</nav>
+
+<nav> <!-- Noncompliant -->
+</nav>
+
+<nav aria-label="foo"> <!-- Compliant -->
+</nav>
+
+<nav aria-labelledby="foo">  <!-- Compliant -->
+</nav>
+
+<aside> <!-- Noncompliant -->
+</aside>
+
+<aside> <!-- Noncompliant -->
+</aside>
+
+<aside aria-label="foo"> <!-- Compliant -->
+</aside>
+
+<aside aria-labelledby="foo">  <!-- Compliant -->
+</aside>
+
+<div role="banner"> <!-- Noncompliant -->
+</div>
+
+<p role="banner"></p> <!-- Noncompliant -->
+</p>
+
+<table role="complementary"> <!-- Compliant -->
+</table>
+
+<div role="contentinfo"> <!-- Compliant -->
+</div>
+
+<div role="form"> <!-- Compliant -->
+</div>
+
+<div role="main"> <!-- Compliant -->
+</div>
+
+<div role="navigation"> <!-- Compliant -->
+</div>
+
+<div role="search"> <!-- Compliant -->
+</div>
+
+<div role="application"> <!-- Compliant -->
+</div>
+
+<div role="none"></div>
+
+<div></div>

--- a/sonar-html-plugin/src/test/resources/checks/IndistinguishableSimilarElementsCheck/MultipleNavAside.html
+++ b/sonar-html-plugin/src/test/resources/checks/IndistinguishableSimilarElementsCheck/MultipleNavAside.html
@@ -7,7 +7,7 @@
 <nav aria-label="foo"> <!-- Compliant -->
 </nav>
 
-<nav aria-labelledby="foo">  <!-- Compliant -->
+<nav aria-labelledby="foo"> <!-- Compliant -->
 </nav>
 
 <aside> <!-- Noncompliant -->
@@ -25,7 +25,7 @@
 <div role="banner"> <!-- Noncompliant -->
 </div>
 
-<p role="banner">   <!-- Noncompliant -->
+<p role="banner"> <!-- Noncompliant -->
 </p>
 
 <strong role="Banner"> <!-- Noncompliant -->
@@ -46,13 +46,16 @@
 <div role="navigation"> <!-- Compliant -->
 </div>
 
-<div role="search"> <!-- Compliant -->
+<div role="search" aria-labelledby="foo"> <!-- Compliant -->
 </div>
 
-<div role="application"> <!-- Compliant -->
+<div role="search" aria-labelledby="bar"> <!-- Compliant -->
 </div>
 
-<p role="application"  aria-labelledby="foo1"> <!-- Compliant-->
+<div role="application"> <!-- Noncompliant -->
+</div>
+
+<p role="application" aria-labelledby="foo1"> <!-- Compliant-->
 </p>
 
 <div role="none"></div>

--- a/sonar-html-plugin/src/test/resources/checks/IndistinguishableSimilarElementsCheck/MultipleNavAside.html
+++ b/sonar-html-plugin/src/test/resources/checks/IndistinguishableSimilarElementsCheck/MultipleNavAside.html
@@ -19,14 +19,17 @@
 <aside aria-label="foo"> <!-- Compliant -->
 </aside>
 
-<aside aria-labelledby="foo">  <!-- Compliant -->
+<aside aria-labelledby="foo"> <!-- Compliant -->
 </aside>
 
 <div role="banner"> <!-- Noncompliant -->
 </div>
 
-<p role="banner"></p> <!-- Noncompliant -->
+<p role="banner">   <!-- Noncompliant -->
 </p>
+
+<strong role="Banner"> <!-- Noncompliant -->
+</strong>
 
 <table role="complementary"> <!-- Compliant -->
 </table>
@@ -48,6 +51,9 @@
 
 <div role="application"> <!-- Compliant -->
 </div>
+
+<p role="application"  aria-labelledby="foo1"> <!-- Compliant-->
+</p>
 
 <div role="none"></div>
 

--- a/sonar-html-plugin/src/test/resources/checks/IndistinguishableSimilarElementsCheck/SingleNavAside.html
+++ b/sonar-html-plugin/src/test/resources/checks/IndistinguishableSimilarElementsCheck/SingleNavAside.html
@@ -1,0 +1,3 @@
+<nav></nav> <!-- Compliant -->
+
+<aside></aside> <!-- Compliant -->


### PR DESCRIPTION
… should be used to differentiate similar elements