### PR TITLE
SONARHTML-258 Support STIG security standard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 
     <jakarta.el.version>4.0.2</jakarta.el.version>
     <sslr.version>1.24.0.633</sslr.version>
-    <analyzerCommons.version>2.7.0.1482</analyzerCommons.version>
+    <analyzerCommons.version>2.16.0.3141</analyzerCommons.version>
     <sonar.plugin.api.version>10.1.0.809</sonar.plugin.api.version>
 
     <sonarqube.api.impl.version>10.1.0.73491</sonarqube.api.impl.version>


### PR DESCRIPTION
[SONARHTML-258](https://sonarsource.atlassian.net/browse/SONARHTML-258)

FYI sonar-analyzer-commons introduced STIG security standard in [2.12](https://github.com/SonarSource/sonar-analyzer-commons/releases/tag/2.12.0.2964) while SonarHTML used 2.7.



[SONARHTML-258]: https://sonarsource.atlassian.net/browse/SONARHTML-258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ