### PR TITLE
SONARHTML-358 chore: sync RSPEC definitions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,16 @@ Test files go in `src/test/resources/checks/{CheckName}/`.
 HTML: `.html`, `.htm`, `.xhtml`, `.cshtml`, `.vbhtml`, `.aspx`, `.ascx`, `.rhtml`, `.erb`, `.shtm`, `.shtml`, `.cmp`, `.twig`
 JSP: `.jsp`, `.jspf`, `.jspx`
 
+## Syncing RSPEC Definitions
+
+Rule metadata and descriptions are managed in the [RSPEC repository](https://github.com/SonarSource/rspec). To sync updates:
+
+1. Download the rule-api JAR from [sonar-rule-api](https://github.com/SonarSource/sonar-rule-api?tab=readme-ov-file#usage)
+2. From the repository root, run:
+```bash
+java -jar ../rule-api-2.18.0.5734.jar update
+```
+
 ## Pull Requests
 
 When creating PRs, add `quality-web-squad` as a reviewer (requires org prefix):

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/FileLengthCheck.json
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/FileLengthCheck.json
@@ -13,7 +13,6 @@
     "constantCost": "1h"
   },
   "tags": [
-    "architecture",
     "brain-overload"
   ],
   "defaultSeverity": "Major",

--- a/sonarpedia.json
+++ b/sonarpedia.json
@@ -3,7 +3,7 @@
   "languages": [
     "HTML"
   ],
-  "latest-update": "2025-10-09T13:49:27.589945Z",
+  "latest-update": "2026-02-12T09:22:16.070671Z",
   "options": {
     "no-language-in-filenames": true,
     "preserve-filenames": true


### PR DESCRIPTION
## Summary
- Sync rule metadata from RSPEC repository using `rule-api 2.18.0.5734`
- Minor update to `FileLengthCheck.json` and `sonarpedia.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)