### PR TITLE
SONARHTML-356 fix(S6853): Align aspFor test message with updated rule message

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,3 +81,10 @@ Test files go in `src/test/resources/checks/{CheckName}/`.
 
 HTML: `.html`, `.htm`, `.xhtml`, `.cshtml`, `.vbhtml`, `.aspx`, `.ascx`, `.rhtml`, `.erb`, `.shtm`, `.shtml`, `.cmp`, `.twig`
 JSP: `.jsp`, `.jspf`, `.jspx`
+
+## Pull Requests
+
+When creating PRs, add `quality-web-squad` as a reviewer (requires org prefix):
+```bash
+gh pr edit <PR_NUMBER> --add-reviewer SonarSource/quality-web-squad
+```

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheckTest.java
@@ -109,7 +109,7 @@ class LabelHasAssociatedControlCheckTest {
             new File("src/test/resources/checks/LabelHasAssociatedControlCheck/aspFor.cshtml"),
             new LabelHasAssociatedControlCheck());
     checkMessagesVerifier.verify(sourceCode.getIssues())
-            .next().atLine(6).withMessage("A form label must be associated with a control.")
+            .next().atLine(6).withMessage("A form label must be associated with a control and have accessible text.")
             .next().atLine(7)
             .noMore();
   }


### PR DESCRIPTION
## Summary
- Fix master build failure caused by merge conflict between SONARHTML-331 (#567) and SONARHTML-254 (#574)
- The `aspFor()` test added in #567 used the old message `"A form label must be associated with a control."` but #574 changed it to `"...and have accessible text."`

## Test plan
- [x] `LabelHasAssociatedControlCheckTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)