### PR TITLE
SONARHTML-361 Restore release.yml with workflow_dispatch only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+---
+name: sonar-release
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        description: Version
+        required: true
+      releaseId:
+        type: string
+        description: Release ID
+        required: true
+      dryRun:
+        type: boolean
+        description: Flag to enable the dry-run execution
+        default: false
+        required: false
+
+jobs:
+  release:
+    permissions:
+      id-token: write
+      contents: write
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v6
+    with:
+      publishToBinaries: true
+      mavenCentralSync: true
+      slackChannel: ask-squad-web
+      version: ${{ inputs.version }}
+      releaseId: ${{ inputs.releaseId }}
+      dryRun: ${{ inputs.dryRun == true }}


### PR DESCRIPTION
## Summary

- Re-add `release.yml` workflow keeping only `workflow_dispatch` trigger
- Removed the `release: published` trigger that was causing duplicate releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)