### PR TITLE
fix(Web:InternationalizationCheck): Ensure ignoredContentRegex is not bypassed

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/InternationalizationCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/InternationalizationCheck.java
@@ -18,6 +18,7 @@ package org.sonar.plugins.html.checks.coding;
 
 import java.util.List;
 import java.util.regex.Pattern;
+
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
@@ -75,7 +76,7 @@ public class InternationalizationCheck extends AbstractPageCheck {
       String value = element.getAttribute(attribute.getAttributeName());
       if (value != null) {
         value = value.trim();
-        if (value.length() > 0 && isValidText(value)) {
+        if (!value.isEmpty() && isValidText(value)) {
           createViolation(element, "Define this label in the resource bundle.");
           return true;
         }
@@ -85,7 +86,11 @@ public class InternationalizationCheck extends AbstractPageCheck {
   }
 
   private boolean isValidText(String value) {
-    return !isUnifiedExpression(value) && hasNoPunctuationOrSpace(value) && !isIgnoredByRegex(value);
+    // Guard clause to be sure that the ignoredContentRegex rule parameter is not bypassed by anything else
+    if (isIgnoredByRegex(value)) {
+      return false;
+    }
+    return !isUnifiedExpression(value) && hasNoPunctuationOrSpace(value);
   }
 
   private static boolean hasNoPunctuationOrSpace(String value) {


### PR DESCRIPTION
some HTML internationalization tools are based on source code annotation in HTML with special attributes (e.g `translate`).

For example: `<label for="username" translate>Username:</label>`

In that case `ignoredContentRegex` can be used to avoid triggering `Web:InternationalizationCheck` issues.

But the evaluation of the regexp is not independent from others checks on the same code block, and this can create false positives because the regexp is bypassed  :

```java
private boolean isValidText(String value) {
    return !isUnifiedExpression(value) && hasNoPunctuationOrSpace(value) && !isIgnoredByRegex(value);
``` 
In the example below we have set up `ignoredContentRegex` to ignore blocks annotated with `translate`.

The first two code blocks matching the `ignoredContentRegex` are still flagged with `Web:InternationalizationCheck` , while the third is properly ignored. This is because the hasNoPunctuationOrSpace is matched for the first two blocks, and the regexp check is bypassed.

<img width="864" height="846" alt="InternationalizationCheck-issue" src="https://github.com/user-attachments/assets/c31b2006-533f-48ba-bd95-44c560036a43" />

The proposed fix introduces a guard clause  in  `isValidText` to avoid this situation


