### PR TITLE
Resolve SONARHTML-232 - Deprecate S1092

### DIFF
--- a/its/plugin/src/test/java/com/sonar/it/web/SonarLintTest.java
+++ b/its/plugin/src/test/java/com/sonar/it/web/SonarLintTest.java
@@ -94,7 +94,6 @@ public class SonarLintTest {
       .extracting(Issue::getRuleKey, WithTextRange::getStartLine, i -> i.getInputFile().getPath(), Issue::getSeverity).containsOnly(
       tuple("Web:DoctypePresenceCheck", 1, inputFile.getPath(), MAJOR),
       tuple("Web:S5254", 1, inputFile.getPath(), MAJOR),
-      tuple("Web:LinkToImageCheck", 3, inputFile.getPath(), MAJOR),
       tuple("Web:PageWithoutTitleCheck", 1, inputFile.getPath(), MAJOR));
   }
 

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S1092.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S1092.html
@@ -1,0 +1,17 @@
+<p>This rule is deprecated, and will eventually be removed.</p>
+<h2>Why is this an issue?</h2>
+<p>Whenever a user clicks on a link that targets an image, the website’s navigation menu will be lost.</p>
+<p>From a user point of view, it is as if she left the website.</p>
+<p>The only way to return to it is using the browser’s 'Back' button.</p>
+<p>Instead, it is better to create a page which will display the image using the <code>&lt;img&gt;</code> tag and preserve the navigation menu.</p>
+<p>Further, in terms of accessibility, when the image is embedded into a page, content providers are able to provide an alternate text equivalent
+through the <code>alt</code> attribute.</p>
+<h3>Noncompliant code example</h3>
+<pre>
+&lt;a href="image.png"&gt;...&lt;/a&gt;  &lt;!-- Non-Compliant --&gt;
+</pre>
+<h3>Compliant solution</h3>
+<pre>
+&lt;a href="page.html"&gt;...&lt;/a&gt;  &lt;!-- Compliant --&gt;
+</pre>
+

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S1092.json
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S1092.json
@@ -1,0 +1,18 @@
+{
+  "title": "Links should not directly target images",
+  "type": "CODE_SMELL",
+  "status": "deprecated",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "15min"
+  },
+  "tags": [
+    "accessibility",
+    "user-experience"
+  ],
+  "defaultSeverity": "Major",
+  "ruleSpecification": "RSPEC-1092",
+  "sqKey": "LinkToImageCheck",
+  "scope": "Main",
+  "quickfix": "unknown"
+}

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/Sonar_way_profile.json
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/Sonar_way_profile.json
@@ -8,7 +8,6 @@
     "FrameWithoutTitleCheck",
     "ImgWithoutAltCheck",
     "ItemTagNotWithinContainerTagCheck",
-    "LinkToImageCheck",
     "MetaRefreshCheck",
     "PageWithoutTitleCheck",
     "S1134",


### PR DESCRIPTION
* Apply the up-to-date RSPEC documentation
* Demote S1092 (`LinkToImageCheck`) from the Sonar way profile