### PR TITLE
SONARHTML-300 Use "sonar.scanner.skipJreProvisioning" in integration tests

### DIFF
--- a/its/plugin/src/test/java/com/sonar/it/web/HtmlTestSuite.java
+++ b/its/plugin/src/test/java/com/sonar/it/web/HtmlTestSuite.java
@@ -67,7 +67,8 @@ public class HtmlTestSuite {
   }
 
   public static SonarScanner createSonarScanner() {
-    return SonarScanner.create();
+    return SonarScanner.create()
+      .setProperty("sonar.scanner.skipJreProvisioning", "true");
   }
 
   static Measures.Measure getMeasure(Orchestrator orchestrator, String componentKey, String metricKey) {

--- a/its/ruling/src/test/java/org/sonar/web/it/WebRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/web/it/WebRulingTest.java
@@ -72,6 +72,7 @@ public class WebRulingTest {
     orchestrator.getServer().provisionProject(projectKey, projectKey);
     orchestrator.getServer().associateProjectToQualityProfile(projectKey, LANGUAGE, "rules");
     SonarScanner build = SonarScanner.create()
+      .setProperty("sonar.scanner.skipJreProvisioning", "true")
       .setProjectDir(FileLocation.of("../sources").getFile())
       .setProjectKey(projectKey)
       .setProjectName(projectKey)


### PR DESCRIPTION
[SONARHTML-300](https://sonarsource.atlassian.net/browse/SONARHTML-300)

On ephemeral CI machine this avoids unnecessary downloading and unpacking of JRE from SQ and thus reduces time of execution of the first project analysis in integration tests.

During execution of integration tests we already have suitable JDK.

Testing of JRE provisioning feature should not be the responsibility of analyzers.


[SONARHTML-300]: https://sonarsource.atlassian.net/browse/SONARHTML-300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ