### PR TITLE
[SONARHTML-248] Modify rule S1093: Add `<menu>` as allowed parent element for `<li>`

### DIFF
--- a/its/ruling/src/test/resources/expected/Web-ItemTagNotWithinContainerTagCheck.json
+++ b/its/ruling/src/test/resources/expected/Web-ItemTagNotWithinContainerTagCheck.json
@@ -17,17 +17,7 @@
 10,
 11
 ],
-"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLMenuElement01.html": [
-9,
-10,
-11
-],
 "project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLDirectoryElement01.xhtml": [
-11,
-12,
-13
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLMenuElement01.xhtml": [
 11,
 12,
 13

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheck.java
@@ -37,7 +37,7 @@ public class ItemTagNotWithinContainerTagCheck extends AbstractPageCheck {
     TagNode parent = node.getParent();
 
     while (parent != null) {
-      if (isLi(parent) || isUlOrOlOrMenu(parent)) {
+      if (isLi(parent) || isLiAllowedParent(parent)) {
         return true;
       }
       parent = parent.getParent();
@@ -67,7 +67,7 @@ public class ItemTagNotWithinContainerTagCheck extends AbstractPageCheck {
     return "DT".equalsIgnoreCase(node.getNodeName());
   }
 
-  private static boolean isUlOrOlOrMenu(TagNode node) {
+  private static boolean isLiAllowedParent(TagNode node) {
     return isUl(node) || isOl(node) || isMenu(node);
   }
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheck.java
@@ -37,7 +37,7 @@ public class ItemTagNotWithinContainerTagCheck extends AbstractPageCheck {
     TagNode parent = node.getParent();
 
     while (parent != null) {
-      if (isLi(parent) || isUlOrOl(parent)) {
+      if (isLi(parent) || isUlOrOlOrMenu(parent)) {
         return true;
       }
       parent = parent.getParent();
@@ -67,8 +67,8 @@ public class ItemTagNotWithinContainerTagCheck extends AbstractPageCheck {
     return "DT".equalsIgnoreCase(node.getNodeName());
   }
 
-  private static boolean isUlOrOl(TagNode node) {
-    return isUl(node) || isOl(node);
+  private static boolean isUlOrOlOrMenu(TagNode node) {
+    return isUl(node) || isOl(node) || isMenu(node);
   }
 
   private static boolean isUl(TagNode node) {
@@ -77,6 +77,10 @@ public class ItemTagNotWithinContainerTagCheck extends AbstractPageCheck {
 
   private static boolean isOl(TagNode node) {
     return "OL".equalsIgnoreCase(node.getNodeName());
+  }
+
+  private static boolean isMenu(TagNode node) {
+    return "MENU".equalsIgnoreCase(node.getNodeName());
   }
 
   private static boolean isDl(TagNode node) {

--- a/sonar-html-plugin/src/test/resources/checks/ItemTagNotWithinContainerTagCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/ItemTagNotWithinContainerTagCheck.html
@@ -23,6 +23,11 @@
   <li>bar
 </ul>
 
+<menu>
+  <li>foo
+  <li>bar
+</menu>
+
 <ol>
   <li>foo
   <li>bar


### PR DESCRIPTION
Fixes https://sonarsource.atlassian.net/browse/SONARHTML-248