### PR TITLE
Add s6821

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ target/
 .project
 .settings
 
+# --- VS Code
+.vscode/
+
 # ---- Mac OS X
 .DS_Store?
 Icon?

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/HtmlConstants.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/HtmlConstants.java
@@ -19,6 +19,8 @@ package org.sonar.plugins.html.api;
 
 import java.util.List;
 import java.util.Set;
+
+import org.sonar.plugins.html.api.accessibility.AriaRole;
 import org.sonar.plugins.html.node.TagNode;
 
 public class HtmlConstants {
@@ -207,9 +209,10 @@ public class HtmlConstants {
   public static final Set<String> PRESENTATION_ROLES = Set.of("none", "presentation");
 
   // computed from https://github.com/A11yance/aria-query/blob/main/src/etc/roles/ariaAbstractRoles.js
-  public static final Set<String> ABSTRACT_ROLES = Set.of(
-    "command", "composite", "input", "landmark", "range", "roletype", "section", "sectionhead", "select", "structure", "toolbar", "widget", "window"
-  );
+  public static final Set<AriaRole> ABSTRACT_ROLES = Set.of(
+    AriaRole.COMMAND, AriaRole.COMPOSITE, AriaRole.INPUT, AriaRole.LANDMARK, AriaRole.RANGE, AriaRole.ROLETYPE,
+    AriaRole.SECTION, AriaRole.SECTIONHEAD, AriaRole.SELECT, AriaRole.STRUCTURE, AriaRole.TOOLBAR, AriaRole.WIDGET,
+    AriaRole.WINDOW);
 
   // computed from https://github.com/A11yance/aria-query/blob/main/src/domMap.js
   public static final Set<String> RESERVED_NODE_SET = Set.of(
@@ -243,7 +246,7 @@ public class HtmlConstants {
 
   public static boolean hasAbstractRole(TagNode element) {
     var role = element.getAttribute("role");
-    return role != null && ABSTRACT_ROLES.stream().anyMatch(role::equalsIgnoreCase);
+    return role != null && AriaRole.of(role) != null && ABSTRACT_ROLES.stream().anyMatch(AriaRole.of(role)::equals);
   }
 
   public static boolean hasKnownHTMLTag(TagNode element) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/Aria.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/Aria.java
@@ -20,16 +20,17 @@ package org.sonar.plugins.html.api.accessibility;
 
 import java.util.EnumMap;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.sonar.plugins.html.node.TagNode;
 
 public class Aria {
 
-  protected static final EnumMap<AriaProperty, AriaPropertyValues> ARIA_PROPERTIES =
+  protected static final Map<AriaProperty, AriaPropertyValues> ARIA_PROPERTIES =
     new EnumMap<>(AriaProperty.class);
-  protected static final EnumMap<AriaRole, RoleProperties> ROLES = new EnumMap<>(AriaRole.class);
-  protected static final EnumMap<Element, ElementRoles> ELEMENTS = new EnumMap<>(Element.class);
+  protected static final Map<AriaRole, RoleProperties> ROLES = new EnumMap<>(AriaRole.class);
+  protected static final Map<Element, ElementRoles> ELEMENTS = new EnumMap<>(Element.class);
 
   static {
     ARIA_PROPERTIES.put(
@@ -3880,6 +3881,10 @@ public class Aria {
 
   public static ElementRoles getElement(Element name) {
     return ELEMENTS.get(name);
+  }
+
+  public static Set<AriaProperty> getProperties() {
+    return ARIA_PROPERTIES.keySet();
   }
 
   public static class AriaPropertyValues {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaRoleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaRoleCheck.java
@@ -28,11 +28,11 @@ import org.sonar.plugins.html.node.TagNode;
 public class AriaRoleCheck extends AbstractPageCheck {
     @Override
     public void startElement(TagNode element) {
-        var roleValue = element.getProperty("role");
-        if (roleValue == null) {
+        var role = element.getAttribute("role");
+        if (role == null) {
             return;
         }
-        var values = roleValue.getValue().split(" ");
+        var values = role.split(" ");
         for (var value : values) {
             AriaRole ariaRole = AriaRole.of(value);
             if (ariaRole == null || ABSTRACT_ROLES.contains(ariaRole)) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaRoleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaRoleCheck.java
@@ -1,0 +1,45 @@
+/*
+ * SonarSource HTML analyzer :: Sonar Plugin
+ * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * sonarqube@googlegroups.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sonar.plugins.html.checks.accessibility;
+
+import static org.sonar.plugins.html.api.HtmlConstants.ABSTRACT_ROLES;
+
+import org.sonar.check.Rule;
+import org.sonar.plugins.html.api.accessibility.AriaRole;
+import org.sonar.plugins.html.checks.AbstractPageCheck;
+import org.sonar.plugins.html.node.TagNode;
+
+@Rule(key = "S6821")
+public class AriaRoleCheck extends AbstractPageCheck {
+    @Override
+    public void startElement(TagNode element) {
+        var roleValue = element.getProperty("role");
+        if (roleValue == null) {
+            return;
+        }
+        var values = roleValue.getValue().split(" ");
+        for (var value : values) {
+            AriaRole ariaRole = AriaRole.of(value);
+            if (ariaRole == null || ABSTRACT_ROLES.contains(ariaRole)) {
+                createViolation(element, String.format(
+                        "Elements with ARIA roles must use a valid, non-abstract ARIA role. \"%s\" is not a valid role.",
+                        value));
+            }
+        }
+    }
+}

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaUnsupportedElementsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaUnsupportedElementsCheck.java
@@ -17,13 +17,12 @@
  */
 package org.sonar.plugins.html.checks.accessibility;
 
-import org.sonar.plugins.html.api.accessibility.Aria;
+import org.sonar.plugins.html.api.accessibility.AriaProperty;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
 import org.sonar.plugins.html.node.TagNode;
 
 import static org.sonar.plugins.html.api.HtmlConstants.isReservedNode;
 
-import java.util.HashSet;
 import java.util.Locale;
 
 import org.sonar.check.Rule;
@@ -37,10 +36,9 @@ public class AriaUnsupportedElementsCheck extends AbstractPageCheck {
     if (!isReservedNode(element)) {
       return;
     }
-    var invalidAttributes = new HashSet<String>(Aria.ARIA_PROPERTIES.keySet());
-    invalidAttributes.add("role");
     element.getAttributes().forEach(attr -> {
-      if (invalidAttributes.contains(attr.getName().toLowerCase(Locale.ROOT))) {
+      var attrName = attr.getName().toLowerCase(Locale.ROOT);
+      if (AriaProperty.of(attrName) != null || attrName.equals("role")) {
         createViolation(
             element,
             String.format("This element does not support ARIA roles, states and properties. Try removing the prop %s.",

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/CheckClasses.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/CheckClasses.java
@@ -23,6 +23,7 @@ import org.sonar.plugins.html.checks.accessibility.AnchorsHaveContentCheck;
 import org.sonar.plugins.html.checks.accessibility.AnchorsShouldNotBeUsedAsButtonsCheck;
 import org.sonar.plugins.html.checks.accessibility.AriaActiveDescendantHasTabIndexCheck;
 import org.sonar.plugins.html.checks.accessibility.AriaProptypesCheck;
+import org.sonar.plugins.html.checks.accessibility.AriaRoleCheck;
 import org.sonar.plugins.html.checks.accessibility.AriaUnsupportedElementsCheck;
 import org.sonar.plugins.html.checks.accessibility.FocusableInteractiveElementsCheck;
 import org.sonar.plugins.html.checks.accessibility.NoAriaHiddenOnFocusableCheck;
@@ -113,6 +114,7 @@ public final class CheckClasses {
     AnchorsShouldNotBeUsedAsButtonsCheck.class,
     AriaActiveDescendantHasTabIndexCheck.class,
     AriaProptypesCheck.class,
+    AriaRoleCheck.class,
     AriaUnsupportedElementsCheck.class,
     AvoidCommentedOutCodeCheck.class,
     AvoidHtmlCommentCheck.class,

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S6821.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S6821.html
@@ -1,0 +1,29 @@
+<h2>Why is this an issue?</h2>
+<p>ARIA (Accessible Rich Internet Applications) attributes are used to enhance the accessibility of web content and web applications. These attributes
+provide additional information about an element’s role, state, properties, and values to assistive technologies like screen readers.</p>
+<p>This rule checks that when using the <code>role</code> property in DOM elements, its value is a valid non-abstract ARIA role.</p>
+<h2>How to fix it</h2>
+<p>Check that each element with a defined ARIA role has a valid non-abstract value.</p>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+&lt;div role="meth" aria-label="a^{2} + b^{2} = c^{2}"&gt;
+  a&lt;sup&gt;2&lt;/sup&gt; + b&lt;sup&gt;2&lt;/sup&gt; = c&lt;sup&gt;2&lt;/sup&gt;
+&lt;/div&gt;
+</pre>
+<p>To fix the code use a valid value for the ARIA role attribute.</p>
+<pre data-diff-id="1" data-diff-type="compliant">
+&lt;div role="math" aria-label="a^{2} + b^{2} = c^{2}"&gt;
+  a&lt;sup&gt;2&lt;/sup&gt; + b&lt;sup&gt;2&lt;/sup&gt; = c&lt;sup&gt;2&lt;/sup&gt;
+&lt;/div&gt;
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li> MDN web docs - <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques">Using ARIA: Roles, states, and
+  properties</a> </li>
+  <li> MDN web docs - <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles">ARIA roles (Reference)</a> </li>
+</ul>
+<h3>Standards</h3>
+<ul>
+  <li> W3C - <a href="https://www.w3.org/TR/wai-aria-1.2/">Accessible Rich Internet Applications (WAI-ARIA) 1.2</a> </li>
+</ul>
+

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S6821.json
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S6821.json
@@ -1,0 +1,25 @@
+{
+  "title": "DOM elements with ARIA roles should have a valid non-abstract role",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5min"
+  },
+  "tags": [
+    "react",
+    "accessibility"
+  ],
+  "defaultSeverity": "Major",
+  "ruleSpecification": "RSPEC-6821",
+  "sqKey": "S6821",
+  "scope": "All",
+  "quickfix": "infeasible",
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "LOW",
+      "RELIABILITY": "MEDIUM"
+    },
+    "attribute": "LOGICAL"
+  }
+}

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/Sonar_way_profile.json
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/Sonar_way_profile.json
@@ -1,7 +1,6 @@
 {
   "name": "Sonar way",
   "ruleKeys": [
-    "S6811",
     "AvoidCommentedOutCodeCheck",
     "DoctypePresenceCheck",
     "FieldsetWithoutLegendCheck",
@@ -28,6 +27,8 @@
     "S5264",
     "S5725",
     "S6793",
+    "S6811",
+    "S6821",
     "S6823",
     "S6824",
     "S6825",

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaRoleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaRoleCheckTest.java
@@ -1,0 +1,52 @@
+/*
+ * SonarSource HTML analyzer :: Sonar Plugin
+ * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * sonarqube@googlegroups.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sonar.plugins.html.checks.accessibility;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.sonar.plugins.html.checks.CheckMessagesVerifierRule;
+import org.sonar.plugins.html.checks.TestHelper;
+import org.sonar.plugins.html.visitor.HtmlSourceCode;
+
+class AriaRoleCheckTest {
+
+  @RegisterExtension
+  public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
+
+  @Test
+  void html() throws Exception {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+        new File("src/test/resources/checks/AriaRoleCheck.html"),
+        new AriaRoleCheck());
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+        .next().atLine(1)
+        .withMessage(
+            "Elements with ARIA roles must use a valid, non-abstract ARIA role. \"foobar\" is not a valid role.")
+        .next().atLine(2)
+        .next().atLine(3)
+        .next().atLine(4)
+        .next().atLine(5)
+        .next().atLine(6)
+        .next().atLine(7)
+        .next().atLine(8)
+        .next().atLine(9)
+        .noMore();
+  }
+}

--- a/sonar-html-plugin/src/test/resources/checks/AriaRoleCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/AriaRoleCheck.html
@@ -1,0 +1,16 @@
+<div role="foobar" />                       <!-- Noncompliant -->
+<div role="datepicker"></div>               <!-- Noncompliant -->
+<div role="range"></div>                    <!-- Noncompliant -->
+<div role="Button"></div>                   <!-- Noncompliant -->
+<div role=""></div>                         <!-- Noncompliant -->
+<div role="tabpanel row foobar"></div>      <!-- Noncompliant -->
+<div role="tabpanel row range"></div>       <!-- Noncompliant -->
+<div role="doc-endnotes range"></div>       <!-- Noncompliant -->
+<div role />                                <!-- Noncompliant -->
+
+<div />
+<div></div>
+<div role="tabpanel row" />
+<div role="switch" />
+<div role="doc-abstract" />
+<div role="doc-appendix doc-bibliography" />

--- a/sonar-html-plugin/src/test/resources/checks/AriaRoleCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/AriaRoleCheck.html
@@ -14,3 +14,4 @@
 <div role="switch" />
 <div role="doc-abstract" />
 <div role="doc-appendix doc-bibliography" />
+<moderator v-for="(item, index) in mods" :role="item.role"></moderator>


### PR DESCRIPTION
Mimicking logic from: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/src/rules/aria-role.js

Not including the options for now, as there also aren't any defaults in the original implementation.

The 1 thing I worry is about the templating languages hence using getAttribute vs getProperty to find mostly vanilla calls of : <... rule=""> instead of the vue or angular style attributes, where they can pass variables.