### PR TITLE
SONARHTML-284 fix(UnclosedTagCheck): Add <wbr> to ignored void elements

### DIFF
--- a/its/ruling/src/test/resources/expected/Web-UnclosedTagCheck.json
+++ b/its/ruling/src/test/resources/expected/Web-UnclosedTagCheck.json
@@ -741,27 +741,11 @@
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/autocorrection/undo-autocorrection.html": [
 15
 ],
-"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/bugzilla-14899.html": [
-30
-],
-"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/compositing/resources/flash-frame.html": [
-3
-],
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/contenteditable-link.html": [
 6
 ],
-"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/disabled-option-elements.html": [
-11,
-21
-],
-"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/divx-plugin-fails-to-draw.html": [
-10
-],
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/drag-image-to-desktop.html": [
 5
-],
-"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/flash-unload-tab.html": [
-23
 ],
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/hash-ref.html": [
 12
@@ -779,17 +763,8 @@
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/plain-text-paste.html": [
 26
 ],
-"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/plugins/timeout-dialog-displayed-over-navigation.html": [
-21
-],
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/print-onload-with-image.html": [
 8
-],
-"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/resources/nested-plug-ins-inner-frame.html": [
-1
-],
-"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/resources/nested-plug-ins-outer-frame.html": [
-1
 ],
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/resources/video-tab.html": [
 1
@@ -817,9 +792,6 @@
 ],
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/write-after-open.html": [
 38
-],
-"project:external_webkit-jb-mr1/Source/WebKit/chromium/tests/data/pageserialization/top_frame.html": [
-22
 ],
 "project:external_webkit-jb-mr1/Source/WebKit/gtk/resources/error.html": [
 47
@@ -854,8 +826,7 @@
 3
 ],
 "project:external_webkit-jb-mr1/Tools/iExploder/iexploder-1.7.2/testcases/testcase-U_Linux_x86_64_en-US_AppleWebKit-534.7_Chrome-7.0.513.0-4800-5_80,65,15.html": [
-9,
-10
+9
 ],
 "project:phpMyAdmin-4.0.4-english/db_datadict.php": [
 238
@@ -887,11 +858,5 @@
 ],
 "project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/rules_configuration/_rule_note.html.erb": [
 32
-],
-"project:voten/resources/assets/js/components/GifPlayer.vue": [
-27
-],
-"project:voten/resources/assets/js/components/submission/GifSubmission.vue": [
-24
 ]
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/UnclosedTagCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/UnclosedTagCheck.java
@@ -31,7 +31,7 @@ import static org.sonar.plugins.html.api.Helpers.isCshtmlFile;
 public class UnclosedTagCheck extends AbstractPageCheck {
 
   private static final String DEFAULT_IGNORE_TAGS = "HTML,HEAD,BODY,P,DT,DD,LI,OPTION,THEAD,TH,TBODY,TR,TD,TFOOT,COLGROUP" +
-    ",IMG,INPUT,BR,HR,FRAME,AREA,BASE,BASEFONT,COL,ISINDEX,LINK,META,PARAM";
+    ",IMG,INPUT,BR,HR,FRAME,AREA,BASE,BASEFONT,COL,ISINDEX,LINK,META,PARAM,WBR";
 
   @RuleProperty(
     key = "ignoreTags",

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/UnclosedTagCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/UnclosedTagCheck.java
@@ -30,8 +30,8 @@ import static org.sonar.plugins.html.api.Helpers.isCshtmlFile;
 @Rule(key = "UnclosedTagCheck")
 public class UnclosedTagCheck extends AbstractPageCheck {
 
-  private static final String DEFAULT_IGNORE_TAGS = "HTML,HEAD,BODY,P,DT,DD,LI,OPTION,THEAD,TH,TBODY,TR,TD,TFOOT,COLGROUP" +
-    ",IMG,INPUT,BR,HR,FRAME,AREA,BASE,BASEFONT,COL,ISINDEX,LINK,META,PARAM,WBR";
+  private static final String DEFAULT_IGNORE_TAGS = "HTML,HEAD,BODY,P,DT,DD,LI,OPTION,OPTGROUP,THEAD,TH,TBODY,TR,TD,TFOOT,COLGROUP,RT,RP" +
+    ",IMG,INPUT,BR,HR,FRAME,AREA,BASE,BASEFONT,COL,ISINDEX,LINK,META,PARAM,WBR,EMBED,SOURCE,TRACK";
 
   @RuleProperty(
     key = "ignoreTags",

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/UnclosedTagCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/UnclosedTagCheckTest.java
@@ -34,7 +34,7 @@ class UnclosedTagCheckTest {
   void detected() {
     UnclosedTagCheck check = new UnclosedTagCheck();
     assertThat(check.ignoreTags).isEqualTo(
-      "HTML,HEAD,BODY,P,DT,DD,LI,OPTION,THEAD,TH,TBODY,TR,TD,TFOOT,COLGROUP,IMG,INPUT,BR,HR,FRAME,AREA,BASE,BASEFONT,COL,ISINDEX,LINK,META,PARAM");
+      "HTML,HEAD,BODY,P,DT,DD,LI,OPTION,THEAD,TH,TBODY,TR,TD,TFOOT,COLGROUP,IMG,INPUT,BR,HR,FRAME,AREA,BASE,BASEFONT,COL,ISINDEX,LINK,META,PARAM,WBR");
     HtmlSourceCode sourceCode = TestHelper.scan(new File("src/test/resources/checks/UnclosedTagCheck/UnclosedTagCheck.html"), check);
 
     checkMessagesVerifier.verify(sourceCode.getIssues())
@@ -52,6 +52,7 @@ class UnclosedTagCheckTest {
     checkMessagesVerifier.verify(sourceCode.getIssues())
       .next().atLine(4).withMessage("The tag \"li\" has no corresponding closing tag.")
       .next().atLine(7).withMessage("The tag \"br\" has no corresponding closing tag.")
+      .next().atLine(8).withMessage("The tag \"wbr\" has no corresponding closing tag.")
       .next().atLine(15).withMessage("The tag \"li\" has no corresponding closing tag.");
   }
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/UnclosedTagCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/UnclosedTagCheckTest.java
@@ -34,7 +34,8 @@ class UnclosedTagCheckTest {
   void detected() {
     UnclosedTagCheck check = new UnclosedTagCheck();
     assertThat(check.ignoreTags).isEqualTo(
-      "HTML,HEAD,BODY,P,DT,DD,LI,OPTION,THEAD,TH,TBODY,TR,TD,TFOOT,COLGROUP,IMG,INPUT,BR,HR,FRAME,AREA,BASE,BASEFONT,COL,ISINDEX,LINK,META,PARAM,WBR");
+      "HTML,HEAD,BODY,P,DT,DD,LI,OPTION,OPTGROUP,THEAD,TH,TBODY,TR,TD,TFOOT,COLGROUP,RT,RP" +
+      ",IMG,INPUT,BR,HR,FRAME,AREA,BASE,BASEFONT,COL,ISINDEX,LINK,META,PARAM,WBR,EMBED,SOURCE,TRACK");
     HtmlSourceCode sourceCode = TestHelper.scan(new File("src/test/resources/checks/UnclosedTagCheck/UnclosedTagCheck.html"), check);
 
     checkMessagesVerifier.verify(sourceCode.getIssues())

--- a/sonar-html-plugin/src/test/resources/checks/UnclosedTagCheck/UnclosedTagCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/UnclosedTagCheck/UnclosedTagCheck.html
@@ -5,7 +5,7 @@
 </ul>
 
 foo<br>
-bar
+bar<wbr>baz
 
 <foo>
 <bar />


### PR DESCRIPTION
## Summary
- Add `WBR` to the list of void elements that don't require closing tags
- Add missing HTML5 void elements: `EMBED`, `SOURCE`, `TRACK`
- Add tags with optional end tags: `OPTGROUP`, `RT`, `RP`

## Context
The `<wbr>` tag (Word Break Opportunity) is a void element like `<br>` that doesn't have a closing tag according to the [HTML specification](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-wbr-element). UnclosedTagCheck was incorrectly flagging it as missing a closing tag.

Additionally, other HTML5 void elements (`embed`, `source`, `track`) and tags with optional closing tags (`optgroup`, `rt`, `rp`) were missing from the ignore list.

Fixes [SONARHTML-284](https://sonarsource.atlassian.net/browse/SONARHTML-284)

## Test plan
- [x] Added `<wbr>` to test file to verify it's properly ignored
- [x] Updated test expectations for custom ignore list scenario
- [x] All UnclosedTagCheck tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)

[SONARHTML-284]: https://sonarsource.atlassian.net/browse/SONARHTML-284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ