### PR TITLE
Improve S6793: Ignore dynamic values

### DIFF
--- a/its/ruling/src/test/resources/expected/Web-HeaderCheck.json
+++ b/its/ruling/src/test/resources/expected/Web-HeaderCheck.json
@@ -1565,6 +1565,9 @@
 "project:custom/S6842.html": [
 0
 ],
+"project:custom/S6843.html": [
+0
+],
 "project:external_webkit-jb-mr1/Examples/NetscapeCocoaPlugin/test.html": [
 0
 ],

--- a/its/ruling/src/test/resources/expected/Web-InputWithoutLabelCheck.json
+++ b/its/ruling/src/test/resources/expected/Web-InputWithoutLabelCheck.json
@@ -758,6 +758,10 @@
 "project:Silverpeas-Core-master/war-core/src/main/webapp/wysiwyg/jsp/uploadWebsiteFile.jsp": [
 124
 ],
+"project:custom/S6843.html": [
+2,
+3
+],
 "project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLBodyElement07.html": [
 10,
 12

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaProptypesCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaProptypesCheck.java
@@ -44,11 +44,19 @@ public class AriaProptypesCheck extends AbstractPageCheck {
       }
 
       var value = attribute.getValue();
+      if (isDynamicValue(value)) {
+        continue;
+      }
+
       var property = ARIA_PROPERTIES.get(normalizedName);
       if (!isValid(property, value)) {
         createViolation(element.getStartLinePosition(), message(name, property.getType(), property.getValues()));
       }
     }
+  }
+
+  private static boolean isDynamicValue(String value) {
+    return value.startsWith("<?php") || value.startsWith("{{") || value.startsWith("{%");
   }
 
   private static boolean isValid(AriaProperty property, String value) {

--- a/sonar-html-plugin/src/test/resources/checks/AriaProptypesCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/AriaProptypesCheck.html
@@ -50,3 +50,8 @@
 <!-- ID -->
 <div aria-details="id1" />
 <div aria-details="" />  <!-- Noncompliant -->
+
+<!-- Dynamic -->
+<div aria-details="{{ foo() }}" />
+<div aria-details="{% foo() %}" />
+<div aria-details="<?php foo() ?>" />


### PR DESCRIPTION
While verifying the issues on Peach, it seems the rule is raising false positives of dynamically compute values:

- https://peach.aws-prd.sonarsource.com/project/issues?issues=AY3JVV5FxJrisCaLYXV4&open=AY3JVV5FxJrisCaLYXV4&id=python%3Aindico
- https://peach.aws-prd.sonarsource.com/project/issues?issues=AY3JD2LAxNuVZlBcGcGV&open=AY3JD2LAxNuVZlBcGcGV&id=php%3Awordpress