### PR TITLE
Fix S6793 for aria-haspopup property

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/Aria.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/Aria.java
@@ -48,7 +48,7 @@ public class Aria {
     ARIA_PROPERTIES.put("aria-expanded", new AriaProperty("aria-expanded", AriaPropertyType.BOOLEAN, true, "true", "false"));
     ARIA_PROPERTIES.put("aria-flowto", new AriaProperty("aria-flowto", AriaPropertyType.IDLIST));
     ARIA_PROPERTIES.put("aria-grabbed", new AriaProperty("aria-grabbed", AriaPropertyType.BOOLEAN, true, "true", "false", "undefined"));
-    ARIA_PROPERTIES.put("aria-haspopup", new AriaProperty("aria-haspopup", AriaPropertyType.BOOLEAN, true, "true", "false", "menu", "listbox", "tree", "grid", "dialog"));
+    ARIA_PROPERTIES.put("aria-haspopup", new AriaProperty("aria-haspopup", AriaPropertyType.TOKEN, true, "true", "false", "menu", "listbox", "tree", "grid", "dialog"));
     ARIA_PROPERTIES.put("aria-hidden", new AriaProperty("aria-hidden", AriaPropertyType.BOOLEAN, true, "true", "false"));
     ARIA_PROPERTIES.put("aria-invalid", new AriaProperty("aria-invalid", AriaPropertyType.TOKEN, "true", "false", "grammar", "spelling"));
     ARIA_PROPERTIES.put("aria-keyshortcuts", new AriaProperty("aria-keyshortcuts", AriaPropertyType.STRING));


### PR DESCRIPTION
This PR fixes a false-positive for [rule S6793](https://sonarsource.github.io/rspec/#/rspec/S6793/html): The HTML plugin returns a false-positive for the ARIA property `aria-haspopup`. 

The [`aria-haspopup` property](https://w3c.github.io/aria/#aria-haspopup) allows the following token values: "false, true, menu, listbox, tree, grid, dialog". But if any value other than true or false is used, the following error is reported: *The value of the attribute "aria-haspopup" must be a boolean.*

See [this post on Sonar Community](https://community.sonarsource.com/t/fp-s6793-aria-property-aria-haspopup-allows-token-values-but-is-treated-as-a-boolean/111606) for background.