### PR TITLE
Fix S6793: aria-haspopup must accept values beyond boolean (typo)

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/Aria.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/Aria.java
@@ -48,7 +48,7 @@ public class Aria {
     ARIA_PROPERTIES.put("aria-expanded", new AriaProperty("aria-expanded", AriaPropertyType.BOOLEAN, true, "true", "false"));
     ARIA_PROPERTIES.put("aria-flowto", new AriaProperty("aria-flowto", AriaPropertyType.IDLIST));
     ARIA_PROPERTIES.put("aria-grabbed", new AriaProperty("aria-grabbed", AriaPropertyType.BOOLEAN, true, "true", "false", "undefined"));
-    ARIA_PROPERTIES.put("aria-haspopup", new AriaProperty("aria-haspopup", AriaPropertyType.BOOLEAN, true, "true", "false", "menu", "listbox", "tree", "grid", "dialog"));
+    ARIA_PROPERTIES.put("aria-haspopup", new AriaProperty("aria-haspopup", AriaPropertyType.TOKEN, true, "true", "false", "menu", "listbox", "tree", "grid", "dialog"));
     ARIA_PROPERTIES.put("aria-hidden", new AriaProperty("aria-hidden", AriaPropertyType.BOOLEAN, true, "true", "false"));
     ARIA_PROPERTIES.put("aria-invalid", new AriaProperty("aria-invalid", AriaPropertyType.TOKEN, "true", "false", "grammar", "spelling"));
     ARIA_PROPERTIES.put("aria-keyshortcuts", new AriaProperty("aria-keyshortcuts", AriaPropertyType.STRING));

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaProptypesCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaProptypesCheckTest.java
@@ -42,11 +42,11 @@ class AriaProptypesCheckTest {
       .next().atLine(20).withMessage("The value of the attribute \"aria-checked\" must be a boolean or the string \"mixed\".")
       .next().atLine(26).withMessage("The value of the attribute \"aria-valuemax\" must be a number.")
       .next().atLine(32).withMessage("The value of the attribute \"aria-posinset\" must be a integer.")
-      .next().atLine(37)
-      .next().atLine(42)
+      .next().atLine(38)
       .next().atLine(43)
-      .next().atLine(48).withMessage("The value of the attribute \"aria-controls\" must be a list of strings that represent DOM element IDs (idlist).")
-      .next().atLine(52).withMessage("The value of the attribute \"aria-details\" must be a string that represents a DOM element ID.")
+      .next().atLine(44)
+      .next().atLine(49).withMessage("The value of the attribute \"aria-controls\" must be a list of strings that represent DOM element IDs (idlist).")
+      .next().atLine(53).withMessage("The value of the attribute \"aria-details\" must be a string that represents a DOM element ID.")
       .noMore();
   }
 }

--- a/sonar-html-plugin/src/test/resources/checks/AriaProptypesCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/AriaProptypesCheck.html
@@ -32,6 +32,7 @@
 <div aria-posinset="foo" />  <!-- Noncompliant -->
 
 <!-- Token -->
+<div aria-haspopup="menu" />
 <div aria-orientation="horizontal" />
 <div aria-orientation="vertical" />
 <div aria-orientation="foo" />  <!-- Noncompliant -->


### PR DESCRIPTION
raised in https://community.sonarsource.com/t/fp-s6793-aria-property-aria-haspopup-allows-token-values-but-is-treated-as-a-boolean/111606/6