### PR TITLE
SONARHTML-276 Remove dev from owners

### DIFF
--- a/its/plugin/pom.xml
+++ b/its/plugin/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>it-html-plugin</artifactId>
 
-  <name>SonarSource :: HTML :: ITs :: Plugin</name>
+  <name>SonarQube HTML Plugin :: ITs :: Plugin</name>
   <inceptionYear>2011</inceptionYear>
   <organization>
     <name>SonarSource</name>

--- a/its/plugin/pom.xml
+++ b/its/plugin/pom.xml
@@ -19,7 +19,7 @@
   <properties>
     <license.name>AL2</license.name>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
-    <license.owner>SonarSource SA and Matthijs Galesloot</license.owner>
+    <license.owner>SonarSource SA</license.owner>
     <license.mailto>sonarqube@googlegroups.com</license.mailto>
     <gitRepositoryName>sonar-html</gitRepositoryName>
   </properties>

--- a/its/plugin/pom.xml
+++ b/its/plugin/pom.xml
@@ -17,10 +17,7 @@
     <url>http://www.sonarsource.com</url>
   </organization>
   <properties>
-    <license.name>AL2</license.name>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
-    <license.owner>SonarSource SA</license.owner>
-    <license.mailto>sonarqube@googlegroups.com</license.mailto>
     <gitRepositoryName>sonar-html</gitRepositoryName>
   </properties>
 

--- a/its/plugin/src/test/java/com/sonar/it/web/FileSuffixesTest.java
+++ b/its/plugin/src/test/java/com/sonar/it/web/FileSuffixesTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: ITs :: Plugin
+ * SonarQube HTML
  * Copyright (C) 2011-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/its/plugin/src/test/java/com/sonar/it/web/FileSuffixesTest.java
+++ b/its/plugin/src/test/java/com/sonar/it/web/FileSuffixesTest.java
@@ -1,6 +1,6 @@
 /*
- * SonarQube HTML Plugin
- * Copyright (C) 2010-2024 SonarSource SA
+ * SonarQube HTML Plugin :: ITs :: Plugin
+ * Copyright (C) 2011-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/plugin/src/test/java/com/sonar/it/web/FileSuffixesTest.java
+++ b/its/plugin/src/test/java/com/sonar/it/web/FileSuffixesTest.java
@@ -1,19 +1,18 @@
 /*
- * SonarSource :: HTML :: ITs :: Plugin
- * Copyright (c) 2011-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * SonarQube HTML Plugin
+ * Copyright (C) 2010-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package com.sonar.it.web;
 

--- a/its/plugin/src/test/java/com/sonar/it/web/HtmlTestSuite.java
+++ b/its/plugin/src/test/java/com/sonar/it/web/HtmlTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: ITs :: Plugin
+ * SonarQube HTML
  * Copyright (C) 2011-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/its/plugin/src/test/java/com/sonar/it/web/HtmlTestSuite.java
+++ b/its/plugin/src/test/java/com/sonar/it/web/HtmlTestSuite.java
@@ -1,6 +1,6 @@
 /*
- * SonarQube HTML Plugin
- * Copyright (C) 2010-2024 SonarSource SA
+ * SonarQube HTML Plugin :: ITs :: Plugin
+ * Copyright (C) 2011-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/plugin/src/test/java/com/sonar/it/web/HtmlTestSuite.java
+++ b/its/plugin/src/test/java/com/sonar/it/web/HtmlTestSuite.java
@@ -1,19 +1,18 @@
 /*
- * SonarSource :: HTML :: ITs :: Plugin
- * Copyright (c) 2011-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * SonarQube HTML Plugin
+ * Copyright (C) 2010-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package com.sonar.it.web;
 

--- a/its/plugin/src/test/java/com/sonar/it/web/PhpFilesTest.java
+++ b/its/plugin/src/test/java/com/sonar/it/web/PhpFilesTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: ITs :: Plugin
+ * SonarQube HTML
  * Copyright (C) 2011-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/its/plugin/src/test/java/com/sonar/it/web/PhpFilesTest.java
+++ b/its/plugin/src/test/java/com/sonar/it/web/PhpFilesTest.java
@@ -1,6 +1,6 @@
 /*
- * SonarQube HTML Plugin
- * Copyright (C) 2010-2024 SonarSource SA
+ * SonarQube HTML Plugin :: ITs :: Plugin
+ * Copyright (C) 2011-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/plugin/src/test/java/com/sonar/it/web/PhpFilesTest.java
+++ b/its/plugin/src/test/java/com/sonar/it/web/PhpFilesTest.java
@@ -1,19 +1,18 @@
 /*
- * SonarSource :: HTML :: ITs :: Plugin
- * Copyright (c) 2011-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * SonarQube HTML Plugin
+ * Copyright (C) 2010-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package com.sonar.it.web;
 

--- a/its/plugin/src/test/java/com/sonar/it/web/SonarLintTest.java
+++ b/its/plugin/src/test/java/com/sonar/it/web/SonarLintTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: ITs :: Plugin
+ * SonarQube HTML
  * Copyright (C) 2011-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/its/plugin/src/test/java/com/sonar/it/web/SonarLintTest.java
+++ b/its/plugin/src/test/java/com/sonar/it/web/SonarLintTest.java
@@ -1,6 +1,6 @@
 /*
- * SonarQube HTML Plugin
- * Copyright (C) 2010-2024 SonarSource SA
+ * SonarQube HTML Plugin :: ITs :: Plugin
+ * Copyright (C) 2011-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/plugin/src/test/java/com/sonar/it/web/SonarLintTest.java
+++ b/its/plugin/src/test/java/com/sonar/it/web/SonarLintTest.java
@@ -1,19 +1,18 @@
 /*
- * SonarSource :: HTML :: ITs :: Plugin
- * Copyright (c) 2011-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * SonarQube HTML Plugin
+ * Copyright (C) 2010-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package com.sonar.it.web;
 

--- a/its/plugin/src/test/java/com/sonar/it/web/StandardMeasuresTest.java
+++ b/its/plugin/src/test/java/com/sonar/it/web/StandardMeasuresTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: ITs :: Plugin
+ * SonarQube HTML
  * Copyright (C) 2011-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/its/plugin/src/test/java/com/sonar/it/web/StandardMeasuresTest.java
+++ b/its/plugin/src/test/java/com/sonar/it/web/StandardMeasuresTest.java
@@ -1,6 +1,6 @@
 /*
- * SonarQube HTML Plugin
- * Copyright (C) 2010-2024 SonarSource SA
+ * SonarQube HTML Plugin :: ITs :: Plugin
+ * Copyright (C) 2011-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/plugin/src/test/java/com/sonar/it/web/StandardMeasuresTest.java
+++ b/its/plugin/src/test/java/com/sonar/it/web/StandardMeasuresTest.java
@@ -1,19 +1,18 @@
 /*
- * SonarSource :: HTML :: ITs :: Plugin
- * Copyright (c) 2011-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * SonarQube HTML Plugin
+ * Copyright (C) 2010-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package com.sonar.it.web;
 

--- a/its/plugin/src/test/java/com/sonar/it/web/StandardMeasuresTest.java
+++ b/its/plugin/src/test/java/com/sonar/it/web/StandardMeasuresTest.java
@@ -70,9 +70,6 @@ public class StandardMeasuresTest {
 
     assertThat(getProjectMeasureAsDouble("public_api")).isNull();
     assertThat(getProjectMeasureAsDouble("complexity")).isEqualTo(391d);
-    assertThat(getProjectMeasureAsDouble("function_complexity")).isNull();
-    assertThat(getProjectMeasureAsDouble("function_complexity_distribution")).isNull();
-    assertThat(getProjectMeasureAsDouble("file_complexity")).isEqualTo(3.8);
   }
 
   @Test
@@ -104,9 +101,6 @@ public class StandardMeasuresTest {
     assertThat(getFileMeasureAsDouble("duplicated_lines_density")).isZero();
     assertThat(getFileMeasureAsDouble("statements")).isNull();
     assertThat(getFileMeasureAsDouble("complexity")).isEqualTo(16d);
-    assertThat(getFileMeasureAsDouble("function_complexity")).isNull();
-    assertThat(getFileMeasureAsDouble("function_complexity_distribution")).isNull();
-    assertThat(getFileMeasureAsDouble("file_complexity")).isEqualTo(16.0d);
   }
 
   @Test

--- a/its/plugin/src/test/java/com/sonar/it/web/VariousTest.java
+++ b/its/plugin/src/test/java/com/sonar/it/web/VariousTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: ITs :: Plugin
+ * SonarQube HTML
  * Copyright (C) 2011-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/its/plugin/src/test/java/com/sonar/it/web/VariousTest.java
+++ b/its/plugin/src/test/java/com/sonar/it/web/VariousTest.java
@@ -1,6 +1,6 @@
 /*
- * SonarQube HTML Plugin
- * Copyright (C) 2010-2024 SonarSource SA
+ * SonarQube HTML Plugin :: ITs :: Plugin
+ * Copyright (C) 2011-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/plugin/src/test/java/com/sonar/it/web/VariousTest.java
+++ b/its/plugin/src/test/java/com/sonar/it/web/VariousTest.java
@@ -1,19 +1,18 @@
 /*
- * SonarSource :: HTML :: ITs :: Plugin
- * Copyright (c) 2011-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * SonarQube HTML Plugin
+ * Copyright (C) 2010-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package com.sonar.it.web;
 

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>html-its</artifactId>
-  <name>SonarSource :: Web :: ITs</name>
+  <name>SonarQube HTML Plugin :: ITs</name>
   <packaging>pom</packaging>
 
   <modules>

--- a/its/ruling/pom.xml
+++ b/its/ruling/pom.xml
@@ -21,7 +21,7 @@
     <webVersion>2.2-SNAPSHOT</webVersion>
 
     <surefire.argLine>-server -Xmx512m</surefire.argLine>
-    <license.owner>SonarSource SA and Matthijs Galesloot</license.owner>
+    <license.owner>SonarSource SA</license.owner>
     <license.mailto>sonarqube@googlegroups.com</license.mailto>
     <gitRepositoryName>sonar-html</gitRepositoryName>
 

--- a/its/ruling/pom.xml
+++ b/its/ruling/pom.xml
@@ -17,14 +17,9 @@
   </organization>
 
   <properties>
-    <license.name>AL2</license.name>
     <webVersion>2.2-SNAPSHOT</webVersion>
-
     <surefire.argLine>-server -Xmx512m</surefire.argLine>
-    <license.owner>SonarSource SA</license.owner>
-    <license.mailto>sonarqube@googlegroups.com</license.mailto>
     <gitRepositoryName>sonar-html</gitRepositoryName>
-
     <gson.version>2.10</gson.version>
   </properties>
 

--- a/its/ruling/pom.xml
+++ b/its/ruling/pom.xml
@@ -9,7 +9,7 @@
 
   <artifactId>it-html-ruling</artifactId>
 
-  <name>SonarSource :: HTML :: ITs :: Ruling</name>
+  <name>SonarQube HTML Plugin :: ITs :: Ruling</name>
   <inceptionYear>2013</inceptionYear>
   <organization>
     <name>SonarSource</name>

--- a/its/ruling/src/test/java/org/sonar/web/it/WebRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/web/it/WebRulingTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: ITs :: Ruling
+ * SonarQube HTML
  * Copyright (C) 2013-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/its/ruling/src/test/java/org/sonar/web/it/WebRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/web/it/WebRulingTest.java
@@ -1,19 +1,18 @@
 /*
- * SonarSource :: HTML :: ITs :: Ruling
- * Copyright (c) 2013-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * SonarQube HTML Plugin
+ * Copyright (C) 2010-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.web.it;
 

--- a/its/ruling/src/test/java/org/sonar/web/it/WebRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/web/it/WebRulingTest.java
@@ -1,6 +1,6 @@
 /*
- * SonarQube HTML Plugin
- * Copyright (C) 2010-2024 SonarSource SA
+ * SonarQube HTML Plugin :: ITs :: Ruling
+ * Copyright (C) 2013-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/pom.xml
+++ b/pom.xml
@@ -120,13 +120,6 @@
               <excludes>
                 <!-- Folders -->
                 <exclude>its/sources/**/*</exclude>
-                <!-- Generated -->
-                <exclude>**/bin/**/*</exclude>
-                <exclude>**/dist/**/*</exclude>
-                <exclude>**/lib/**/*</exclude>
-                <!-- Fixtures -->
-                <exclude>**/fixtures/**/*</exclude>
-                <exclude>**/*.fixture.*</exclude>
                 <!-- Resources -->
                 <exclude>**/src/test/resources/**/*</exclude>
               </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <version>3.18.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-  <name>SonarSource :: HTML</name>
+  <name>SonarQube HTML Plugin</name>
 
   <url>http://redirect.sonarsource.com/plugins/web.html</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -105,4 +105,45 @@
     </profile>
   </profiles>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <!-- This plugin is already configured in parent pom, however we want a configuration specific to this project -->
+        <configuration>
+          <licenseSets>
+            <licenseSet>
+              <includes>
+                <include>**/*.java</include>
+              </includes>
+              <excludes>
+                <!-- Folders -->
+                <exclude>its/sources/**/*</exclude>
+                <!-- Generated -->
+                <exclude>**/bin/**/*</exclude>
+                <exclude>**/dist/**/*</exclude>
+                <exclude>**/lib/**/*</exclude>
+                <!-- Fixtures -->
+                <exclude>**/fixtures/**/*</exclude>
+                <exclude>**/*.fixture.*</exclude>
+                <!-- Resources -->
+                <exclude>**/src/test/resources/**/*</exclude>
+              </excludes>
+            </licenseSet>
+          </licenseSets>
+        </configuration>
+      </plugin>
+    </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>3.5.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <inceptionYear>2010</inceptionYear>
   <organization>
-    <name>SonarSource and Matthijs Galesloot</name>
+    <name>SonarSource</name>
   </organization>
   <licenses>
     <license>
@@ -65,7 +65,7 @@
 
   <properties>
     <revision>3.5-SNAPSHOT</revision>
-    <license.owner>SonarSource SA and Matthijs Galesloot</license.owner>
+    <license.owner>SonarSource SA</license.owner>
     <gitRepositoryName>sonar-html</gitRepositoryName>
 
     <jakarta.el.version>4.0.2</jakarta.el.version>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 
   <properties>
     <revision>3.5-SNAPSHOT</revision>
-    <license.owner>SonarSource SA</license.owner>
+    <license.title>SonarQube HTML</license.title>
     <gitRepositoryName>sonar-html</gitRepositoryName>
 
     <jakarta.el.version>4.0.2</jakarta.el.version>
@@ -104,39 +104,5 @@
       </modules>
     </profile>
   </profiles>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>com.mycila</groupId>
-        <artifactId>license-maven-plugin</artifactId>
-        <!-- This plugin is already configured in parent pom, however we want a configuration specific to this project -->
-        <configuration>
-          <licenseSets>
-            <licenseSet>
-              <includes>
-                <include>**/*.java</include>
-              </includes>
-              <excludes>
-                <!-- Folders -->
-                <exclude>its/sources/**/*</exclude>
-                <!-- Resources -->
-                <exclude>**/src/test/resources/**/*</exclude>
-              </excludes>
-            </licenseSet>
-          </licenseSets>
-        </configuration>
-      </plugin>
-    </plugins>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>exec-maven-plugin</artifactId>
-          <version>3.5.0</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
 
 </project>

--- a/sonar-html-plugin/pom.xml
+++ b/sonar-html-plugin/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>sonar-html-plugin</artifactId>
   <packaging>sonar-plugin</packaging>
 
-  <name>SonarSource HTML analyzer :: Sonar Plugin</name>
+  <name>SonarQube HTML Plugin :: Sonar Plugin</name>
   <description>Code analyzer for HTML</description>
   <url>http://redirect.sonarsource.com/plugins/web.html</url>
 

--- a/sonar-html-plugin/pom.xml
+++ b/sonar-html-plugin/pom.xml
@@ -15,14 +15,6 @@
   <description>Code analyzer for HTML</description>
   <url>http://redirect.sonarsource.com/plugins/web.html</url>
 
-  <licenses>
-    <license>
-      <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
-
   <scm>
     <connection>scm:git:git@github.com:SonarSource/sonar-html.git</connection>
     <developerConnection>scm:git:git@github.com:SonarSource/sonar-html.git</developerConnection>

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/HtmlPlugin.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/HtmlPlugin.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/HtmlPlugin.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/HtmlPlugin.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/HtmlPlugin.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/HtmlPlugin.java
@@ -31,8 +31,7 @@ import org.sonar.plugins.html.rules.SonarWayProfile;
 /**
  * HTML Plugin publishes extensions to sonar engine.
  *
- * @author Matthijs Galesloot
- * @since 1.0
+
  */
 public final class HtmlPlugin implements Plugin {
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/HtmlPlugin.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/HtmlPlugin.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/analyzers/ComplexityVisitor.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/analyzers/ComplexityVisitor.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/analyzers/ComplexityVisitor.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/analyzers/ComplexityVisitor.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/analyzers/ComplexityVisitor.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/analyzers/ComplexityVisitor.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/analyzers/PageCountLines.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/analyzers/PageCountLines.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/analyzers/PageCountLines.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/analyzers/PageCountLines.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/analyzers/PageCountLines.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/analyzers/PageCountLines.java
@@ -29,8 +29,7 @@ import org.sonar.plugins.html.visitor.HtmlSourceCode;
 /**
  * Count lines of code in web files.
  *
- * @author Matthijs Galesloot
- * @since 1.0
+
  */
 public class PageCountLines extends DefaultNodeVisitor {
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/analyzers/PageCountLines.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/analyzers/PageCountLines.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/analyzers/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/analyzers/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/analyzers/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/analyzers/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/analyzers/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/analyzers/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/BufferStack.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/BufferStack.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/BufferStack.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/BufferStack.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/BufferStack.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/BufferStack.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/HtmlConstants.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/HtmlConstants.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/HtmlConstants.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/HtmlConstants.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/HtmlConstants.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/HtmlConstants.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtils.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtils.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtils.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtils.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtils.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/Aria.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/Aria.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/Aria.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/Aria.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/Aria.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/Aria.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AriaProperty.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AriaProperty.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AriaProperty.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AriaProperty.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AriaProperty.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AriaProperty.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AriaRole.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AriaRole.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AriaRole.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AriaRole.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AriaRole.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AriaRole.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/ControlGroup.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/ControlGroup.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/ControlGroup.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/ControlGroup.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/ControlGroup.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/ControlGroup.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/Element.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/Element.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/Element.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/Element.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/Element.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/Element.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/AbstractPageCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/AbstractPageCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/AbstractPageCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/AbstractPageCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/AbstractPageCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/AbstractPageCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/AbstractPageCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/AbstractPageCheck.java
@@ -27,8 +27,7 @@ import org.sonar.plugins.html.visitor.DefaultNodeVisitor;
 
 /**
  * Abtract superclass for checks.
- *
- * @author Matthijs Galesloot
+
  */
 public abstract class AbstractPageCheck extends DefaultNodeVisitor {
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/HtmlIssue.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/HtmlIssue.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/HtmlIssue.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/HtmlIssue.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/HtmlIssue.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/HtmlIssue.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/PreciseHtmlIssue.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/PreciseHtmlIssue.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/PreciseHtmlIssue.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/PreciseHtmlIssue.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/PreciseHtmlIssue.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/PreciseHtmlIssue.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsShouldNotBeUsedAsButtonsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsShouldNotBeUsedAsButtonsCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsShouldNotBeUsedAsButtonsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsShouldNotBeUsedAsButtonsCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsShouldNotBeUsedAsButtonsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsShouldNotBeUsedAsButtonsCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaActiveDescendantHasTabIndexCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaActiveDescendantHasTabIndexCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaActiveDescendantHasTabIndexCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaActiveDescendantHasTabIndexCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaActiveDescendantHasTabIndexCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaActiveDescendantHasTabIndexCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaProptypesCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaProptypesCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaProptypesCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaProptypesCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaProptypesCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaProptypesCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaRoleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaRoleCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaRoleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaRoleCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaRoleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaRoleCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaUnsupportedElementsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaUnsupportedElementsCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaUnsupportedElementsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaUnsupportedElementsCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaUnsupportedElementsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaUnsupportedElementsCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ElementWithRoleShouldHaveRequiredPropertiesCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ElementWithRoleShouldHaveRequiredPropertiesCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ElementWithRoleShouldHaveRequiredPropertiesCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ElementWithRoleShouldHaveRequiredPropertiesCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ElementWithRoleShouldHaveRequiredPropertiesCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ElementWithRoleShouldHaveRequiredPropertiesCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/EventHandlers.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/EventHandlers.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/EventHandlers.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/EventHandlers.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/EventHandlers.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/EventHandlers.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/FocusableInteractiveElementsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/FocusableInteractiveElementsCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/FocusableInteractiveElementsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/FocusableInteractiveElementsCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/FocusableInteractiveElementsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/FocusableInteractiveElementsCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/HeadingHasAccessibleContentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/HeadingHasAccessibleContentCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/HeadingHasAccessibleContentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/HeadingHasAccessibleContentCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/HeadingHasAccessibleContentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/HeadingHasAccessibleContentCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ImgRedundantAltCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ImgRedundantAltCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ImgRedundantAltCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ImgRedundantAltCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ImgRedundantAltCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ImgRedundantAltCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAriaHiddenOnFocusableCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAriaHiddenOnFocusableCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAriaHiddenOnFocusableCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAriaHiddenOnFocusableCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAriaHiddenOnFocusableCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAriaHiddenOnFocusableCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoInteractiveElementToNoninteractiveRoleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoInteractiveElementToNoninteractiveRoleCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoInteractiveElementToNoninteractiveRoleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoInteractiveElementToNoninteractiveRoleCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoInteractiveElementToNoninteractiveRoleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoInteractiveElementToNoninteractiveRoleCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNonInteractiveElementsWithHandlersCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNonInteractiveElementsWithHandlersCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNonInteractiveElementsWithHandlersCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNonInteractiveElementsWithHandlersCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNonInteractiveElementsWithHandlersCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNonInteractiveElementsWithHandlersCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveElementToInteractiveRoleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveElementToInteractiveRoleCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveElementToInteractiveRoleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveElementToInteractiveRoleCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveElementToInteractiveRoleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveElementToInteractiveRoleCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoRedundantRolesCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoRedundantRolesCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoRedundantRolesCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoRedundantRolesCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoRedundantRolesCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoRedundantRolesCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoStaticElementInteractionsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoStaticElementInteractionsCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoStaticElementInteractionsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoStaticElementInteractionsCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoStaticElementInteractionsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoStaticElementInteractionsCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/RoleSupportsAriaPropertyCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/RoleSupportsAriaPropertyCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/RoleSupportsAriaPropertyCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/RoleSupportsAriaPropertyCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/RoleSupportsAriaPropertyCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/RoleSupportsAriaPropertyCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/TabIndexNoPositiveCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/TabIndexNoPositiveCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/TabIndexNoPositiveCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/TabIndexNoPositiveCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/TabIndexNoPositiveCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/TabIndexNoPositiveCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ValidAutocompleteCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ValidAutocompleteCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ValidAutocompleteCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ValidAutocompleteCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ValidAutocompleteCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ValidAutocompleteCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/IllegalAttributeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/IllegalAttributeCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/IllegalAttributeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/IllegalAttributeCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/IllegalAttributeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/IllegalAttributeCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/NoAccessKeyCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/NoAccessKeyCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/NoAccessKeyCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/NoAccessKeyCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/NoAccessKeyCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/NoAccessKeyCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/RequiredAttributeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/RequiredAttributeCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/RequiredAttributeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/RequiredAttributeCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/RequiredAttributeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/RequiredAttributeCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/ComplexityCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/ComplexityCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/ComplexityCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/ComplexityCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/ComplexityCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/ComplexityCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/DoubleQuotesCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/DoubleQuotesCheck.java
@@ -21,10 +21,7 @@ import org.sonar.plugins.html.checks.AbstractPageCheck;
 import org.sonar.plugins.html.node.Attribute;
 import org.sonar.plugins.html.node.TagNode;
 
-/**
- * @author Matthijs Galesloot
- * @since 1.0
- */
+
 @Rule(key = "DoubleQuotesCheck")
 public class DoubleQuotesCheck extends AbstractPageCheck {
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/DoubleQuotesCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/DoubleQuotesCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/DoubleQuotesCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/DoubleQuotesCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/DoubleQuotesCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/DoubleQuotesCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/FileLengthCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/FileLengthCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/FileLengthCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/FileLengthCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/FileLengthCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/FileLengthCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/InternationalizationCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/InternationalizationCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/InternationalizationCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/InternationalizationCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/InternationalizationCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/InternationalizationCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/MaxLineLengthCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/MaxLineLengthCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/MaxLineLengthCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/MaxLineLengthCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/MaxLineLengthCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/MaxLineLengthCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/UnclosedTagCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/UnclosedTagCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/UnclosedTagCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/UnclosedTagCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/UnclosedTagCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/UnclosedTagCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/AvoidCommentedOutCodeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/AvoidCommentedOutCodeCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/AvoidCommentedOutCodeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/AvoidCommentedOutCodeCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/AvoidCommentedOutCodeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/AvoidCommentedOutCodeCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/AvoidHtmlCommentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/AvoidHtmlCommentCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/AvoidHtmlCommentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/AvoidHtmlCommentCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/AvoidHtmlCommentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/AvoidHtmlCommentCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/CommentUtils.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/CommentUtils.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/CommentUtils.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/CommentUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/CommentUtils.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/CommentUtils.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/FixmeCommentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/FixmeCommentCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/FixmeCommentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/FixmeCommentCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/FixmeCommentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/FixmeCommentCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/TodoCommentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/TodoCommentCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/TodoCommentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/TodoCommentCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/TodoCommentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/TodoCommentCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/comments/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/DynamicJspIncludeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/DynamicJspIncludeCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/DynamicJspIncludeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/DynamicJspIncludeCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/DynamicJspIncludeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/DynamicJspIncludeCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/IllegalNamespaceCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/IllegalNamespaceCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/IllegalNamespaceCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/IllegalNamespaceCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/IllegalNamespaceCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/IllegalNamespaceCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/IllegalTagLibsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/IllegalTagLibsCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/IllegalTagLibsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/IllegalTagLibsCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/IllegalTagLibsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/IllegalTagLibsCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/LibraryDependencyCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/LibraryDependencyCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/LibraryDependencyCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/LibraryDependencyCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/LibraryDependencyCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/LibraryDependencyCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/dependencies/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/header/HeaderCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/header/HeaderCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/header/HeaderCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/header/HeaderCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/header/HeaderCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/header/HeaderCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/header/MultiplePageDirectivesCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/header/MultiplePageDirectivesCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/header/MultiplePageDirectivesCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/header/MultiplePageDirectivesCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/header/MultiplePageDirectivesCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/header/MultiplePageDirectivesCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/header/MultiplePageDirectivesCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/header/MultiplePageDirectivesCheck.java
@@ -23,10 +23,7 @@ import org.sonar.plugins.html.node.Node;
 
 import java.util.List;
 
-/**
- * @author Matthijs Galesloot
- * @since 1.0
- */
+
 @Rule(key = "MultiplePageDirectivesCheck")
 public class MultiplePageDirectivesCheck extends AbstractPageCheck {
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/header/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/header/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/header/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/header/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/header/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/header/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/JspScriptletCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/JspScriptletCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/JspScriptletCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/JspScriptletCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/JspScriptletCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/JspScriptletCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/LongJavaScriptCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/LongJavaScriptCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/LongJavaScriptCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/LongJavaScriptCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/LongJavaScriptCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/LongJavaScriptCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/NestedJavaScriptCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/NestedJavaScriptCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/NestedJavaScriptCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/NestedJavaScriptCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/NestedJavaScriptCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/NestedJavaScriptCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/UnifiedExpressionCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/UnifiedExpressionCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/UnifiedExpressionCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/UnifiedExpressionCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/UnifiedExpressionCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/UnifiedExpressionCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/scripting/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/DisabledAutoescapeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/DisabledAutoescapeCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/DisabledAutoescapeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/DisabledAutoescapeCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/DisabledAutoescapeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/DisabledAutoescapeCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/ResourceIntegrityCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/ResourceIntegrityCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/ResourceIntegrityCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/ResourceIntegrityCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/ResourceIntegrityCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/ResourceIntegrityCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/AbsoluteURICheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/AbsoluteURICheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/AbsoluteURICheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/AbsoluteURICheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/AbsoluteURICheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/AbsoluteURICheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/BoldAndItalicTagsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/BoldAndItalicTagsCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/BoldAndItalicTagsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/BoldAndItalicTagsCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/BoldAndItalicTagsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/BoldAndItalicTagsCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/DeprecatedAttributesInHtml5Check.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/DeprecatedAttributesInHtml5Check.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/DeprecatedAttributesInHtml5Check.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/DeprecatedAttributesInHtml5Check.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/DeprecatedAttributesInHtml5Check.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/DeprecatedAttributesInHtml5Check.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/DoctypePresenceCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/DoctypePresenceCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/DoctypePresenceCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/DoctypePresenceCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/DoctypePresenceCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/DoctypePresenceCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ElementWithGivenIdPresentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ElementWithGivenIdPresentCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ElementWithGivenIdPresentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ElementWithGivenIdPresentCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ElementWithGivenIdPresentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ElementWithGivenIdPresentCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FieldsetWithoutLegendCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FieldsetWithoutLegendCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FieldsetWithoutLegendCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FieldsetWithoutLegendCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FieldsetWithoutLegendCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FieldsetWithoutLegendCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FlashHelper.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FlashHelper.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FlashHelper.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FlashHelper.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FlashHelper.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FlashHelper.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FlashUsesBothObjectAndEmbedCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FlashUsesBothObjectAndEmbedCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FlashUsesBothObjectAndEmbedCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FlashUsesBothObjectAndEmbedCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FlashUsesBothObjectAndEmbedCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FlashUsesBothObjectAndEmbedCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FrameWithoutTitleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FrameWithoutTitleCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FrameWithoutTitleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FrameWithoutTitleCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FrameWithoutTitleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/FrameWithoutTitleCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ImgWithoutAltCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ImgWithoutAltCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ImgWithoutAltCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ImgWithoutAltCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ImgWithoutAltCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ImgWithoutAltCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ImgWithoutWidthOrHeightCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ImgWithoutWidthOrHeightCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ImgWithoutWidthOrHeightCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ImgWithoutWidthOrHeightCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ImgWithoutWidthOrHeightCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ImgWithoutWidthOrHeightCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/IndistinguishableSimilarElementsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/IndistinguishableSimilarElementsCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/IndistinguishableSimilarElementsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/IndistinguishableSimilarElementsCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/IndistinguishableSimilarElementsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/IndistinguishableSimilarElementsCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LangAttributeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LangAttributeCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LangAttributeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LangAttributeCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LangAttributeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LangAttributeCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LayoutTableCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LayoutTableCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LayoutTableCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LayoutTableCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LayoutTableCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LayoutTableCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LayoutTableWithSemanticMarkupCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LayoutTableWithSemanticMarkupCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LayoutTableWithSemanticMarkupCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LayoutTableWithSemanticMarkupCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LayoutTableWithSemanticMarkupCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LayoutTableWithSemanticMarkupCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinkToImageCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinkToImageCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinkToImageCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinkToImageCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinkToImageCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinkToImageCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinkToNothingCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinkToNothingCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinkToNothingCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinkToNothingCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinkToNothingCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinkToNothingCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinkWithTargetBlankCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinkWithTargetBlankCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinkWithTargetBlankCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinkWithTargetBlankCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinkWithTargetBlankCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinkWithTargetBlankCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinksIdenticalTextsDifferentTargetsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinksIdenticalTextsDifferentTargetsCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinksIdenticalTextsDifferentTargetsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinksIdenticalTextsDifferentTargetsCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinksIdenticalTextsDifferentTargetsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LinksIdenticalTextsDifferentTargetsCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MetaRefreshCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MetaRefreshCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MetaRefreshCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MetaRefreshCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MetaRefreshCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MetaRefreshCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/NonConsecutiveHeadingCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/NonConsecutiveHeadingCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/NonConsecutiveHeadingCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/NonConsecutiveHeadingCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/NonConsecutiveHeadingCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/NonConsecutiveHeadingCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ObjectWithAlternativeContentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ObjectWithAlternativeContentCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ObjectWithAlternativeContentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ObjectWithAlternativeContentCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ObjectWithAlternativeContentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ObjectWithAlternativeContentCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/PageWithoutFaviconCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/PageWithoutFaviconCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/PageWithoutFaviconCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/PageWithoutFaviconCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/PageWithoutFaviconCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/PageWithoutFaviconCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/PageWithoutTitleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/PageWithoutTitleCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/PageWithoutTitleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/PageWithoutTitleCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/PageWithoutTitleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/PageWithoutTitleCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ServerSideImageMapsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ServerSideImageMapsCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ServerSideImageMapsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ServerSideImageMapsCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ServerSideImageMapsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ServerSideImageMapsCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableHeaderHasIdOrScopeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableHeaderHasIdOrScopeCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableHeaderHasIdOrScopeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableHeaderHasIdOrScopeCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableHeaderHasIdOrScopeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableHeaderHasIdOrScopeCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableHeaderReferenceCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableHeaderReferenceCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableHeaderReferenceCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableHeaderReferenceCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableHeaderReferenceCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableHeaderReferenceCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutCaptionCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutCaptionCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutCaptionCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutCaptionCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutCaptionCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutCaptionCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/UnsupportedTagsInHtml5Check.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/UnsupportedTagsInHtml5Check.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/UnsupportedTagsInHtml5Check.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/UnsupportedTagsInHtml5Check.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/UnsupportedTagsInHtml5Check.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/UnsupportedTagsInHtml5Check.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/VideoTrackCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/VideoTrackCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/VideoTrackCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/VideoTrackCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/VideoTrackCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/VideoTrackCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/WmodeIsWindowCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/WmodeIsWindowCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/WmodeIsWindowCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/WmodeIsWindowCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/WmodeIsWindowCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/WmodeIsWindowCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ChildElementIllegalCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ChildElementIllegalCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ChildElementIllegalCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ChildElementIllegalCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ChildElementIllegalCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ChildElementIllegalCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ChildElementRequiredCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ChildElementRequiredCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ChildElementRequiredCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ChildElementRequiredCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ChildElementRequiredCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ChildElementRequiredCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/IllegalElementCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/IllegalElementCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/IllegalElementCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/IllegalElementCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/IllegalElementCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/IllegalElementCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ParentElementIllegalCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ParentElementIllegalCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ParentElementIllegalCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ParentElementIllegalCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ParentElementIllegalCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ParentElementIllegalCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ParentElementRequiredCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ParentElementRequiredCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ParentElementRequiredCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ParentElementRequiredCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ParentElementRequiredCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/ParentElementRequiredCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/structure/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/style/InlineStyleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/style/InlineStyleCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/style/InlineStyleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/style/InlineStyleCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/style/InlineStyleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/style/InlineStyleCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/style/InlineStyleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/style/InlineStyleCheck.java
@@ -24,8 +24,7 @@ import org.sonar.plugins.html.node.TagNode;
  * Checker for occurrence of inline style.
  *
  *
- * @author Matthijs Galesloot
- * @since 1.0
+
  */
 @Rule(key = "InlineStyleCheck")
 public class InlineStyleCheck extends AbstractPageCheck {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/style/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/style/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/style/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/style/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/style/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/style/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/whitespace/IllegalTabCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/whitespace/IllegalTabCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/whitespace/IllegalTabCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/whitespace/IllegalTabCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/whitespace/IllegalTabCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/whitespace/IllegalTabCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/whitespace/WhiteSpaceAroundCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/whitespace/WhiteSpaceAroundCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/whitespace/WhiteSpaceAroundCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/whitespace/WhiteSpaceAroundCheck.java
@@ -23,10 +23,7 @@ import org.sonar.plugins.html.node.DirectiveNode;
 import org.sonar.plugins.html.node.ExpressionNode;
 import org.sonar.plugins.html.node.Node;
 
-/**
- * @author Matthijs Galesloot
- * @since 1.0
- */
+
 @Rule(key = "WhiteSpaceAroundCheck")
 public class WhiteSpaceAroundCheck extends AbstractPageCheck {
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/whitespace/WhiteSpaceAroundCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/whitespace/WhiteSpaceAroundCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/whitespace/WhiteSpaceAroundCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/whitespace/WhiteSpaceAroundCheck.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/whitespace/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/whitespace/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/whitespace/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/whitespace/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/whitespace/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/whitespace/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/Html.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/Html.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/Html.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/Html.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/Html.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/Html.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlLexer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlLexer.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlLexer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlLexer.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlLexer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlLexer.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlSensor.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlSensor.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlSensor.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlSensor.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlSensor.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlSensor.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlTokenType.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlTokenType.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlTokenType.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlTokenType.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlTokenType.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlTokenType.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlTokensVisitor.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlTokensVisitor.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlTokensVisitor.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlTokensVisitor.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlTokensVisitor.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlTokensVisitor.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/Jsp.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/Jsp.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/Jsp.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/Jsp.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/Jsp.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/Jsp.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/TokenLocation.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/TokenLocation.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/TokenLocation.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/TokenLocation.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/TokenLocation.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/TokenLocation.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/AbstractTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/AbstractTokenizer.java
@@ -26,8 +26,7 @@ import org.sonar.sslr.channel.EndMatcher;
 /**
  * AbstractTokenizer provides basic token parsing.
  *
- * @author Matthijs Galesloot
- * @since 1.0
+
  */
 abstract class AbstractTokenizer<T extends List<Node>> extends Channel<T> {
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/AbstractTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/AbstractTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/AbstractTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/AbstractTokenizer.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/AbstractTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/AbstractTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/CdataTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/CdataTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/CdataTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/CdataTokenizer.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/CdataTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/CdataTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/CommentTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/CommentTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/CommentTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/CommentTokenizer.java
@@ -27,8 +27,7 @@ import org.sonar.sslr.channel.EndMatcher;
 /**
  * Tokenizer for a HTML or JSP comment.
  *
- * @author Matthijs Galesloot
- * @since 1.0
+
  */
 class CommentTokenizer<T extends List<Node>> extends AbstractTokenizer<T> {
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/CommentTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/CommentTokenizer.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/CommentTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/CommentTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/DirectiveTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/DirectiveTokenizer.java
@@ -22,8 +22,7 @@ import org.sonar.plugins.html.node.Node;
 /**
  * Tokenizer for directives.
  *
- * @author Matthijs Galesloot
- * @since 1.0
+
  */
 class DirectiveTokenizer extends ElementTokenizer {
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/DirectiveTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/DirectiveTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/DirectiveTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/DirectiveTokenizer.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/DirectiveTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/DirectiveTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/DoctypeTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/DoctypeTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/DoctypeTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/DoctypeTokenizer.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/DoctypeTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/DoctypeTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/ElementTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/ElementTokenizer.java
@@ -29,8 +29,7 @@ import org.sonar.sslr.channel.EndMatcher;
 /**
  * Tokenizer for elements.
  *
- * @author Matthijs Galesloot
- * @since 1.0
+
  */
 class ElementTokenizer extends AbstractTokenizer<List<Node>> {
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/ElementTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/ElementTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/ElementTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/ElementTokenizer.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/ElementTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/ElementTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/ExpressionTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/ExpressionTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/ExpressionTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/ExpressionTokenizer.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/ExpressionTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/ExpressionTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/ExpressionTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/ExpressionTokenizer.java
@@ -24,8 +24,7 @@ import org.sonar.plugins.html.node.Node;
 /**
  * Tokenizer for expressions.
  *
- * @author Matthijs Galesloot
- * @since 1.0
+
  */
 class ExpressionTokenizer extends AbstractTokenizer<List<Node>> {
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/NormalElementTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/NormalElementTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/NormalElementTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/NormalElementTokenizer.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/NormalElementTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/NormalElementTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/PageLexer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/PageLexer.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/PageLexer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/PageLexer.java
@@ -34,8 +34,7 @@ import org.sonar.sslr.channel.CodeReader;
 
 /**
  * Lexical analysis of a web page.
- *
- * @author Matthijs Galesloot
+
  */
 @SuppressWarnings("unchecked")
 public class PageLexer {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/PageLexer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/PageLexer.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/PageLexer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/PageLexer.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/TextTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/TextTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/TextTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/TextTokenizer.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/TextTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/TextTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/TextTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/TextTokenizer.java
@@ -27,8 +27,7 @@ import org.sonar.sslr.channel.EndMatcher;
 /**
  * Tokenizer for content.
  *
- * @author Matthijs Galesloot
- * @since 1.0
+
  *
  *        TODO - handle CDATA
  */

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/VueLexer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/VueLexer.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/VueLexer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/VueLexer.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/VueLexer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/VueLexer.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/Attribute.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/Attribute.java
@@ -1,19 +1,18 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * SonarQube HTML Plugin :: Sonar Plugin
+ * Copyright (C) 2010-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.node;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/Attribute.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/Attribute.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/CommentNode.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/CommentNode.java
@@ -1,19 +1,18 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * SonarQube HTML Plugin :: Sonar Plugin
+ * Copyright (C) 2010-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.node;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/CommentNode.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/CommentNode.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/CommentNode.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/CommentNode.java
@@ -20,8 +20,7 @@ package org.sonar.plugins.html.node;
 /**
  * Defines a comment.
  *
- * @author Matthijs Galesloot
- * @since 1.0
+
  */
 public class CommentNode extends Node {
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/DirectiveNode.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/DirectiveNode.java
@@ -1,19 +1,18 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * SonarQube HTML Plugin :: Sonar Plugin
+ * Copyright (C) 2010-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.node;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/DirectiveNode.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/DirectiveNode.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/DirectiveNode.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/DirectiveNode.java
@@ -20,8 +20,7 @@ package org.sonar.plugins.html.node;
 /**
  * Defines a directive.
  *
- * @author Matthijs Galesloot
- * @since 1.0
+
  */
 public class DirectiveNode extends TagNode {
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/ExpressionNode.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/ExpressionNode.java
@@ -1,19 +1,18 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * SonarQube HTML Plugin :: Sonar Plugin
+ * Copyright (C) 2010-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.node;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/ExpressionNode.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/ExpressionNode.java
@@ -20,8 +20,7 @@ package org.sonar.plugins.html.node;
 /**
  * Defines an expression.
  *
- * @author Matthijs Galesloot
- * @since 1.0
+
  */
 public class ExpressionNode extends Node {
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/ExpressionNode.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/ExpressionNode.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/Node.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/Node.java
@@ -1,19 +1,18 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * SonarQube HTML Plugin :: Sonar Plugin
+ * Copyright (C) 2010-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.node;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/Node.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/Node.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/Node.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/Node.java
@@ -20,8 +20,7 @@ package org.sonar.plugins.html.node;
 /**
  * Defines a node.
  *
- * @author Matthijs Galesloot
- * @since 1.0
+
  */
 public abstract class Node {
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/NodeType.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/NodeType.java
@@ -1,19 +1,18 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * SonarQube HTML Plugin :: Sonar Plugin
+ * Copyright (C) 2010-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.node;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/NodeType.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/NodeType.java
@@ -20,8 +20,7 @@ package org.sonar.plugins.html.node;
 /**
  * Defines nodetypes.
  *
- * @author Matthijs Galesloot
- * @since 1.0
+
  */
 public enum NodeType {
   COMMENT, DIRECTIVE, EXPRESSION, TAG, TEXT

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/NodeType.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/NodeType.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/TagNode.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/TagNode.java
@@ -1,19 +1,18 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * SonarQube HTML Plugin :: Sonar Plugin
+ * Copyright (C) 2010-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.node;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/TagNode.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/TagNode.java
@@ -25,8 +25,7 @@ import javax.annotation.Nullable;
 /**
  * Defines a tag.
  *
- * @author Matthijs Galesloot
- * @since 1.0
+
  */
 public class TagNode extends Node {
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/TagNode.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/TagNode.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/TextNode.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/TextNode.java
@@ -1,19 +1,18 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * SonarQube HTML Plugin :: Sonar Plugin
+ * Copyright (C) 2010-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.node;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/TextNode.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/TextNode.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/TextNode.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/TextNode.java
@@ -20,8 +20,7 @@ package org.sonar.plugins.html.node;
 /**
  * Defines a text node.
  *
- * @author Matthijs Galesloot
- * @since 1.0
+
  */
 public class TextNode extends Node {
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/package-info.java
@@ -1,19 +1,18 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * SonarQube HTML Plugin :: Sonar Plugin
+ * Copyright (C) 2010-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @ParametersAreNonnullByDefault
 package org.sonar.plugins.html.node;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/CheckClasses.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/CheckClasses.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/CheckClasses.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/CheckClasses.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/CheckClasses.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/CheckClasses.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/HtmlRulesDefinition.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/HtmlRulesDefinition.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/HtmlRulesDefinition.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/HtmlRulesDefinition.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/HtmlRulesDefinition.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/HtmlRulesDefinition.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/JspQualityProfile.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/JspQualityProfile.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/JspQualityProfile.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/JspQualityProfile.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/JspQualityProfile.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/JspQualityProfile.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/SonarWayProfile.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/SonarWayProfile.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/SonarWayProfile.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/SonarWayProfile.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/SonarWayProfile.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/SonarWayProfile.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/rules/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/DefaultNodeVisitor.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/DefaultNodeVisitor.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/DefaultNodeVisitor.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/DefaultNodeVisitor.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/DefaultNodeVisitor.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/DefaultNodeVisitor.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/HtmlAstScanner.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/HtmlAstScanner.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/HtmlAstScanner.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/HtmlAstScanner.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/HtmlAstScanner.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/HtmlAstScanner.java
@@ -28,8 +28,7 @@ import org.sonar.plugins.html.node.TextNode;
 /**
  * Scans the nodes of a page and send events to the visitors.
  *
- * @author Matthijs Galesloot
- * @since 1.0
+
  */
 public class HtmlAstScanner {
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/HtmlAstScanner.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/HtmlAstScanner.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/HtmlSourceCode.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/HtmlSourceCode.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/HtmlSourceCode.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/HtmlSourceCode.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/HtmlSourceCode.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/HtmlSourceCode.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/NoSonarScanner.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/NoSonarScanner.java
@@ -28,8 +28,7 @@ import java.util.Set;
 /**
  * Scans for //NOSONAR indicator.
  *
- * @author Matthijs Galesloot
- * @since 1.0
+
  */
 public class NoSonarScanner extends DefaultNodeVisitor {
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/NoSonarScanner.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/NoSonarScanner.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/NoSonarScanner.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/NoSonarScanner.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/NoSonarScanner.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/NoSonarScanner.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/package-info.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/package-info.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/HtmlPluginTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/HtmlPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/HtmlPluginTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/HtmlPluginTest.java
@@ -25,9 +25,7 @@ import org.sonar.api.utils.Version;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * @author Matthijs Galesloot
- */
+
 public class HtmlPluginTest {
 
   @Test

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/HtmlPluginTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/HtmlPluginTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/HtmlPluginTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/HtmlPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/analyzers/ComplexityVisitorTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/analyzers/ComplexityVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/analyzers/ComplexityVisitorTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/analyzers/ComplexityVisitorTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/analyzers/ComplexityVisitorTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/analyzers/ComplexityVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/analyzers/PageCountLinesTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/analyzers/PageCountLinesTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/analyzers/PageCountLinesTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/analyzers/PageCountLinesTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/analyzers/PageCountLinesTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/analyzers/PageCountLinesTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/HtmlConstantsTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/HtmlConstantsTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/HtmlConstantsTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/HtmlConstantsTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/HtmlConstantsTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/HtmlConstantsTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/CheckMessagesVerifier.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/CheckMessagesVerifier.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/CheckMessagesVerifier.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/CheckMessagesVerifier.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/CheckMessagesVerifier.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/CheckMessagesVerifier.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/CheckMessagesVerifierRule.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/CheckMessagesVerifierRule.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/CheckMessagesVerifierRule.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/CheckMessagesVerifierRule.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/CheckMessagesVerifierRule.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/CheckMessagesVerifierRule.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/TestHelper.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/TestHelper.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/TestHelper.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/TestHelper.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/TestHelper.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/TestHelper.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AnchorsShouldNotBeUsedAsButtonsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AnchorsShouldNotBeUsedAsButtonsCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AnchorsShouldNotBeUsedAsButtonsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AnchorsShouldNotBeUsedAsButtonsCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AnchorsShouldNotBeUsedAsButtonsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AnchorsShouldNotBeUsedAsButtonsCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaActiveDescendantHasTabIndexCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaActiveDescendantHasTabIndexCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaActiveDescendantHasTabIndexCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaActiveDescendantHasTabIndexCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaActiveDescendantHasTabIndexCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaActiveDescendantHasTabIndexCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaProptypesCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaProptypesCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaProptypesCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaProptypesCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaProptypesCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaProptypesCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaRoleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaRoleCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaRoleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaRoleCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaRoleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaRoleCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaUnsupportedElementsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaUnsupportedElementsCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaUnsupportedElementsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaUnsupportedElementsCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaUnsupportedElementsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaUnsupportedElementsCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ElementWithRoleShouldHaveRequiredPropertiesCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ElementWithRoleShouldHaveRequiredPropertiesCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ElementWithRoleShouldHaveRequiredPropertiesCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ElementWithRoleShouldHaveRequiredPropertiesCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ElementWithRoleShouldHaveRequiredPropertiesCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ElementWithRoleShouldHaveRequiredPropertiesCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/FocusableInteractiveElementsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/FocusableInteractiveElementsCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/FocusableInteractiveElementsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/FocusableInteractiveElementsCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/FocusableInteractiveElementsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/FocusableInteractiveElementsCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/HeadingHasAccessibleContentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/HeadingHasAccessibleContentCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/HeadingHasAccessibleContentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/HeadingHasAccessibleContentCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/HeadingHasAccessibleContentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/HeadingHasAccessibleContentCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ImgRedundantAltCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ImgRedundantAltCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ImgRedundantAltCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ImgRedundantAltCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ImgRedundantAltCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ImgRedundantAltCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoAriaHiddenOnFocusableCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoAriaHiddenOnFocusableCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoAriaHiddenOnFocusableCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoAriaHiddenOnFocusableCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoAriaHiddenOnFocusableCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoAriaHiddenOnFocusableCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoInteractiveElementToNoninteractiveRoleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoInteractiveElementToNoninteractiveRoleCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoInteractiveElementToNoninteractiveRoleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoInteractiveElementToNoninteractiveRoleCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoInteractiveElementToNoninteractiveRoleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoInteractiveElementToNoninteractiveRoleCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNonInteractiveElementsWithHandlersCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNonInteractiveElementsWithHandlersCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNonInteractiveElementsWithHandlersCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNonInteractiveElementsWithHandlersCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNonInteractiveElementsWithHandlersCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNonInteractiveElementsWithHandlersCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveElementToInteractiveRoleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveElementToInteractiveRoleCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveElementToInteractiveRoleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveElementToInteractiveRoleCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveElementToInteractiveRoleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveElementToInteractiveRoleCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoRedundantRolesCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoRedundantRolesCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoRedundantRolesCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoRedundantRolesCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoRedundantRolesCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoRedundantRolesCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoStaticElementInteractionsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoStaticElementInteractionsCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoStaticElementInteractionsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoStaticElementInteractionsCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoStaticElementInteractionsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoStaticElementInteractionsCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/RoleSupportsAriaPropertyCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/RoleSupportsAriaPropertyCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/RoleSupportsAriaPropertyCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/RoleSupportsAriaPropertyCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/RoleSupportsAriaPropertyCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/RoleSupportsAriaPropertyCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/TabIndexNoPositiveCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/TabIndexNoPositiveCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/TabIndexNoPositiveCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/TabIndexNoPositiveCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/TabIndexNoPositiveCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/TabIndexNoPositiveCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ValidAutocompleteCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ValidAutocompleteCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ValidAutocompleteCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ValidAutocompleteCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ValidAutocompleteCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ValidAutocompleteCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/IllegalAttributeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/IllegalAttributeCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/IllegalAttributeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/IllegalAttributeCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/IllegalAttributeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/IllegalAttributeCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/NoAccessKeyCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/NoAccessKeyCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/NoAccessKeyCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/NoAccessKeyCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/NoAccessKeyCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/NoAccessKeyCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/RequiredAttributeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/RequiredAttributeCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/RequiredAttributeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/RequiredAttributeCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/RequiredAttributeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/RequiredAttributeCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/ComplexityCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/ComplexityCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/ComplexityCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/ComplexityCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/ComplexityCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/ComplexityCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/DoubleQuotesCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/DoubleQuotesCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/DoubleQuotesCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/DoubleQuotesCheckTest.java
@@ -23,9 +23,7 @@ import org.sonar.plugins.html.checks.CheckMessagesVerifierRule;
 import org.sonar.plugins.html.checks.TestHelper;
 import org.sonar.plugins.html.visitor.HtmlSourceCode;
 
-/**
- * @author Matthijs Galesloot
- */
+
 public class DoubleQuotesCheckTest {
 
   @RegisterExtension

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/DoubleQuotesCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/DoubleQuotesCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/DoubleQuotesCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/DoubleQuotesCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/FileLengthCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/FileLengthCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/FileLengthCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/FileLengthCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/FileLengthCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/FileLengthCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/InternationalizationCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/InternationalizationCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/InternationalizationCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/InternationalizationCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/InternationalizationCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/InternationalizationCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/MaxLineLengthCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/MaxLineLengthCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/MaxLineLengthCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/MaxLineLengthCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/MaxLineLengthCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/MaxLineLengthCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/UnclosedTagCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/UnclosedTagCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/UnclosedTagCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/UnclosedTagCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/UnclosedTagCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/UnclosedTagCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/AvoidCommentedOutCodeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/AvoidCommentedOutCodeCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/AvoidCommentedOutCodeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/AvoidCommentedOutCodeCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/AvoidCommentedOutCodeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/AvoidCommentedOutCodeCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/AvoidHtmlCommentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/AvoidHtmlCommentCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/AvoidHtmlCommentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/AvoidHtmlCommentCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/AvoidHtmlCommentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/AvoidHtmlCommentCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/CommentUtilsTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/CommentUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/CommentUtilsTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/CommentUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/CommentUtilsTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/CommentUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/FixmeCommentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/FixmeCommentCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/FixmeCommentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/FixmeCommentCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/FixmeCommentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/FixmeCommentCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/TodoCommentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/TodoCommentCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/TodoCommentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/TodoCommentCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/TodoCommentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/comments/TodoCommentCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/DynamicJspIncludeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/DynamicJspIncludeCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/DynamicJspIncludeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/DynamicJspIncludeCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/DynamicJspIncludeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/DynamicJspIncludeCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/IllegalNamespaceCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/IllegalNamespaceCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/IllegalNamespaceCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/IllegalNamespaceCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/IllegalNamespaceCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/IllegalNamespaceCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/IllegalTagLibsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/IllegalTagLibsCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/IllegalTagLibsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/IllegalTagLibsCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/IllegalTagLibsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/IllegalTagLibsCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/LibraryDependencyCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/LibraryDependencyCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/LibraryDependencyCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/LibraryDependencyCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/LibraryDependencyCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/dependencies/LibraryDependencyCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/header/HeaderCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/header/HeaderCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/header/HeaderCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/header/HeaderCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/header/HeaderCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/header/HeaderCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/header/MultiplePageDirectivesCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/header/MultiplePageDirectivesCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/header/MultiplePageDirectivesCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/header/MultiplePageDirectivesCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/header/MultiplePageDirectivesCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/header/MultiplePageDirectivesCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/JspScriptletCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/JspScriptletCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/JspScriptletCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/JspScriptletCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/JspScriptletCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/JspScriptletCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/JspScriptletCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/JspScriptletCheckTest.java
@@ -23,9 +23,7 @@ import org.sonar.plugins.html.checks.CheckMessagesVerifierRule;
 import org.sonar.plugins.html.checks.TestHelper;
 import org.sonar.plugins.html.visitor.HtmlSourceCode;
 
-/**
- * @author Matthijs Galesloot
- */
+
 public class JspScriptletCheckTest {
 
   @RegisterExtension

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/LongJavaScriptCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/LongJavaScriptCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/LongJavaScriptCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/LongJavaScriptCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/LongJavaScriptCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/LongJavaScriptCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/NestedJavaScriptCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/NestedJavaScriptCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/NestedJavaScriptCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/NestedJavaScriptCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/NestedJavaScriptCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/NestedJavaScriptCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/UnifiedExpressionCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/UnifiedExpressionCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/UnifiedExpressionCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/UnifiedExpressionCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/UnifiedExpressionCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/UnifiedExpressionCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/security/DisabledAutoescapeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/security/DisabledAutoescapeCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/security/DisabledAutoescapeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/security/DisabledAutoescapeCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/security/DisabledAutoescapeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/security/DisabledAutoescapeCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/security/ResourceIntegrityCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/security/ResourceIntegrityCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/security/ResourceIntegrityCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/security/ResourceIntegrityCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/security/ResourceIntegrityCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/security/ResourceIntegrityCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/AbsoluteURICheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/AbsoluteURICheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/AbsoluteURICheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/AbsoluteURICheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/AbsoluteURICheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/AbsoluteURICheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/BoldAndItalicTagsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/BoldAndItalicTagsCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/BoldAndItalicTagsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/BoldAndItalicTagsCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/BoldAndItalicTagsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/BoldAndItalicTagsCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/DeprecatedAttributesInHtml5CheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/DeprecatedAttributesInHtml5CheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/DeprecatedAttributesInHtml5CheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/DeprecatedAttributesInHtml5CheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/DeprecatedAttributesInHtml5CheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/DeprecatedAttributesInHtml5CheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/DoctypePresenceCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/DoctypePresenceCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/DoctypePresenceCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/DoctypePresenceCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/DoctypePresenceCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/DoctypePresenceCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ElementWithGivenIdPresentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ElementWithGivenIdPresentCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ElementWithGivenIdPresentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ElementWithGivenIdPresentCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ElementWithGivenIdPresentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ElementWithGivenIdPresentCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/FieldsetWithoutLegendCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/FieldsetWithoutLegendCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/FieldsetWithoutLegendCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/FieldsetWithoutLegendCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/FieldsetWithoutLegendCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/FieldsetWithoutLegendCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/FlashUsesBothObjectAndEmbedCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/FlashUsesBothObjectAndEmbedCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/FlashUsesBothObjectAndEmbedCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/FlashUsesBothObjectAndEmbedCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/FlashUsesBothObjectAndEmbedCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/FlashUsesBothObjectAndEmbedCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/FrameWithoutTitleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/FrameWithoutTitleCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/FrameWithoutTitleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/FrameWithoutTitleCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/FrameWithoutTitleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/FrameWithoutTitleCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ImgWithoutAltCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ImgWithoutAltCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ImgWithoutAltCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ImgWithoutAltCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ImgWithoutAltCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ImgWithoutAltCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ImgWithoutWidthOrHeightCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ImgWithoutWidthOrHeightCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ImgWithoutWidthOrHeightCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ImgWithoutWidthOrHeightCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ImgWithoutWidthOrHeightCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ImgWithoutWidthOrHeightCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/IndistinguishableSimilarElementsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/IndistinguishableSimilarElementsCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/IndistinguishableSimilarElementsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/IndistinguishableSimilarElementsCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/IndistinguishableSimilarElementsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/IndistinguishableSimilarElementsCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LangAttributeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LangAttributeCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LangAttributeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LangAttributeCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LangAttributeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LangAttributeCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LayoutTableCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LayoutTableCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LayoutTableCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LayoutTableCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LayoutTableCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LayoutTableCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LayoutTableWithSemanticMarkupCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LayoutTableWithSemanticMarkupCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LayoutTableWithSemanticMarkupCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LayoutTableWithSemanticMarkupCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LayoutTableWithSemanticMarkupCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LayoutTableWithSemanticMarkupCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinkToImageCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinkToImageCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinkToImageCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinkToImageCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinkToImageCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinkToImageCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinkToNothingCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinkToNothingCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinkToNothingCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinkToNothingCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinkToNothingCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinkToNothingCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinkWithTargetBlankCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinkWithTargetBlankCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinkWithTargetBlankCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinkWithTargetBlankCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinkWithTargetBlankCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinkWithTargetBlankCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinksIdenticalTextsDifferentTargetsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinksIdenticalTextsDifferentTargetsCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinksIdenticalTextsDifferentTargetsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinksIdenticalTextsDifferentTargetsCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinksIdenticalTextsDifferentTargetsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LinksIdenticalTextsDifferentTargetsCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MetaRefreshCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MetaRefreshCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MetaRefreshCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MetaRefreshCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MetaRefreshCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MetaRefreshCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/NonConsecutiveHeadingCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/NonConsecutiveHeadingCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/NonConsecutiveHeadingCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/NonConsecutiveHeadingCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/NonConsecutiveHeadingCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/NonConsecutiveHeadingCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ObjectWithAlternativeContentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ObjectWithAlternativeContentCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ObjectWithAlternativeContentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ObjectWithAlternativeContentCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ObjectWithAlternativeContentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ObjectWithAlternativeContentCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/PageWithoutFaviconCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/PageWithoutFaviconCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/PageWithoutFaviconCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/PageWithoutFaviconCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/PageWithoutFaviconCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/PageWithoutFaviconCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/PageWithoutTitleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/PageWithoutTitleCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/PageWithoutTitleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/PageWithoutTitleCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/PageWithoutTitleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/PageWithoutTitleCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ServerSideImageMapsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ServerSideImageMapsCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ServerSideImageMapsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ServerSideImageMapsCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ServerSideImageMapsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ServerSideImageMapsCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableHeaderHasIdOrScopeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableHeaderHasIdOrScopeCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableHeaderHasIdOrScopeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableHeaderHasIdOrScopeCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableHeaderHasIdOrScopeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableHeaderHasIdOrScopeCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableHeaderReferenceCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableHeaderReferenceCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableHeaderReferenceCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableHeaderReferenceCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableHeaderReferenceCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableHeaderReferenceCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutCaptionCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutCaptionCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutCaptionCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutCaptionCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutCaptionCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutCaptionCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/UnsupportedTagsInHtml5CheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/UnsupportedTagsInHtml5CheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/UnsupportedTagsInHtml5CheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/UnsupportedTagsInHtml5CheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/UnsupportedTagsInHtml5CheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/UnsupportedTagsInHtml5CheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/VideoTrackCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/VideoTrackCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/VideoTrackCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/VideoTrackCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/VideoTrackCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/VideoTrackCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/WmodeIsWindowCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/WmodeIsWindowCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/WmodeIsWindowCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/WmodeIsWindowCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/WmodeIsWindowCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/WmodeIsWindowCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ChildElementIllegalCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ChildElementIllegalCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ChildElementIllegalCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ChildElementIllegalCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ChildElementIllegalCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ChildElementIllegalCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ChildElementRequiredCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ChildElementRequiredCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ChildElementRequiredCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ChildElementRequiredCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ChildElementRequiredCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ChildElementRequiredCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/IllegalElementCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/IllegalElementCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/IllegalElementCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/IllegalElementCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/IllegalElementCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/IllegalElementCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ParentElementIllegalCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ParentElementIllegalCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ParentElementIllegalCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ParentElementIllegalCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ParentElementIllegalCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ParentElementIllegalCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ParentElementRequiredCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ParentElementRequiredCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ParentElementRequiredCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ParentElementRequiredCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ParentElementRequiredCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/structure/ParentElementRequiredCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/style/InlineStyleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/style/InlineStyleCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/style/InlineStyleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/style/InlineStyleCheckTest.java
@@ -23,9 +23,7 @@ import org.sonar.plugins.html.checks.CheckMessagesVerifierRule;
 import org.sonar.plugins.html.checks.TestHelper;
 import org.sonar.plugins.html.visitor.HtmlSourceCode;
 
-/**
- * @author Matthijs Galesloot
- */
+
 public class InlineStyleCheckTest {
 
   @RegisterExtension

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/style/InlineStyleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/style/InlineStyleCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/style/InlineStyleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/style/InlineStyleCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/whitespace/IllegalTabCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/whitespace/IllegalTabCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/whitespace/IllegalTabCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/whitespace/IllegalTabCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/whitespace/IllegalTabCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/whitespace/IllegalTabCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/whitespace/WhiteSpaceAroundCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/whitespace/WhiteSpaceAroundCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/whitespace/WhiteSpaceAroundCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/whitespace/WhiteSpaceAroundCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/whitespace/WhiteSpaceAroundCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/whitespace/WhiteSpaceAroundCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/whitespace/WhiteSpaceAroundCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/whitespace/WhiteSpaceAroundCheckTest.java
@@ -23,9 +23,7 @@ import org.sonar.plugins.html.checks.CheckMessagesVerifierRule;
 import org.sonar.plugins.html.checks.TestHelper;
 import org.sonar.plugins.html.visitor.HtmlSourceCode;
 
-/**
- * @author Matthijs Galesloot
- */
+
 public class WhiteSpaceAroundCheckTest {
 
   @RegisterExtension

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlLexerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlLexerTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlLexerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlLexerTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlLexerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlLexerTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlSensorTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlSensorTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlSensorTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlSensorTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlSensorTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlSensorTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/JspTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/JspTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/JspTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/JspTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/JspTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/JspTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/l10n/LocalizedBundlesTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/l10n/LocalizedBundlesTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/l10n/LocalizedBundlesTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/l10n/LocalizedBundlesTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/l10n/LocalizedBundlesTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/l10n/LocalizedBundlesTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/NormalElementTokenizerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/NormalElementTokenizerTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/NormalElementTokenizerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/NormalElementTokenizerTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/NormalElementTokenizerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/NormalElementTokenizerTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/PageLexerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/PageLexerTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/PageLexerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/PageLexerTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/PageLexerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/PageLexerTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/PageLexerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/PageLexerTest.java
@@ -33,9 +33,7 @@ import org.sonar.sslr.channel.CodeReader;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * @author Matthijs Galesloot
- */
+
 public class PageLexerTest {
 
   @Test

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/TextTokenizerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/TextTokenizerTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/TextTokenizerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/TextTokenizerTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/TextTokenizerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/TextTokenizerTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/VueLexerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/VueLexerTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/VueLexerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/VueLexerTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/VueLexerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/VueLexerTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/node/AttributeTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/node/AttributeTest.java
@@ -1,19 +1,18 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * SonarQube HTML Plugin :: Sonar Plugin
+ * Copyright (C) 2010-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.node;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/node/AttributeTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/node/AttributeTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/node/TagNodeTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/node/TagNodeTest.java
@@ -1,19 +1,18 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * SonarQube HTML Plugin :: Sonar Plugin
+ * Copyright (C) 2010-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.node;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/node/TagNodeTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/node/TagNodeTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/node/TextNodeTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/node/TextNodeTest.java
@@ -1,19 +1,18 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (c) 2010-2024 SonarSource SA and Matthijs Galesloot
- * sonarqube@googlegroups.com
+ * SonarQube HTML Plugin :: Sonar Plugin
+ * Copyright (C) 2010-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonar.plugins.html.node;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/node/TextNodeTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/node/TextNodeTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/CheckClassesTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/CheckClassesTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/CheckClassesTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/CheckClassesTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/CheckClassesTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/CheckClassesTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/HtmlRulesDefinitionTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/HtmlRulesDefinitionTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/HtmlRulesDefinitionTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/HtmlRulesDefinitionTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/HtmlRulesDefinitionTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/HtmlRulesDefinitionTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/SonarWayProfileTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/SonarWayProfileTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/SonarWayProfileTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/SonarWayProfileTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/SonarWayProfileTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/SonarWayProfileTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/visitor/NoSonarScannerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/visitor/NoSonarScannerTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarSource HTML analyzer :: Sonar Plugin
+ * SonarQube HTML Plugin :: Sonar Plugin
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/visitor/NoSonarScannerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/visitor/NoSonarScannerTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource HTML analyzer :: Sonar Plugin
- * Copyright (C) 2010-2024 SonarSource SA and Matthijs Galesloot
+ * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/visitor/NoSonarScannerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/visitor/NoSonarScannerTest.java
@@ -1,5 +1,5 @@
 /*
- * SonarQube HTML Plugin :: Sonar Plugin
+ * SonarQube HTML
  * Copyright (C) 2010-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/visitor/NoSonarScannerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/visitor/NoSonarScannerTest.java
@@ -37,9 +37,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-/**
- * @author Matthijs Galesloot
- */
+
 public class NoSonarScannerTest {
   private static final String CONTENT = "<table>\n<!-- //NOSONAR --><td>\n</table>";
 


### PR DESCRIPTION
[SONARHTML-276](https://sonarsource.atlassian.net/browse/SONARHTML-276)

The logical changes are in the `pom.xml` files.

1. Remove Galesloot from owners and javadoc.
2. Update remaining LGPL licenses to SSAL

The license setup is still flacky, but is out of scope for now: [SONARHTML-260](https://sonarsource.atlassian.net/jira/software/c/projects/SONARHTML/issues/SONARHTML-260)


[SONARHTML-276]: https://sonarsource.atlassian.net/browse/SONARHTML-276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SONARHTML-260]: https://sonarsource.atlassian.net/browse/SONARHTML-260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ