### PR TITLE
SONARHTML-355 fix(S6853): Move trailing comments to their own lines

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheck.java
@@ -70,9 +70,12 @@ public class LabelHasAssociatedControlCheck extends AbstractPageCheck {
   private static boolean hasForAttribute(TagNode label) {
     return label.hasProperty("for") ||
            label.hasProperty("htmlFor") ||
-           label.hasProperty("[for]") ||        // Angular binding
-           label.hasProperty(":for") ||         // Vue shorthand binding
-           label.hasProperty("v-bind:for");     // Vue full binding syntax
+           // Angular binding
+           label.hasProperty("[for]") ||
+           // Vue shorthand binding
+           label.hasProperty(":for") ||
+           // Vue full binding syntax
+           label.hasProperty("v-bind:for");
   }
 
   private static boolean hasAccessibleLabel(TagNode node) {


### PR DESCRIPTION
## Summary
- Fixes java:S139 SonarQube issues in `LabelHasAssociatedControlCheck`
- Moves trailing comments for Angular/Vue binding attributes to their own lines above each statement
- Resolves 3 code smell issues on master

## Test plan
- [x] Unit tests pass (`mvn test -Dtest=LabelHasAssociatedControlCheckTest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)