### PR TITLE
SONARHTML-194 Create rule S6851: Images should have a non-redundant alternate description

### DIFF
--- a/its/ruling/src/test/resources/expected/Web-S6851.json
+++ b/its/ruling/src/test/resources/expected/Web-S6851.json
@@ -1,0 +1,269 @@
+{
+"project:Silverpeas-Core-master/war-core/src/main/webapp/sharing/jsp/displayTicketInfo.jsp": [
+71
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLBodyElement07.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLBodyElement08.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLBodyElement09.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLBodyElement10.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLBodyElement11.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLBodyElement12.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLDocument01.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLDocument02.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLDocument03.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLDocument04.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLDocument05.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLDocument07.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLDocument08.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLDocument09.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLDocument10.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLDocument11.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLDocument12.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLDocument13.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLDocument14.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLDocument15.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLDocument16.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLDocument17.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLDocument18.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLDocument19.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLDocument20.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLDocument21.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLDocument22.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLDocument23.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLDocument24.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLDocument25.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLDocument26.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLDocument27.html": [
+22
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLImageElement01.html": [
+9
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLImageElement02.html": [
+9
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLImageElement03.html": [
+9
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLImageElement04.html": [
+9
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLImageElement05.html": [
+9
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLImageElement06.html": [
+9
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLImageElement07.html": [
+9
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLImageElement08.html": [
+9
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLImageElement09.html": [
+9
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLImageElement10.html": [
+9
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLImageElement11.html": [
+9
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLImageElement12.html": [
+9
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLBodyElement07.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLBodyElement08.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLBodyElement09.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLBodyElement10.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLBodyElement11.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLBodyElement12.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLDocument01.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLDocument02.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLDocument03.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLDocument04.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLDocument05.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLDocument07.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLDocument08.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLDocument09.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLDocument10.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLDocument11.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLDocument12.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLDocument13.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLDocument14.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLDocument15.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLDocument16.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLDocument17.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLDocument18.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLDocument19.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLDocument20.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLDocument21.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLDocument22.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLDocument23.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLDocument24.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLDocument25.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLDocument26.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLDocument27.xhtml": [
+24
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLImageElement01.xhtml": [
+11
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLImageElement02.xhtml": [
+11
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLImageElement03.xhtml": [
+11
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLImageElement04.xhtml": [
+11
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLImageElement05.xhtml": [
+11
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLImageElement06.xhtml": [
+11
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLImageElement07.xhtml": [
+11
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLImageElement08.xhtml": [
+11
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLImageElement09.xhtml": [
+11
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLImageElement10.xhtml": [
+11
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLImageElement11.xhtml": [
+11
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLImageElement12.xhtml": [
+11
+]
+}

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AccessibilityUtils.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AccessibilityUtils.java
@@ -1,0 +1,33 @@
+/*
+ * SonarSource HTML analyzer :: Sonar Plugin
+ * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * sonarqube@googlegroups.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sonar.plugins.html.checks.accessibility;
+
+import org.sonar.plugins.html.node.TagNode;
+
+public class AccessibilityUtils {
+
+  private AccessibilityUtils() {
+    // utility class
+  }
+
+  public static boolean isHidden(TagNode element) {
+    return ("input".equalsIgnoreCase(element.getNodeName())
+        && "hidden".equalsIgnoreCase(element.getPropertyValue("type")))
+        || "true".equalsIgnoreCase(element.getPropertyValue("aria-hidden"));
+  }
+}

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheck.java
@@ -26,6 +26,8 @@ import org.sonar.plugins.html.node.ExpressionNode;
 import org.sonar.plugins.html.node.TagNode;
 import org.sonar.plugins.html.node.TextNode;
 
+import static org.sonar.plugins.html.checks.accessibility.AccessibilityUtils.isHidden;
+
 @Rule(key = "S6827")
 public class AnchorsHaveContentCheck extends AbstractPageCheck {
 
@@ -101,11 +103,5 @@ public class AnchorsHaveContentCheck extends AbstractPageCheck {
       }
     }
     return element.hasProperty("title") || element.hasProperty("aria-label");
-  }
-
-  private static boolean isHidden(TagNode element) {
-    return ("input".equalsIgnoreCase(element.getNodeName())
-        && "hidden".equalsIgnoreCase(element.getPropertyValue("type")))
-        || "true".equalsIgnoreCase(element.getPropertyValue("aria-hidden"));
   }
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ImgRedundantAltCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ImgRedundantAltCheck.java
@@ -1,0 +1,58 @@
+/*
+ * SonarSource HTML analyzer :: Sonar Plugin
+ * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * sonarqube@googlegroups.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sonar.plugins.html.checks.accessibility;
+
+import org.sonar.check.Rule;
+import org.sonar.plugins.html.checks.AbstractPageCheck;
+import org.sonar.plugins.html.node.TagNode;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+import static org.sonar.plugins.html.checks.accessibility.AccessibilityUtils.isHidden;
+
+@Rule(key = "S6851")
+public class ImgRedundantAltCheck extends AbstractPageCheck {
+
+  private static final String MESSAGE_TEMPLATE = "Remove redundant word%s %s from the \"alt\" attribute of your \"img\" tag.";
+  private static final List<String> REDUNDANT_WORDS = List.of("image", "photo", "picture");
+
+  @Override
+  public void startElement(TagNode element) {
+    if (!isImg(element) || isHidden(element)) {
+      return;
+    }
+
+    var alt = element.getPropertyValue("alt");
+    if (alt == null) {
+      return;
+    }
+
+    var words = REDUNDANT_WORDS.stream().filter(w -> alt.toLowerCase(Locale.ENGLISH).contains(w)).collect(Collectors.toList());
+    if (!words.isEmpty()) {
+      var quotedWords = words.stream().map(w -> "\"" + w + "\"" ).collect(Collectors.joining(", "));
+      var punctuation = words.size() == 1 ? "" : "s";
+      var message = String.format(MESSAGE_TEMPLATE, punctuation, quotedWords);
+      createViolation(element.getStartLinePosition(), message);
+    }
+  }
+
+  private static boolean isImg(TagNode element) {
+    return "img".equalsIgnoreCase(element.getNodeName());
+  }
+}

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * SonarSource HTML analyzer :: Sonar Plugin
+ * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * sonarqube@googlegroups.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@ParametersAreNonnullByDefault
+package org.sonar.plugins.html.checks.accessibility;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/CheckClasses.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/CheckClasses.java
@@ -20,6 +20,7 @@ package org.sonar.plugins.html.rules;
 import java.util.List;
 
 import org.sonar.plugins.html.checks.accessibility.AnchorsHaveContentCheck;
+import org.sonar.plugins.html.checks.accessibility.ImgRedundantAltCheck;
 import org.sonar.plugins.html.checks.attributes.IllegalAttributeCheck;
 import org.sonar.plugins.html.checks.attributes.NoAccessKeyCheck;
 import org.sonar.plugins.html.checks.attributes.RequiredAttributeCheck;
@@ -103,6 +104,7 @@ public final class CheckClasses {
     IllegalElementCheck.class,
     IllegalTabCheck.class,
     IllegalTagLibsCheck.class,
+    ImgRedundantAltCheck.class,
     InlineStyleCheck.class,
     InternationalizationCheck.class,
     JspScriptletCheck.class,

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S6851.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S6851.html
@@ -1,0 +1,32 @@
+<h2>Why is this an issue?</h2>
+<p><code>alt</code> attributes, also known as "alt tags" or "alt descriptions," are used to specify alternative text that is rendered when an image
+cannot be displayed. They are crucial for improving web accessibility, as they provide a text description of images for users who rely on screen
+readers.</p>
+<p>Screen readers announce the presence of an <code>&lt;img&gt;</code> element and read its <code>alt</code> attribute aloud to describe the image. If
+the <code>alt</code> attribute includes words like "image", "picture", or "photo", it leads to redundancy as the screen reader would repeat "image".
+For instance, an <code>alt</code> attribute like "image of a sunrise" would be read as "Image, image of a sunrise", unnecessarily repeating
+"image".</p>
+<p>Instead, the <code>alt</code> attribute should focus on describing the content of the image, not the fact that it is an image. This makes the
+browsing experience more efficient and enjoyable for users of screen readers, as they receive a concise and meaningful description of the image
+without unnecessary repetition.</p>
+<h2>How to fix it</h2>
+<p>To fix this issue, you should revise the <code>alt</code> attribute of your <code>&lt;img&gt;</code> elements to remove any instances of the words
+"image", "picture", or "photo". Instead, provide a concise and accurate description of the image content that adds value for users who cannot see the
+image.</p>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+&lt;img src="sunrise.jpg" alt="image of a sunrise" /&gt; &lt;!-- Noncompliant: "Image, image of a sunrise" --&gt;
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+&lt;img src="sunrise.jpg" alt="a sunrise over a mountain range" /&gt;
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li> MDN web docs - <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img">img element</a> </li>
+  <li> MDN web docs - <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/alt">alt property</a> </li>
+  <li> WebAIM - <a href="https://webaim.org/techniques/alttext/">Alternative Text</a> </li>
+</ul>
+

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S6851.json
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S6851.json
@@ -1,0 +1,24 @@
+{
+  "title": "Images should have a non-redundant alternate description",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5min"
+  },
+  "tags": [
+    "accessibility"
+  ],
+  "defaultSeverity": "Minor",
+  "ruleSpecification": "RSPEC-6851",
+  "sqKey": "S6851",
+  "scope": "All",
+  "quickfix": "infeasible",
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "LOW",
+      "RELIABILITY": "LOW"
+    },
+    "attribute": "CONVENTIONAL"
+  }
+}

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/Sonar_way_profile.json
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/Sonar_way_profile.json
@@ -28,6 +28,7 @@
     "S5725",
     "S6827",
     "S6846",
+    "S6851",
     "ServerSideImageMapsCheck",
     "TableHeaderHasIdOrScopeCheck",
     "TableWithoutCaptionCheck",

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ImgRedundantAltCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ImgRedundantAltCheckTest.java
@@ -1,0 +1,47 @@
+/*
+ * SonarSource HTML analyzer :: Sonar Plugin
+ * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * sonarqube@googlegroups.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sonar.plugins.html.checks.accessibility;
+
+import java.io.File;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.sonar.plugins.html.checks.CheckMessagesVerifierRule;
+import org.sonar.plugins.html.checks.TestHelper;
+import org.sonar.plugins.html.visitor.HtmlSourceCode;
+
+class ImgRedundantAltCheckTest {
+
+  @RegisterExtension
+  public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
+
+  @Test
+  void test() throws Exception {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/ImgRedundantAltCheck.html"),
+      new ImgRedundantAltCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(1).withMessage(
+        "Remove redundant words \"photo\", \"picture\" from the \"alt\" attribute of your \"img\" tag.")
+      .next().atLine(2).withMessage(
+        "Remove redundant word \"photo\" from the \"alt\" attribute of your \"img\" tag.")
+      .next().atLine(3)
+      .next().atLine(4)
+      .noMore();
+  }
+}

--- a/sonar-html-plugin/src/test/resources/checks/ImgRedundantAltCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/ImgRedundantAltCheck.html
@@ -1,0 +1,9 @@
+<img alt="Photo of me taking pictures of cats." />  <!-- Noncompliant -->
+<img alt="Photo of a cat." />                       <!-- Noncompliant -->
+<img alt="picture of dog." />                       <!-- Noncompliant -->
+<img alt="IMAGE of a turtle." />                    <!-- Noncompliant -->
+
+<img alt="A cat." />                                <!-- Compliant -->
+<img alt="" />                                      <!-- Compliant -->
+<img />                                             <!-- Compliant -->
+<img alt="Photo of cat." aria-hidden="true" />      <!-- Compliant -->


### PR DESCRIPTION
Inspired from [img-redundant-alt](https://github.com/bradbirdsallCHANGED/eslint-plugin-jsx-a11y/blob/main/src/rules/img-redundant-alt.js)