### PR TITLE
Resolve SONARHTML-234 - Deprecate S1086

### DIFF
--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/NonConsecutiveHeadingCheck.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/NonConsecutiveHeadingCheck.html
@@ -1,3 +1,4 @@
+<p>This rule is deprecated, and will eventually be removed.</p>
 <h2>Why is this an issue?</h2>
 <p>Heading tags are used by search engines and screen reader softwares to construct an outline of the page.</p>
 <p>Starting at <code>&lt;h1&gt;</code> and not skipping any level eases this automatic construction.</p>

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/NonConsecutiveHeadingCheck.json
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/NonConsecutiveHeadingCheck.json
@@ -1,7 +1,7 @@
 {
   "title": "Heading tags should be used consecutively from \"H1\" to \"H6\"",
   "type": "CODE_SMELL",
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
     "func": "Constant\/Issue",
     "constantCost": "5min"


### PR DESCRIPTION
Note that this rule is not include in the Sonar way profile so there was no need to demote it.