### PR TITLE
SONARHTML-169 Fix UnclosedTagCheck false positives in Twig templates

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/ElementTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/ElementTokenizer.java
@@ -76,7 +76,7 @@ class ElementTokenizer extends AbstractTokenizer<List<Node>> {
         case '<':
           nestedTag(element, codeReader, mode);
           continue;
-        case '>', '/', '%', '@':
+        case '>', '/', '%', '@', '{', '}':
           codeReader.pop();
           continue;
         default:
@@ -210,7 +210,7 @@ class ElementTokenizer extends AbstractTokenizer<List<Node>> {
 
     @Override
     public boolean match(int character) {
-      if (character == '>' || character == '/') {
+      if (character == '>' || character == '/' || character == '{') {
         return true;
       }
       return Character.isWhitespace(character);

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/UnclosedTagCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/UnclosedTagCheckTest.java
@@ -69,6 +69,14 @@ class UnclosedTagCheckTest {
   }
 
   @Test
+  void twig_template_no_false_positives() {
+    UnclosedTagCheck check = new UnclosedTagCheck();
+    HtmlSourceCode sourceCode = TestHelper.scan(new File("src/test/resources/checks/UnclosedTagCheck/twig-file.twig"), check);
+
+    checkMessagesVerifier.verify(sourceCode.getIssues()).noMore();
+  }
+
+  @Test
   void cshtml_are_ignored_by_the_rule() {
     UnclosedTagCheck check = new UnclosedTagCheck();
     HtmlSourceCode sourceCode = TestHelper.scan(new File("src/test/resources/checks/UnclosedTagCheck/UnclosedTagCheck.cshtml"), check);

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/PageLexerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/PageLexerTest.java
@@ -569,6 +569,19 @@ class PageLexerTest {
     assertThat(nodes).extracting(Node::getCode).containsExactly("<a>", " ", "<");
   }
 
+  @Test
+  void twig_expression_in_tag_does_not_pollute_node_name() {
+    StringReader reader = new StringReader("<article{{ attributes }}>content</article>");
+    PageLexer lexer = new PageLexer();
+    List<Node> nodeList = lexer.parse(reader);
+
+    assertThat(nodeList).hasSize(3);
+    TagNode openTag = (TagNode) nodeList.get(0);
+    assertThat(openTag.getNodeName()).isEqualTo("article");
+    TagNode closeTag = (TagNode) nodeList.get(2);
+    assertThat(closeTag.getNodeName()).isEqualTo("article");
+  }
+
   private void assertSingleTag(String code) {
     StringReader reader = new StringReader(code);
     List<Node> nodeList = new PageLexer().parse(reader);

--- a/sonar-html-plugin/src/test/resources/checks/UnclosedTagCheck/twig-file.twig
+++ b/sonar-html-plugin/src/test/resources/checks/UnclosedTagCheck/twig-file.twig
@@ -1,0 +1,20 @@
+{#
+  Drupal Twig template - standard pattern with Twig expressions in tag attributes.
+  No false positives should be raised.
+#}
+<article{{ attributes }}>
+  <div{{ content_attributes }}>
+    <h2>{{ label }}</h2>
+    {% if display_submitted %}
+      <footer>
+        {{ author_picture }}
+        <div{{ author_attributes }}>
+          {% trans %}Submitted by {{ author_name }} on {{ date }}{% endtrans %}
+        </div>
+      </footer>
+    {% endif %}
+    <div{{ content_attributes }}>
+      {{ content }}
+    </div>
+  </div>
+</article>


### PR DESCRIPTION
## Summary

- Fix false positives on `Web:UnclosedTagCheck` in `.twig` files where Twig expressions in tag attributes (e.g. `<article{{ attributes }}>`) caused the lexer to produce node name `article{{` instead of `article`, so `</article>` didn't match
- Stop tag name parsing at `{` in `ElementTokenizer` and skip `{`/`}` in tag body — safe for all file types since `{` is never valid in HTML/XML tag names

Community report: https://community.sonarsource.com/t/possible-false-positives-on-rule-web-unclosedtagcheck/177766

## Test plan

- [x] New `PageLexerTest` verifying `<article{{ attributes }}>` produces node name `article`
- [x] New `UnclosedTagCheckTest` verifying no false positives on a Drupal-style Twig template
- [x] Full regression: `mvn clean install` passes (294 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)