### PR TITLE
SONARHTML-279 Remove assertions of endpoints that were removed in SQS

### DIFF
--- a/its/plugin/src/test/java/com/sonar/it/web/StandardMeasuresTest.java
+++ b/its/plugin/src/test/java/com/sonar/it/web/StandardMeasuresTest.java
@@ -70,9 +70,6 @@ public class StandardMeasuresTest {
 
     assertThat(getProjectMeasureAsDouble("public_api")).isNull();
     assertThat(getProjectMeasureAsDouble("complexity")).isEqualTo(391d);
-    assertThat(getProjectMeasureAsDouble("function_complexity")).isNull();
-    assertThat(getProjectMeasureAsDouble("function_complexity_distribution")).isNull();
-    assertThat(getProjectMeasureAsDouble("file_complexity")).isEqualTo(3.8);
   }
 
   @Test
@@ -104,9 +101,6 @@ public class StandardMeasuresTest {
     assertThat(getFileMeasureAsDouble("duplicated_lines_density")).isZero();
     assertThat(getFileMeasureAsDouble("statements")).isNull();
     assertThat(getFileMeasureAsDouble("complexity")).isEqualTo(16d);
-    assertThat(getFileMeasureAsDouble("function_complexity")).isNull();
-    assertThat(getFileMeasureAsDouble("function_complexity_distribution")).isNull();
-    assertThat(getFileMeasureAsDouble("file_complexity")).isEqualTo(16.0d);
   }
 
   @Test


### PR DESCRIPTION
[SONARHTML-279](https://sonarsource.atlassian.net/browse/SONARHTML-279)

The following endpoints have been recently removed from SQS: [SONAR-12647](https://sonarsource.atlassian.net/browse/SONAR-12647)

[Issue stack trace in CI](https://cirrus-ci.com/task/4514077772349440?logs=qa#L2309)


[SONARHTML-279]: https://sonarsource.atlassian.net/browse/SONARHTML-279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SONAR-12647]: https://sonarsource.atlassian.net/browse/SONAR-12647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ