### PR TITLE
SONARHTML-272 Update parent POM to 82.0.0.2314

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.sonarsource.parent</groupId>
     <artifactId>parent</artifactId>
-    <version>81.0.0.2300</version>
+    <version>82.0.0.2314</version>
   </parent>
 
   <groupId>org.sonarsource.html</groupId>


### PR DESCRIPTION
[SONARHTML-272](https://sonarsource.atlassian.net/browse/SONARHTML-272)

A [new parent POM](https://github.com/SonarSource/parent-oss/releases/tag/82.0.0.2314) was released a few hours ago, making the releasability checks [fail](https://github.com/SonarSource/gh-action_releasability/actions/runs/12032491132/job/33544451211).

[SONARHTML-272]: https://sonarsource.atlassian.net/browse/SONARHTML-272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ