### PR TITLE
SONARHTML-267 Remove <hgroup> as unsupported html tag

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/UnsupportedTagsInHtml5Check.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/UnsupportedTagsInHtml5Check.java
@@ -39,7 +39,6 @@ public class UnsupportedTagsInHtml5Check extends AbstractPageCheck {
       "FONT",
       "FRAME",
       "FRAMESET",
-      "HGROUP",
       "ISINDEX",
       "LISTING",
       "MARQUEE",

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/NestedJavaScriptCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/NestedJavaScriptCheckTest.java
@@ -61,4 +61,12 @@ public class NestedJavaScriptCheckTest {
       .noMore();
   }
 
+  @Test
+  public void nested_script_node_should_result_in_a_violation() {
+    NestedJavaScriptCheck check = new NestedJavaScriptCheck();
+    HtmlSourceCode sourceCode = TestHelper.scan(new File("src/test/resources/checks/NestedJavaScriptCheck/Repro.html"), check);
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+            .noMore();
+  }
+
 }


### PR DESCRIPTION
[SONARHTML-267](https://sonarsource.atlassian.net/browse/SONARHTML-267)

Please see discussion in Community thread - https://community.sonarsource.com/t/hgroup-element-incorrectly-reported-as-deprecated/129479/7?u=michal.zgliczynski

[SONARHTML-267]: https://sonarsource.atlassian.net/browse/SONARHTML-267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ