### PR TITLE
SONARHTML-269 Update license to SONAR Source-Available License v1.0 (SSALv1)

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,165 +1,184 @@
-                   GNU LESSER GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+SONAR Source-Available License v1.0
+Last Updated November 13, 2024
 
- Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
+1. DEFINITIONS
 
+"Agreement" means this Sonar Source-Available License v1.0
 
-  This version of the GNU Lesser General Public License incorporates
-the terms and conditions of version 3 of the GNU General Public
-License, supplemented by the additional permissions listed below.
+"Competing" means marketing a product or service as a substitute for the
+functionality or value of SonarQube. A product or service may compete regardless
+of how it is designed or deployed. For example, a product or service may compete
+even if it provides its functionality via any kind of interface (including
+services, libraries, or plug-ins), even if it is ported to a different platform
+or programming language, and even if it is provided free of charge.
 
-  0. Additional Definitions.
+"Contribution" means:
 
-  As used herein, "this License" refers to version 3 of the GNU Lesser
-General Public License, and the "GNU GPL" refers to version 3 of the GNU
-General Public License.
+  a) in the case of the initial Contributor, the initial content Distributed under
+this Agreement, and
 
-  "The Library" refers to a covered work governed by this License,
-other than an Application or a Combined Work as defined below.
+  b) in the case of each subsequent Contributor:
+    i) changes to the Program, and
+    ii) additions to the Program;
 
-  An "Application" is any work that makes use of an interface provided
-by the Library, but which is not otherwise based on the Library.
-Defining a subclass of a class defined by the Library is deemed a mode
-of using an interface provided by the Library.
+where such changes and/or additions to the Program originate from and are
+Distributed by that particular Contributor. A Contribution "originates" from a
+Contributor if it was added to the Program by such Contributor itself or anyone
+acting on such Contributor's behalf. Contributions do not include changes or
+additions to the Program that are not Modified Works.
 
-  A "Combined Work" is a work produced by combining or linking an
-Application with the Library.  The particular version of the Library
-with which the Combined Work was made is also called the "Linked
-Version".
+"Contributor" means any person or entity that Distributes the Program.
 
-  The "Minimal Corresponding Source" for a Combined Work means the
-Corresponding Source for the Combined Work, excluding any source code
-for portions of the Combined Work that, considered in isolation, are
-based on the Application, and not on the Linked Version.
+"Derivative Works" shall mean any work, whether in Source Code or other form,
+that is based on (or derived from) the Program and for which the editorial
+revisions, annotations, elaborations, or other modifications represent, as a
+whole, an original work of authorship.
 
-  The "Corresponding Application Code" for a Combined Work means the
-object code and/or source code for the Application, including any data
-and utility programs needed for reproducing the Combined Work from the
-Application, but excluding the System Libraries of the Combined Work.
+"Distribute" means the acts of a) distributing or b) making available in any
+manner that enables the transfer of a copy.
 
-  1. Exception to Section 3 of the GNU GPL.
+"Licensed Patents" mean patent claims licensable by a Contributor that are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
 
-  You may convey a covered work under sections 3 and 4 of this License
-without being bound by section 3 of the GNU GPL.
+"Modified Works" shall mean any work in Source Code or other form that results
+from an addition to, deletion from, or modification of the contents of the
+Program, including, for purposes of clarity, any new file in Source Code form
+that contains any contents of the Program. Modified Works shall not include
+works that contain only declarations, interfaces, types, classes, structures, or
+files of the Program solely in each case in order to link to, bind by name, or
+subclass the Program or Modified Works thereof.
 
-  2. Conveying Modified Versions.
+"Non-competitive Purpose" means any purpose except for (a) providing to others
+any product or service that includes or offers the same or substantially similar
+functionality as SonarQube, (b) Competing with SonarQube, and/or (c) employing,
+using, or engaging artificial intelligence technology that is not part of the
+Program to ingest, interpret, analyze, train on, or interact with the data
+provided by the Program, or to engage with the Program in any manner.
 
-  If you modify a copy of the Library, and, in your modifications, a
-facility refers to a function or data to be supplied by an Application
-that uses the facility (other than as an argument passed when the
-facility is invoked), then you may convey a copy of the modified
-version:
+"Notices" means any legal statements or attributions included with the Program,
+including, without limitation, statements concerning copyright, patent,
+trademark, disclaimers of warranty, or limitations of liability
 
-   a) under this License, provided that you make a good faith effort to
-   ensure that, in the event an Application does not supply the
-   function or data, the facility still operates, and performs
-   whatever part of its purpose remains meaningful, or
+"Program" means the Contributions Distributed in accordance with this Agreement.
 
-   b) under the GNU GPL, with none of the additional permissions of
-   this License applicable to that copy.
+"Recipient" means anyone who receives the Program under this Agreement,
+including Contributors.
 
-  3. Object Code Incorporating Material from Library Header Files.
+"SonarQube" means an open-source or commercial edition of software offered by
+SonarSource that is branded "SonarQube".
 
-  The object code form of an Application may incorporate material from
-a header file that is part of the Library.  You may convey such object
-code under terms of your choice, provided that, if the incorporated
-material is not limited to numerical parameters, data structure
-layouts and accessors, or small macros, inline functions and templates
-(ten or fewer lines in length), you do both of the following:
+"SonarSource" means SonarSource SA, a Swiss company registered in Switzerland
+under UID No. CHE-114.587.664.
 
-   a) Give prominent notice with each copy of the object code that the
-   Library is used in it and that the Library and its use are
-   covered by this License.
+"Source Code" means the form of a Program preferred for making modifications,
+including but not limited to software source code, documentation source, and
+configuration files.
 
-   b) Accompany the object code with a copy of the GNU GPL and this license
-   document.
+2. GRANT OF RIGHTS
 
-  4. Combined Works.
+  a) Subject to the terms of this Agreement, each Contributor hereby grants
+Recipient a non-exclusive, worldwide, royalty-free copyright license, for any
+Non-competitive Purpose, to reproduce, prepare Derivative Works of, publicly
+display, publicly perform, Distribute and sublicense the Contribution of such
+Contributor, if any, and such Derivative Works.
 
-  You may convey a Combined Work under terms of your choice that,
-taken together, effectively do not restrict modification of the
-portions of the Library contained in the Combined Work and reverse
-engineering for debugging such modifications, if you also do each of
-the following:
+  b) Subject to the terms of this Agreement, each Contributor hereby grants
+Recipient a non-exclusive, worldwide, royalty-free patent license under Licensed
+Patents, for any Non-competitive Purpose, to make, use, sell, offer to sell,
+import, and otherwise transfer the Contribution of such Contributor, if any, in
+Source Code or other form. This patent license shall apply to the combination of
+the Contribution and the Program if, at the time the Contribution is added by
+the Contributor, such addition of the Contribution causes such combination to be
+covered by the Licensed Patents. The patent license shall not apply to any other
+combinations that include the Contribution.
 
-   a) Give prominent notice with each copy of the Combined Work that
-   the Library is used in it and that the Library and its use are
-   covered by this License.
+  c) Recipient understands that although each Contributor grants the licenses to
+its Contributions set forth herein, no assurances are provided by any
+Contributor that the Program does not infringe the patent or other intellectual
+property rights of any other entity. Each Contributor disclaims any liability to
+Recipient for claims brought by any other entity based on infringement of
+intellectual property rights or otherwise. As a condition to exercising the
+rights and licenses granted hereunder, each Recipient hereby assumes sole
+responsibility to secure any other intellectual property rights needed, if any.
+For example, if a third-party patent license is required to allow Recipient to
+Distribute the Program, it is Recipient's responsibility to acquire that license
+before distributing the Program.
 
-   b) Accompany the Combined Work with a copy of the GNU GPL and this license
-   document.
+  d) Each Contributor represents that to its knowledge it has sufficient copyright
+rights in its Contribution, if any, to grant the copyright license set forth in
+this Agreement.
 
-   c) For a Combined Work that displays copyright notices during
-   execution, include the copyright notice for the Library among
-   these notices, as well as a reference directing the user to the
-   copies of the GNU GPL and this license document.
+3. REQUIREMENTS
 
-   d) Do one of the following:
+3.1 If a Contributor Distributes the Program in any form, then the Program must
+also be made available as Source Code, in accordance with section 3.2, and the
+Contributor must accompany the Program with a statement that the Source Code for
+the Program is available under this Agreement, and inform Recipients how to
+obtain it in a reasonable manner on or through a medium customarily used for
+software exchange; and
 
-       0) Convey the Minimal Corresponding Source under the terms of this
-       License, and the Corresponding Application Code in a form
-       suitable for, and under terms that permit, the user to
-       recombine or relink the Application with a modified version of
-       the Linked Version to produce a modified Combined Work, in the
-       manner specified by section 6 of the GNU GPL for conveying
-       Corresponding Source.
+3.2 When the Program is Distributed as Source Code:
 
-       1) Use a suitable shared library mechanism for linking with the
-       Library.  A suitable mechanism is one that (a) uses at run time
-       a copy of the Library already present on the user's computer
-       system, and (b) will operate properly with a modified version
-       of the Library that is interface-compatible with the Linked
-       Version.
+  a) it must be made available under this Agreement, and
 
-   e) Provide Installation Information, but only if you would otherwise
-   be required to provide such information under section 6 of the
-   GNU GPL, and only to the extent that such information is
-   necessary to install and execute a modified version of the
-   Combined Work produced by recombining or relinking the
-   Application with a modified version of the Linked Version. (If
-   you use option 4d0, the Installation Information must accompany
-   the Minimal Corresponding Source and Corresponding Application
-   Code. If you use option 4d1, you must provide the Installation
-   Information in the manner specified by section 6 of the GNU GPL
-   for conveying Corresponding Source.)
+  b) a copy of this Agreement must be included with each copy of the Program.
 
-  5. Combined Libraries.
+3.3 Contributors may not remove or alter any Notices contained within the
+Program from any copy of the Program which they Distribute, provided that
+Contributors may add their own appropriate Notices.
 
-  You may place library facilities that are a work based on the
-Library side by side in a single library together with other library
-facilities that are not Applications and are not covered by this
-License, and convey such a combined library under terms of your
-choice, if you do both of the following:
+4. NO WARRANTY
 
-   a) Accompany the combined library with a copy of the same work based
-   on the Library, uncombined with any other library facilities,
-   conveyed under the terms of this License.
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT PERMITTED BY
+APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES
+OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT
+LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT,
+MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely
+responsible for determining the appropriateness of using and distributing the
+Program and assumes all risks associated with its exercise of rights under this
+Agreement, including but not limited to the risks and costs of program errors,
+compliance with applicable laws, damage to or loss of data, programs or
+equipment, and unavailability or interruption of operations.
 
-   b) Give prominent notice with the combined library that part of it
-   is a work based on the Library, and explaining where to find the
-   accompanying uncombined form of the same work.
+5. DISCLAIMER OF LIABILITY
 
-  6. Revised Versions of the GNU Lesser General Public License.
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT PERMITTED BY
+APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF
+THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGES.
 
-  The Free Software Foundation may publish revised and/or new versions
-of the GNU Lesser General Public License from time to time. Such new
-versions will be similar in spirit to the present version, but may
-differ in detail to address new problems or concerns.
+6. GENERAL
 
-  Each version is given a distinguishing version number. If the
-Library as you received it specifies that a certain numbered version
-of the GNU Lesser General Public License "or any later version"
-applies to it, you have the option of following the terms and
-conditions either of that published version or of any later version
-published by the Free Software Foundation. If the Library as you
-received it does not specify a version number of the GNU Lesser
-General Public License, you may choose any version of the GNU Lesser
-General Public License ever published by the Free Software Foundation.
+If any provision of this Agreement is invalid or unenforceable under applicable
+law, it shall not affect the validity or enforceability of the remainder of the
+terms of this Agreement, and without further action by the parties hereto, such
+provision shall be reformed to the minimum extent necessary to make such
+provision valid and enforceable.
 
-  If the Library as you received it specifies that a proxy can decide
-whether future versions of the GNU Lesser General Public License shall
-apply, that proxy's public statement of acceptance of any version is
-permanent authorization for you to choose that version for the
-Library.
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient’s patent(s), then such Recipient’s rights granted under
+Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient’s rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and does
+not cure such failure in a reasonable period of time after becoming aware of
+such noncompliance. If all Recipient’s rights under this Agreement terminate,
+Recipient agrees to cease use and distribution of the Program as soon as
+reasonably practicable. However, Recipient’s obligations under this Agreement
+and any licenses granted by Recipient relating to the Program shall continue and
+survive.
+
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives
+no rights or licenses to the intellectual property of any Contributor under this
+Agreement, whether expressly, by implication, estoppel, or otherwise. All rights
+in the Program not expressly granted under this Agreement are reserved. Nothing
+in this Agreement is intended to be enforceable by any entity that is not a
+Contributor or Recipient. No third-party beneficiary rights are created under
+this Agreement.

--- a/README.md
+++ b/README.md
@@ -57,4 +57,6 @@ The "Ruling Test" are an integration test suite which launches the analysis of a
 
 Copyright 2010-2024 SonarSource.
 
-Licensed under the [GNU Lesser General Public License, Version 3.0](http://www.gnu.org/licenses/lgpl.txt)
+SonarQube analyzers released after November 29, 2024, including patch fixes for prior versions, are published under the [Sonar Source-Available License Version 1 (SSALv1)](LICENSE.txt).
+
+See individual files for details that specify the license applicable to each file. Files subject to the SSALv1 will be noted in their headers.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.sonarsource.parent</groupId>
     <artifactId>parent</artifactId>
-    <version>71.0.0.1314</version>
+    <version>81.0.0.2300</version>
   </parent>
 
   <groupId>org.sonarsource.html</groupId>
@@ -22,6 +22,13 @@
   <organization>
     <name>SonarSource and Matthijs Galesloot</name>
   </organization>
+  <licenses>
+    <license>
+      <name>SSALv1</name>
+      <url>https://sonarsource.com/license/ssal/</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
   <developers>
     <developer>
       <id>mgalesloot</id>
@@ -58,9 +65,7 @@
 
   <properties>
     <revision>3.5-SNAPSHOT</revision>
-    <license.name>AL2</license.name>
     <license.owner>SonarSource SA and Matthijs Galesloot</license.owner>
-    <license.mailto>sonarqube@googlegroups.com</license.mailto>
     <gitRepositoryName>sonar-html</gitRepositoryName>
 
     <jakarta.el.version>4.0.2</jakarta.el.version>

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/HtmlPlugin.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/HtmlPlugin.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/analyzers/ComplexityVisitor.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/analyzers/ComplexityVisitor.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.analyzers;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/analyzers/PageCountLines.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/analyzers/PageCountLines.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.analyzers;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/analyzers/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/analyzers/package-info.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @ParametersAreNonnullByDefault
 package org.sonar.plugins.html.analyzers;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/BufferStack.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/BufferStack.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.api;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.api;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/HtmlConstants.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/HtmlConstants.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.api;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtils.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtils.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.api.accessibility;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/Aria.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/Aria.java
@@ -1,21 +1,19 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-
 package org.sonar.plugins.html.api.accessibility;
 
 import java.util.EnumMap;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AriaProperty.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AriaProperty.java
@@ -1,21 +1,19 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-
 package org.sonar.plugins.html.api.accessibility;
 
 import java.util.Arrays;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AriaRole.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AriaRole.java
@@ -1,21 +1,19 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-
 package org.sonar.plugins.html.api.accessibility;
 
 import java.util.Arrays;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/ControlGroup.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/ControlGroup.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.api.accessibility;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/Element.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/Element.java
@@ -1,21 +1,19 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-
 package org.sonar.plugins.html.api.accessibility;
 
 import java.util.Arrays;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/package-info.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @ParametersAreNonnullByDefault
 package org.sonar.plugins.html.api.accessibility;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/package-info.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @ParametersAreNonnullByDefault
 package org.sonar.plugins.html.api;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/AbstractPageCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/AbstractPageCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/HtmlIssue.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/HtmlIssue.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/PreciseHtmlIssue.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/PreciseHtmlIssue.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsShouldNotBeUsedAsButtonsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsShouldNotBeUsedAsButtonsCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaActiveDescendantHasTabIndexCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaActiveDescendantHasTabIndexCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaProptypesCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaProptypesCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaRoleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaRoleCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaUnsupportedElementsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaUnsupportedElementsCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ElementWithRoleShouldHaveRequiredPropertiesCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ElementWithRoleShouldHaveRequiredPropertiesCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/EventHandlers.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/EventHandlers.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/FocusableInteractiveElementsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/FocusableInteractiveElementsCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/HeadingHasAccessibleContentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/HeadingHasAccessibleContentCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ImgRedundantAltCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ImgRedundantAltCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAriaHiddenOnFocusableCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAriaHiddenOnFocusableCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoInteractiveElementToNoninteractiveRoleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoInteractiveElementToNoninteractiveRoleCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNonInteractiveElementsWithHandlersCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNonInteractiveElementsWithHandlersCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveElementToInteractiveRoleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveElementToInteractiveRoleCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoRedundantRolesCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoRedundantRolesCheck.java
@@ -1,21 +1,19 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-
 package org.sonar.plugins.html.checks.accessibility;
 
 import static org.sonar.plugins.html.api.accessibility.Aria.getImplicitRole;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoStaticElementInteractionsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoStaticElementInteractionsCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/RoleSupportsAriaPropertyCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/RoleSupportsAriaPropertyCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/TabIndexNoPositiveCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/TabIndexNoPositiveCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ValidAutocompleteCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ValidAutocompleteCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/package-info.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @ParametersAreNonnullByDefault
 package org.sonar.plugins.html.checks.accessibility;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/IllegalAttributeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/IllegalAttributeCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.attributes;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/NoAccessKeyCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/NoAccessKeyCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.attributes;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/RequiredAttributeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/RequiredAttributeCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.attributes;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/package-info.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @ParametersAreNonnullByDefault
 package org.sonar.plugins.html.checks.attributes;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/ComplexityCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/ComplexityCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.coding;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/DoubleQuotesCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/DoubleQuotesCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.coding;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/FileLengthCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/FileLengthCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.coding;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/InternationalizationCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/InternationalizationCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.coding;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/MaxLineLengthCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/MaxLineLengthCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.coding;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/UnclosedTagCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/UnclosedTagCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.coding;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/package-info.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @ParametersAreNonnullByDefault
 package org.sonar.plugins.html.checks.coding;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/AvoidCommentedOutCodeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/AvoidCommentedOutCodeCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.comments;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/AvoidHtmlCommentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/AvoidHtmlCommentCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.comments;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/CommentUtils.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/CommentUtils.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.comments;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/FixmeCommentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/FixmeCommentCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.comments;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/TodoCommentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/TodoCommentCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.comments;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/package-info.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @ParametersAreNonnullByDefault
 package org.sonar.plugins.html.checks.comments;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/DynamicJspIncludeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/DynamicJspIncludeCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.dependencies;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/IllegalNamespaceCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/IllegalNamespaceCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.dependencies;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/IllegalTagLibsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/IllegalTagLibsCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.dependencies;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/LibraryDependencyCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/LibraryDependencyCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.dependencies;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/package-info.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @ParametersAreNonnullByDefault
 package org.sonar.plugins.html.checks.dependencies;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/header/HeaderCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/header/HeaderCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.header;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/header/MultiplePageDirectivesCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/header/MultiplePageDirectivesCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.header;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/header/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/header/package-info.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @ParametersAreNonnullByDefault
 package org.sonar.plugins.html.checks.header;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/package-info.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @ParametersAreNonnullByDefault
 package org.sonar.plugins.html.checks;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/JspScriptletCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/JspScriptletCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.scripting;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/LongJavaScriptCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/LongJavaScriptCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.scripting;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/NestedJavaScriptCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/NestedJavaScriptCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.scripting;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/UnifiedExpressionCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/UnifiedExpressionCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.scripting;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/package-info.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @ParametersAreNonnullByDefault
 package org.sonar.plugins.html.checks.scripting;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/DisabledAutoescapeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/DisabledAutoescapeCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.security;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/ResourceIntegrityCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/ResourceIntegrityCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.security;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/package-info.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @ParametersAreNonnullByDefault
 package org.sonar.plugins.html.checks.security;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/AbsoluteURICheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/AbsoluteURICheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/BoldAndItalicTagsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/BoldAndItalicTagsCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/DeprecatedAttributesInHtml5Check.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/DeprecatedAttributesInHtml5Check.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/DoctypePresenceCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/DoctypePresenceCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ElementWithGivenIdPresentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ElementWithGivenIdPresentCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FieldsetWithoutLegendCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FieldsetWithoutLegendCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FlashHelper.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FlashHelper.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FlashUsesBothObjectAndEmbedCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FlashUsesBothObjectAndEmbedCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FrameWithoutTitleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FrameWithoutTitleCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ImgWithoutAltCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ImgWithoutAltCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ImgWithoutWidthOrHeightCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ImgWithoutWidthOrHeightCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/IndistinguishableSimilarElementsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/IndistinguishableSimilarElementsCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LangAttributeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LangAttributeCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LayoutTableCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LayoutTableCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LayoutTableWithSemanticMarkupCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LayoutTableWithSemanticMarkupCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinkToImageCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinkToImageCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinkToNothingCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinkToNothingCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinkWithTargetBlankCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinkWithTargetBlankCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinksIdenticalTextsDifferentTargetsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinksIdenticalTextsDifferentTargetsCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MetaRefreshCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MetaRefreshCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/NonConsecutiveHeadingCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/NonConsecutiveHeadingCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ObjectWithAlternativeContentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ObjectWithAlternativeContentCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/PageWithoutFaviconCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/PageWithoutFaviconCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/PageWithoutTitleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/PageWithoutTitleCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ServerSideImageMapsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ServerSideImageMapsCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableHeaderHasIdOrScopeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableHeaderHasIdOrScopeCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableHeaderReferenceCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableHeaderReferenceCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutCaptionCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutCaptionCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/UnsupportedTagsInHtml5Check.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/UnsupportedTagsInHtml5Check.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/VideoTrackCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/VideoTrackCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/WmodeIsWindowCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/WmodeIsWindowCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/package-info.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @ParametersAreNonnullByDefault
 package org.sonar.plugins.html.checks.sonar;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ChildElementIllegalCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ChildElementIllegalCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.structure;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ChildElementRequiredCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ChildElementRequiredCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.structure;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/IllegalElementCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/IllegalElementCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.structure;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ParentElementIllegalCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ParentElementIllegalCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.structure;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ParentElementRequiredCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ParentElementRequiredCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.structure;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/package-info.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @ParametersAreNonnullByDefault
 package org.sonar.plugins.html.checks.structure;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/style/InlineStyleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/style/InlineStyleCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.style;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/style/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/style/package-info.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @ParametersAreNonnullByDefault
 package org.sonar.plugins.html.checks.style;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/whitespace/IllegalTabCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/whitespace/IllegalTabCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.whitespace;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/whitespace/WhiteSpaceAroundCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/whitespace/WhiteSpaceAroundCheck.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.whitespace;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/whitespace/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/whitespace/package-info.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @ParametersAreNonnullByDefault
 package org.sonar.plugins.html.checks.whitespace;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/Html.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/Html.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.core;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlLexer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlLexer.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.core;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlSensor.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlSensor.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.core;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlTokenType.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlTokenType.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.core;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlTokensVisitor.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlTokensVisitor.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.core;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/Jsp.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/Jsp.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.core;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/TokenLocation.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/TokenLocation.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.core;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/package-info.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @ParametersAreNonnullByDefault
 package org.sonar.plugins.html.core;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/AbstractTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/AbstractTokenizer.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.lex;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/CdataTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/CdataTokenizer.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.lex;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/CommentTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/CommentTokenizer.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.lex;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/DirectiveTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/DirectiveTokenizer.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.lex;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/DoctypeTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/DoctypeTokenizer.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.lex;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/ElementTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/ElementTokenizer.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.lex;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/ExpressionTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/ExpressionTokenizer.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.lex;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/NormalElementTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/NormalElementTokenizer.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.lex;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/PageLexer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/PageLexer.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.lex;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/TextTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/TextTokenizer.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.lex;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/VueLexer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/VueLexer.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.lex;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/package-info.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @ParametersAreNonnullByDefault
 package org.sonar.plugins.html.lex;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/package-info.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @ParametersAreNonnullByDefault
 package org.sonar.plugins.html;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/CheckClasses.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/CheckClasses.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.rules;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/HtmlRulesDefinition.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/HtmlRulesDefinition.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.rules;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/JspQualityProfile.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/JspQualityProfile.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.rules;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/SonarWayProfile.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/SonarWayProfile.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.rules;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/package-info.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @ParametersAreNonnullByDefault
 package org.sonar.plugins.html.rules;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/DefaultNodeVisitor.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/DefaultNodeVisitor.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.visitor;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/HtmlAstScanner.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/HtmlAstScanner.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.visitor;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/HtmlSourceCode.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/HtmlSourceCode.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.visitor;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/NoSonarScanner.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/NoSonarScanner.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.visitor;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/package-info.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @ParametersAreNonnullByDefault
 package org.sonar.plugins.html.visitor;

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/HtmlPluginTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/HtmlPluginTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/analyzers/ComplexityVisitorTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/analyzers/ComplexityVisitorTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.analyzers;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/analyzers/PageCountLinesTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/analyzers/PageCountLinesTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.analyzers;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/HtmlConstantsTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/HtmlConstantsTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.api;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/CheckMessagesVerifier.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/CheckMessagesVerifier.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/CheckMessagesVerifierRule.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/CheckMessagesVerifierRule.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/TestHelper.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/TestHelper.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AnchorsShouldNotBeUsedAsButtonsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AnchorsShouldNotBeUsedAsButtonsCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaActiveDescendantHasTabIndexCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaActiveDescendantHasTabIndexCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaProptypesCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaProptypesCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaRoleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaRoleCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaUnsupportedElementsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaUnsupportedElementsCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ElementWithRoleShouldHaveRequiredPropertiesCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ElementWithRoleShouldHaveRequiredPropertiesCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/FocusableInteractiveElementsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/FocusableInteractiveElementsCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/HeadingHasAccessibleContentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/HeadingHasAccessibleContentCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ImgRedundantAltCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ImgRedundantAltCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoAriaHiddenOnFocusableCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoAriaHiddenOnFocusableCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoInteractiveElementToNoninteractiveRoleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoInteractiveElementToNoninteractiveRoleCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNonInteractiveElementsWithHandlersCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNonInteractiveElementsWithHandlersCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveElementToInteractiveRoleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveElementToInteractiveRoleCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoRedundantRolesCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoRedundantRolesCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoStaticElementInteractionsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoStaticElementInteractionsCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/RoleSupportsAriaPropertyCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/RoleSupportsAriaPropertyCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/TabIndexNoPositiveCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/TabIndexNoPositiveCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ValidAutocompleteCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ValidAutocompleteCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.accessibility;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/IllegalAttributeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/IllegalAttributeCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.attributes;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/NoAccessKeyCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/NoAccessKeyCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.attributes;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/RequiredAttributeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/RequiredAttributeCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.attributes;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/ComplexityCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/ComplexityCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.coding;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/DoubleQuotesCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/DoubleQuotesCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.coding;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/FileLengthCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/FileLengthCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.coding;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/InternationalizationCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/InternationalizationCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.coding;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/MaxLineLengthCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/MaxLineLengthCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.coding;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/UnclosedTagCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/UnclosedTagCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.coding;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/AvoidCommentedOutCodeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/AvoidCommentedOutCodeCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.comments;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/AvoidHtmlCommentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/AvoidHtmlCommentCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.comments;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/CommentUtilsTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/CommentUtilsTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.comments;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/FixmeCommentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/FixmeCommentCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.comments;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/TodoCommentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/TodoCommentCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.comments;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/DynamicJspIncludeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/DynamicJspIncludeCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.dependencies;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/IllegalNamespaceCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/IllegalNamespaceCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.dependencies;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/IllegalTagLibsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/IllegalTagLibsCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.dependencies;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/LibraryDependencyCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/LibraryDependencyCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.dependencies;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/header/HeaderCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/header/HeaderCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.header;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/header/MultiplePageDirectivesCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/header/MultiplePageDirectivesCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.header;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/JspScriptletCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/JspScriptletCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.scripting;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/LongJavaScriptCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/LongJavaScriptCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.scripting;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/NestedJavaScriptCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/NestedJavaScriptCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.scripting;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/UnifiedExpressionCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/UnifiedExpressionCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.scripting;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/security/DisabledAutoescapeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/security/DisabledAutoescapeCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.security;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/security/ResourceIntegrityCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/security/ResourceIntegrityCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.security;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/AbsoluteURICheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/AbsoluteURICheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/BoldAndItalicTagsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/BoldAndItalicTagsCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/DeprecatedAttributesInHtml5CheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/DeprecatedAttributesInHtml5CheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/DoctypePresenceCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/DoctypePresenceCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ElementWithGivenIdPresentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ElementWithGivenIdPresentCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/FieldsetWithoutLegendCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/FieldsetWithoutLegendCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/FlashUsesBothObjectAndEmbedCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/FlashUsesBothObjectAndEmbedCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/FrameWithoutTitleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/FrameWithoutTitleCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ImgWithoutAltCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ImgWithoutAltCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ImgWithoutWidthOrHeightCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ImgWithoutWidthOrHeightCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/IndistinguishableSimilarElementsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/IndistinguishableSimilarElementsCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LangAttributeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LangAttributeCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LayoutTableCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LayoutTableCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LayoutTableWithSemanticMarkupCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LayoutTableWithSemanticMarkupCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinkToImageCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinkToImageCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinkToNothingCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinkToNothingCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinkWithTargetBlankCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinkWithTargetBlankCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinksIdenticalTextsDifferentTargetsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinksIdenticalTextsDifferentTargetsCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MetaRefreshCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MetaRefreshCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/NonConsecutiveHeadingCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/NonConsecutiveHeadingCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ObjectWithAlternativeContentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ObjectWithAlternativeContentCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/PageWithoutFaviconCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/PageWithoutFaviconCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/PageWithoutTitleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/PageWithoutTitleCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ServerSideImageMapsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ServerSideImageMapsCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableHeaderHasIdOrScopeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableHeaderHasIdOrScopeCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableHeaderReferenceCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableHeaderReferenceCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutCaptionCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutCaptionCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/UnsupportedTagsInHtml5CheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/UnsupportedTagsInHtml5CheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/VideoTrackCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/VideoTrackCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/WmodeIsWindowCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/WmodeIsWindowCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.sonar;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ChildElementIllegalCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ChildElementIllegalCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.structure;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ChildElementRequiredCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ChildElementRequiredCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.structure;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/IllegalElementCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/IllegalElementCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.structure;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ParentElementIllegalCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ParentElementIllegalCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.structure;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ParentElementRequiredCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ParentElementRequiredCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.structure;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/style/InlineStyleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/style/InlineStyleCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.style;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/whitespace/IllegalTabCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/whitespace/IllegalTabCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.whitespace;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/whitespace/WhiteSpaceAroundCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/whitespace/WhiteSpaceAroundCheckTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.checks.whitespace;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlLexerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlLexerTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.core;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlSensorTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlSensorTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.core;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.core;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/JspTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/JspTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.core;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/l10n/LocalizedBundlesTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/l10n/LocalizedBundlesTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.l10n;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/NormalElementTokenizerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/NormalElementTokenizerTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.lex;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/PageLexerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/PageLexerTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.lex;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/TextTokenizerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/TextTokenizerTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.lex;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/VueLexerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/VueLexerTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.lex;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/CheckClassesTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/CheckClassesTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.rules;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/HtmlRulesDefinitionTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/HtmlRulesDefinitionTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.rules;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/SonarWayProfileTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/SonarWayProfileTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.rules;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/visitor/NoSonarScannerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/visitor/NoSonarScannerTest.java
@@ -1,19 +1,18 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.visitor;
 


### PR DESCRIPTION
[SONARHTML-269](https://sonarsource.atlassian.net/browse/SONARHTML-269)

Checklist for the review based on [these instructions](https://sonarsource.atlassian.net/browse/SQRP-80):

- [ ] Source file headers are updated to SSAL (Sonar Source-Available License).
- [ ] License.txt file is updated to SSAL.
- [ ] README.md mentions the history of the license.
- [ ] README.md links to the License.txt file.
- [ ] Maven pom.xml file license is updated to SSAL.
- [ ] Maven pom.xml file uses parent-oss version 81.0.0.2300

[SONARHTML-269]: https://sonarsource.atlassian.net/browse/SONARHTML-269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ