### PR TITLE
SONARHTML-256 fix(S6821): Remove "toolbar" from abstract ARIA roles

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/HtmlConstants.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/HtmlConstants.java
@@ -212,8 +212,7 @@ public class HtmlConstants {
   // computed from https://github.com/A11yance/aria-query/blob/main/src/etc/roles/ariaAbstractRoles.js
   protected static final Set<AriaRole> ABSTRACT_ROLES = EnumSet.of(
     AriaRole.COMMAND, AriaRole.COMPOSITE, AriaRole.INPUT, AriaRole.LANDMARK, AriaRole.RANGE, AriaRole.ROLETYPE,
-    AriaRole.SECTION, AriaRole.SECTIONHEAD, AriaRole.SELECT, AriaRole.STRUCTURE, AriaRole.TOOLBAR, AriaRole.WIDGET,
-    AriaRole.WINDOW);
+    AriaRole.SECTION, AriaRole.SECTIONHEAD, AriaRole.SELECT, AriaRole.STRUCTURE, AriaRole.WIDGET, AriaRole.WINDOW);
 
   // computed from https://github.com/A11yance/aria-query/blob/main/src/domMap.js
   public static final Set<String> RESERVED_NODE_SET = Set.of(

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNonInteractiveElementsWithHandlersCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNonInteractiveElementsWithHandlersCheckTest.java
@@ -35,7 +35,8 @@ class NoNonInteractiveElementsWithHandlersCheckTest {
       new NoNonInteractiveElementsWithHandlersCheck());
 
     checkMessagesVerifier.verify(sourceCode.getIssues())
-      .next().atLine(219).withMessage("Non-interactive elements should not be assigned mouse or keyboard event listeners.")
+      .next().atLine(168).withMessage("Non-interactive elements should not be assigned mouse or keyboard event listeners.")
+      .next().atLine(219)
       .next().atLine(220)
       .next().atLine(221)
       .next().atLine(222)

--- a/sonar-html-plugin/src/test/resources/checks/AriaRoleCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/AriaRoleCheck.html
@@ -14,5 +14,6 @@
 <div role="switch" />
 <div role="doc-abstract" />
 <div role="doc-appendix doc-bibliography" />
+<div role="toolbar" />
 <moderator v-for="(item, index) in mods" :role="item.role"></moderator>
 <div role="<?= $block->escapeHtmlAttr($block->getFormId()) ?>" />

--- a/sonar-html-plugin/src/test/resources/checks/NoNonInteractiveElementsWithHandlersCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/NoNonInteractiveElementsWithHandlersCheck.html
@@ -165,7 +165,7 @@
 <div role="select" onClick="foo()" />
 <div role="structure" onClick="foo()" />
 <div role="tablist" onClick="foo()" />
-<div role="toolbar" onClick="foo()" />
+<div role="toolbar" onClick="foo()" /> <!-- Noncompliant - toolbar is not an abstract role -->
 <div role="tree" onClick="foo()" />
 <div role="treegrid" onClick="foo()" />
 <div role="widget" onClick="foo()" />


### PR DESCRIPTION
## Summary
- Remove `AriaRole.TOOLBAR` from `ABSTRACT_ROLES` set - "toolbar" is a concrete ARIA role, not abstract
- Add test coverage for `role="toolbar"` in S6821 tests
- Update S6847 test expectations (toolbar with event handlers now correctly raises an issue)

## Context
Rule S6821 was incorrectly flagging `role="toolbar"` as an invalid ARIA role. According to the [WAI-ARIA 1.2 specification](https://www.w3.org/TR/wai-aria-1.2/#toolbar) and the [aria-query library](https://github.com/A11yance/aria-query), "toolbar" is a concrete role with superclass chain `roletype → structure → section → group`, not an abstract role.

Fixes [SONARHTML-256](https://sonarsource.atlassian.net/browse/SONARHTML-256)

## Test plan
- [x] Existing tests pass
- [x] Added `role="toolbar"` as compliant case in AriaRoleCheck test
- [x] Updated NoNonInteractiveElementsWithHandlersCheck test expectations

🤖 Generated with [Claude Code](https://claude.ai/code)

[SONARHTML-256]: https://sonarsource.atlassian.net/browse/SONARHTML-256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ