### PR TITLE
SONARHTML-271 Bump to 3.17.0

### DIFF
--- a/its/plugin/pom.xml
+++ b/its/plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.html</groupId>
     <artifactId>html-its</artifactId>
-    <version>3.16.0-SNAPSHOT</version>
+    <version>3.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>it-html-plugin</artifactId>

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.sonarsource.html</groupId>
     <artifactId>html</artifactId>
-    <version>3.16.0-SNAPSHOT</version>
+    <version>3.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>html-its</artifactId>

--- a/its/ruling/pom.xml
+++ b/its/ruling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.html</groupId>
     <artifactId>html-its</artifactId>
-    <version>3.16.0-SNAPSHOT</version>
+    <version>3.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>it-html-ruling</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.sonarsource.html</groupId>
   <artifactId>html</artifactId>
-  <version>3.16.0-SNAPSHOT</version>
+  <version>3.17.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>SonarSource :: HTML</name>

--- a/sonar-html-plugin/pom.xml
+++ b/sonar-html-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.html</groupId>
     <artifactId>html</artifactId>
-    <version>3.16.0-SNAPSHOT</version>
+    <version>3.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>sonar-html-plugin</artifactId>


### PR DESCRIPTION
[SONARHTML-271](https://sonarsource.atlassian.net/browse/SONARHTML-271)

We forgot to bump the version of SonarHTML after releasing [3.16](https://github.com/SonarSource/sonar-html/releases/tag/3.16.0.5274).

[SONARHTML-271]: https://sonarsource.atlassian.net/browse/SONARHTML-271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ