### PR TITLE
SONARHTML-360 Fix release automation Vault secret name

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -59,7 +59,7 @@ jobs:
       branch: ${{ github.event.inputs.branch }}
       pm-email: "gabriel.vivas@sonarsource.com"
       slack-channel: "ask-squad-web"
-      release-automation-secret-name: "SonarHTML-release-automation"
+      release-automation-secret-name: "sonar-html-release-automation"
       runner-environment: "github-ubuntu-latest-s"
       verbose: true
       use-jira-sandbox: false


### PR DESCRIPTION
## Summary
- The `release-automation-secret-name` used `SonarHTML` (project name) instead of `sonar-html` (repo name), causing a 403 Forbidden from Vault during the [automated release](https://github.com/SonarSource/sonar-html/actions/runs/21947919698/job/63391681852)
- Changed from `SonarHTML-release-automation` to `sonar-html-release-automation` to match Vault's naming convention

## Test plan
- [ ] Re-run the automated release workflow and verify Vault secret retrieval succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)