### PR TITLE
SONARHTML-357 fix(S5254): Recognize template placeholders as dynamic lang values

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LangAttributeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/LangAttributeCheck.java
@@ -31,6 +31,7 @@ import java.util.Deque;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Rule(key = "S5254")
@@ -161,12 +162,18 @@ public class LangAttributeCheck extends AbstractPageCheck {
             "tel".equals(t) || "url".equals(t) || "password".equals(t);
   }
 
+  private static final Pattern LANG_CODE_PATTERN = Pattern.compile("[a-zA-Z0-9-]+");
+
   private static boolean isHtmlTag(TagNode node) {
     return "HTML".equalsIgnoreCase(node.getNodeName());
   }
 
   private boolean isValidLangAttributeValue(String langAttributeValue) {
     if (Helpers.isDynamicValue(langAttributeValue, getHtmlSourceCode())) {
+      return true;
+    }
+    // Values containing non-language characters are template placeholders (e.g. %lang%, #{locale})
+    if (!langAttributeValue.isEmpty() && !LANG_CODE_PATTERN.matcher(langAttributeValue).matches()) {
       return true;
     }
     var parts = langAttributeValue.split("-");

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LangAttributeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/LangAttributeCheckTest.java
@@ -19,6 +19,8 @@ package org.sonar.plugins.html.checks.sonar;
 import java.io.File;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.sonar.plugins.html.checks.CheckMessagesVerifierRule;
 import org.sonar.plugins.html.checks.TestHelper;
 import org.sonar.plugins.html.visitor.HtmlSourceCode;
@@ -48,17 +50,14 @@ class LangAttributeCheckTest {
 	    .noMore();
   }
 
-  @Test
-  void jspElExpressionShouldBeConsideredDynamic() {
-    HtmlSourceCode sourceCode = TestHelper.scan(new File("src/test/resources/checks/LangAttributeCheckJspEl.html"), new LangAttributeCheck());
-
-    checkMessagesVerifier.verify(sourceCode.getIssues())
-      .noMore();
-  }
-
-  @Test
-  void erbExpressionShouldBeConsideredDynamic() {
-    HtmlSourceCode sourceCode = TestHelper.scan(new File("src/test/resources/checks/LangAttributeCheckErb.html.erb"), new LangAttributeCheck());
+  @ParameterizedTest
+  @ValueSource(strings = {
+    "src/test/resources/checks/LangAttributeCheckJspEl.html",
+    "src/test/resources/checks/LangAttributeCheckErb.html.erb",
+    "src/test/resources/checks/LangAttributeCheckSvelteKit.html"
+  })
+  void dynamicLangValuesShouldNotRaiseIssues(String file) {
+    HtmlSourceCode sourceCode = TestHelper.scan(new File(file), new LangAttributeCheck());
 
     checkMessagesVerifier.verify(sourceCode.getIssues())
       .noMore();

--- a/sonar-html-plugin/src/test/resources/checks/LangAttributeCheckSvelteKit.html
+++ b/sonar-html-plugin/src/test/resources/checks/LangAttributeCheckSvelteKit.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="%lang%">
+    <head>
+        <meta charset="utf-8" />
+        <link rel="icon" href="%sveltekit.assets%/favicon.png" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        %sveltekit.head%
+    </head>
+    <body data-sveltekit-preload-data="hover">
+        <div style="display: contents">%sveltekit.body%</div>
+    </body>
+</html>


### PR DESCRIPTION
## Summary
- Lang attribute values containing non-alphanumeric characters (e.g. `%lang%`, `#{locale}`) are template placeholders, not misspelled language codes
- Treat them as valid dynamic values to avoid false positives
- Fixes FP in SvelteKit `app.html` where `<html lang="%lang%">` is used

## Approach
Instead of enumerating every template syntax delimiter, check if the lang value contains only valid language code characters (`[a-zA-Z0-9-]`). Any value with special characters like `%`, `#`, `$`, `{`, etc. is clearly a placeholder — real misspelled codes like `engl` or `dutch` are purely alphanumeric and still correctly flagged.

## Test plan
- [x] New `LangAttributeCheckSvelteKit.html` test with `<html lang="%lang%">` — no issues
- [x] Existing test cases still pass (empty lang `"  "` still flagged, `"invalid"` still flagged)
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)