### PR TITLE
SONARHTML-140 S1077 should not raise an issue on "<img th:alt=..."

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ImgWithoutAltCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ImgWithoutAltCheck.java
@@ -17,7 +17,6 @@
  */
 package org.sonar.plugins.html.checks.sonar;
 
-import java.util.Locale;
 import org.apache.commons.lang.StringUtils;
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.checks.AbstractPageCheck;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ImgWithoutAltCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ImgWithoutAltCheck.java
@@ -40,10 +40,7 @@ public class ImgWithoutAltCheck extends AbstractPageCheck {
 
   private static boolean isImageInput(TagNode node) {
     String type = node.getPropertyValue("TYPE");
-
-    return "INPUT".equalsIgnoreCase(node.getNodeName()) &&
-      type != null &&
-      "IMAGE".equalsIgnoreCase(type);
+    return "INPUT".equalsIgnoreCase(node.getNodeName()) && "IMAGE".equalsIgnoreCase(type);
   }
 
   private static boolean isAreaTag(TagNode node) {

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ImgWithoutAltCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ImgWithoutAltCheckTest.java
@@ -46,7 +46,8 @@ public class ImgWithoutAltCheckTest {
         .next().atLine(17)
         .next().atLine(19)
         .next().atLine(20)
-        .next().atLine(21);
+        .next().atLine(21)
+        .next().atLine(30);
   }
 
 }

--- a/sonar-html-plugin/src/test/resources/checks/ImgWithoutAltCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/ImgWithoutAltCheck.html
@@ -23,3 +23,8 @@
 <area shape="rect" v-bind:alt="foo">
 <area shape="rect" :alt="foo">
 <area shape="rect" :[alt]="foo">
+
+<img th:src="${x}" th:alt="foo"/>
+<img th:src="${x}" th:alt-title="foo"/>
+<img th:attr="src=@{logo.png},title=#{logo},alt=#{logo}"/>
+<img th:attr="src=@{logo.png},title=#{logo}"/>


### PR DESCRIPTION
Theoretically, these Thymeleaf attributes would need to be considered in many checks in which we look for the absence or at the value of an attribute ([doc](https://www.thymeleaf.org/doc/tutorials/3.0/usingthymeleaf.html#setting-value-to-specific-attributes)). 
However, I wanted to avoid going down a rabbit hole, and only fixed the specific FP of the ticket (`alt` attribute of an `img` tag). 