### PR TITLE
SONARHTML-353 fix(S5254): Recognize ERB/JSP expressions as dynamic lang values

### DIFF
--- a/its/ruling/src/test/resources/expected/Web-S7930.json
+++ b/its/ruling/src/test/resources/expected/Web-S7930.json
@@ -96,8 +96,5 @@
 ],
 "project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/rules_configuration/_rule.html.erb": [
 119
-],
-"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/settings/_type_LICENSE.html.erb": [
-8
 ]
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
@@ -34,7 +34,7 @@ public class Helpers {
 
   public static boolean isDynamicValue(String value, HtmlSourceCode code) {
     return value.startsWith("<?php") || value.startsWith("{{") || value.startsWith("{%") || value.startsWith("<?=") ||
-            value.startsWith("${") ||
+            value.startsWith("${") || value.startsWith("<%") ||
             (isCshtmlFile(code) && Pattern.compile("(?<!@)@(?!@)").matcher(value).find());
   }
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LangAttributeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LangAttributeCheckTest.java
@@ -55,4 +55,12 @@ class LangAttributeCheckTest {
     checkMessagesVerifier.verify(sourceCode.getIssues())
       .noMore();
   }
+
+  @Test
+  void erbExpressionShouldBeConsideredDynamic() {
+    HtmlSourceCode sourceCode = TestHelper.scan(new File("src/test/resources/checks/LangAttributeCheckErb.html.erb"), new LangAttributeCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .noMore();
+  }
 }

--- a/sonar-html-plugin/src/test/resources/checks/LangAttributeCheckErb.html.erb
+++ b/sonar-html-plugin/src/test/resources/checks/LangAttributeCheckErb.html.erb
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="<%= I18n.locale %>">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <style>
+      /* Email styles need to be inline */
+    </style>
+  </head>
+
+  <body>
+    <%= yield %>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Add support for ERB (`<%= %>`) and JSP (`<% %>`) template expressions in `Helpers.isDynamicValue()`
- Fixes false positive when `lang` attribute uses ERB syntax like `<html lang="<%= I18n.locale %>">`
- Benefits all 8 rules that use `isDynamicValue()` for dynamic value detection

## User Feedback
> [FALSE-POSITIVE] Lang is defined with ERB. (mailer.html.erb:5)

```html
<html lang="<%= I18n.locale %>">
  <head>
    <style>  <!-- FP raised here -->
    </style>
  </head>
</html>
```

## Test plan
- [x] Added unit test `erbExpressionShouldBeConsideredDynamic` with ERB test fixture
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)