### PR TITLE
SONARHTML-252 fix(S6819): Allow role="img" on SVG elements

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/Aria.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/Aria.java
@@ -1385,7 +1385,7 @@ public class Aria {
           AriaProperty.RELEVANT,
           AriaProperty.ROLEDESCRIPTION
         )
-        .setElements(Element.IMG)
+        .setElements(Element.IMG, Element.SVG)
     );
     ROLES.put(AriaRole.INSERTION,
       new RoleDefinition(AriaRole.INSERTION)

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/Element.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/Element.java
@@ -94,6 +94,7 @@ public enum Element {
   TABLE("table"),
   DFN("dfn"),
   DT("dt"),
+  SVG("svg"),
   TEXTAREA("textarea"),
   TIME("time");
 

--- a/sonar-html-plugin/src/test/resources/checks/PreferTagOverRoleCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/PreferTagOverRoleCheck.html
@@ -14,3 +14,4 @@
 <input role="checkbox" />
 <other role="checkbox" />         <!-- Compliant as using non-standard html tag -->
 <mat-card role="region" aria-labelledby="reportsHeading" appearance="outlined" /> <!-- Compliant as using non-standard html tag -->
+<svg role="img" aria-label="Description"></svg> <!-- Compliant - role="img" on SVG is recommended for accessibility -->


### PR DESCRIPTION
## Summary
- Add `SVG` to the `Element` enum
- Associate `Element.SVG` with the `IMG` role in `Aria.java`

## Context
Rule S6819 suggests using semantic HTML elements instead of ARIA roles. However, for `<svg>` elements, adding `role="img"` is the [recommended accessibility pattern](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/img_role#svg_and_roleimg) to indicate that the SVG should be treated as an image by assistive technologies.

By adding SVG to the elements associated with the IMG role, we allow:
```html
<svg role="img" aria-label="Blue rectangle">
  <rect width="100" height="50" fill="blue"/>
</svg>
```

Fixes [SONARHTML-252](https://sonarsource.atlassian.net/browse/SONARHTML-252)

## Test plan
- [x] Added test case for `<svg role="img">` as compliant
- [x] All PreferTagOverRoleCheck tests pass
- [x] All 287 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)

[SONARHTML-252]: https://sonarsource.atlassian.net/browse/SONARHTML-252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ