### PR TITLE
SONARHTML-251 fix(S1082): Recognize Vue @keydown/@keyup and Angular (keyup.enter) as valid keyboard handlers

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
@@ -30,7 +30,20 @@ public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck 
   // Angular 2+ allows key names for the onKeydown pseudo-event to prevent checking the key name manually
   // This pseudo-event also allows key combinations
   // Key names are limited to 10 charters and the combination of keys is realistic limited to 5
-  private static final Pattern KEY_DOWN_WITH_KEY_NAME = Pattern.compile("\\(keydown(\\.\\w{1,10}){1,5}\\)");
+  // Vue also supports key modifiers on @keydown (e.g. @keydown.enter, v-on:keydown.enter)
+  // Note: Vue's @keydown shorthand has the @ stripped by the parser, leaving bare "keydown.enter" as the attribute name
+  private static final Pattern KEY_DOWN_WITH_KEY_NAME = Pattern.compile(
+    "\\(keydown(\\.\\w{1,10}){1,5}\\)" +           // Angular: (keydown.enter)
+    "|keydown(\\.\\w{1,10}){1,5}" +                // Vue shorthand (@ stripped): keydown.enter
+    "|v-on:keydown(\\.\\w{1,10}){1,5}",            // Vue long form: v-on:keydown.enter
+    Pattern.CASE_INSENSITIVE);
+
+  // Vue supports key modifiers on @keyup (e.g. @keyup.enter, v-on:keyup.enter)
+  // Note: Vue's @keyup shorthand has the @ stripped by the parser, leaving bare "keyup.enter" as the attribute name
+  private static final Pattern KEY_UP_WITH_KEY_NAME = Pattern.compile(
+    "keyup(\\.\\w{1,10}){1,5}" +                   // Vue shorthand (@ stripped): keyup.enter
+    "|v-on:keyup(\\.\\w{1,10}){1,5}",              // Vue long form: v-on:keyup.enter
+    Pattern.CASE_INSENSITIVE);
 
   @Override
   public void startElement(TagNode node) {
@@ -94,11 +107,13 @@ public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck 
   }
 
   private static boolean hasOnKeyDown(TagNode node) {
-    return hasEventHandlerAttribute(node, "KEYDOWN") || hasAngularKeyDownWithKeyName(node);
+    // Vue's @keydown shorthand has @ stripped by the parser, leaving bare "keydown" attribute name
+    return hasEventHandlerAttribute(node, "KEYDOWN") || hasAttribute(node, "KEYDOWN") || hasKeyDownWithKeyName(node);
   }
 
   private static boolean hasOnKeyUp(TagNode node) {
-    return hasEventHandlerAttribute(node, "KEYUP");
+    // Vue's @keyup shorthand has @ stripped by the parser, leaving bare "keyup" attribute name
+    return hasEventHandlerAttribute(node, "KEYUP") || hasAttribute(node, "KEYUP") || hasKeyUpWithKeyName(node);
   }
 
   private static boolean hasOnMouseover(TagNode node) {
@@ -123,10 +138,12 @@ public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck 
 
   private static boolean hasEventHandlerAttribute(TagNode node, String eventName) {
     return hasAttribute(node, "ON" + eventName)
-      // angular event binding attributes
+      // Angular event binding attributes
       || hasAttribute(node, "(" + eventName + ")")
       || hasAttribute(node, "ON-" + eventName)
-      || hasAttribute(node, "NG-" + eventName);
+      || hasAttribute(node, "NG-" + eventName)
+      // Vue long form: v-on:eventname (shorthand @eventname has @ stripped by the parser)
+      || hasAttribute(node, "V-ON:" + eventName);
   }
 
   private static boolean hasAttribute(TagNode node, String attributeName) {
@@ -160,7 +177,11 @@ public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck 
       || "LIGHTNING-BUTTON-MENU".equalsIgnoreCase(node.getNodeName());
   }
 
-  private static boolean hasAngularKeyDownWithKeyName(TagNode node) {
-    return node.getAttributes().stream().anyMatch(a -> KEY_DOWN_WITH_KEY_NAME.matcher(a.getName()).find());
+  private static boolean hasKeyDownWithKeyName(TagNode node) {
+    return node.getAttributes().stream().anyMatch(a -> KEY_DOWN_WITH_KEY_NAME.matcher(a.getName()).matches());
+  }
+
+  private static boolean hasKeyUpWithKeyName(TagNode node) {
+    return node.getAttributes().stream().anyMatch(a -> KEY_UP_WITH_KEY_NAME.matcher(a.getName()).matches());
   }
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
@@ -33,18 +33,18 @@ public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck 
   // Vue also supports key modifiers on @keydown (e.g. @keydown.enter, v-on:keydown.enter)
   // Note: Vue's @keydown shorthand has the @ stripped by the parser, leaving bare "keydown.enter" as the attribute name
   private static final Pattern KEY_DOWN_WITH_KEY_NAME = Pattern.compile(
-    "\\(keydown(\\.\\w{1,10}){1,5}\\)" +           // Angular: (keydown.enter)
-    "|keydown(\\.\\w{1,10}){1,5}" +                // Vue shorthand (@ stripped): keydown.enter
-    "|v-on:keydown(\\.\\w{1,10}){1,5}",            // Vue long form: v-on:keydown.enter
+    "\\(keydown(\\.\\w{1,10}){1,5}\\)" +
+    "|keydown(\\.\\w{1,10}){1,5}" +
+    "|v-on:keydown(\\.\\w{1,10}){1,5}",
     Pattern.CASE_INSENSITIVE);
 
   // Angular 2+ allows key names for the onKeyup pseudo-event, similar to keydown
   // Vue also supports key modifiers on @keyup (e.g. @keyup.enter, v-on:keyup.enter)
   // Note: Vue's @keyup shorthand has the @ stripped by the parser, leaving bare "keyup.enter" as the attribute name
   private static final Pattern KEY_UP_WITH_KEY_NAME = Pattern.compile(
-    "\\(keyup(\\.\\w{1,10}){1,5}\\)" +             // Angular: (keyup.enter)
-    "|keyup(\\.\\w{1,10}){1,5}" +                  // Vue shorthand (@ stripped): keyup.enter
-    "|v-on:keyup(\\.\\w{1,10}){1,5}",              // Vue long form: v-on:keyup.enter
+    "\\(keyup(\\.\\w{1,10}){1,5}\\)" +
+    "|keyup(\\.\\w{1,10}){1,5}" +
+    "|v-on:keyup(\\.\\w{1,10}){1,5}",
     Pattern.CASE_INSENSITIVE);
 
   @Override

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
@@ -38,10 +38,12 @@ public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck 
     "|v-on:keydown(\\.\\w{1,10}){1,5}",            // Vue long form: v-on:keydown.enter
     Pattern.CASE_INSENSITIVE);
 
-  // Vue supports key modifiers on @keyup (e.g. @keyup.enter, v-on:keyup.enter)
+  // Angular 2+ allows key names for the onKeyup pseudo-event, similar to keydown
+  // Vue also supports key modifiers on @keyup (e.g. @keyup.enter, v-on:keyup.enter)
   // Note: Vue's @keyup shorthand has the @ stripped by the parser, leaving bare "keyup.enter" as the attribute name
   private static final Pattern KEY_UP_WITH_KEY_NAME = Pattern.compile(
-    "keyup(\\.\\w{1,10}){1,5}" +                   // Vue shorthand (@ stripped): keyup.enter
+    "\\(keyup(\\.\\w{1,10}){1,5}\\)" +             // Angular: (keyup.enter)
+    "|keyup(\\.\\w{1,10}){1,5}" +                  // Vue shorthand (@ stripped): keyup.enter
     "|v-on:keyup(\\.\\w{1,10}){1,5}",              // Vue long form: v-on:keyup.enter
     Pattern.CASE_INSENSITIVE);
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheckTest.java
@@ -52,10 +52,13 @@ class MouseEventWithoutKeyboardEquivalentCheckTest {
         .next().atLine(68)
         .next().atLine(70)
         .next().atLine(71)
-        .next().atLine(79).withMessage("Add a 'onKeyPress|onKeyDown|onKeyUp' attribute to this <div> tag.")
+        // Angular (keyup.X) - invalid key name combinations
+        .next().atLine(76)
+        .next().atLine(77)
+        .next().atLine(85).withMessage("Add a 'onKeyPress|onKeyDown|onKeyUp' attribute to this <div> tag.")
         // Vue.js - invalid key name combinations
-        .next().atLine(100)
-        .next().atLine(101)
+        .next().atLine(106)
+        .next().atLine(107)
     ;
   }
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheckTest.java
@@ -53,6 +53,9 @@ class MouseEventWithoutKeyboardEquivalentCheckTest {
         .next().atLine(70)
         .next().atLine(71)
         .next().atLine(79).withMessage("Add a 'onKeyPress|onKeyDown|onKeyUp' attribute to this <div> tag.")
+        // Vue.js - invalid key name combinations
+        .next().atLine(100)
+        .next().atLine(101)
     ;
   }
 }

--- a/sonar-html-plugin/src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.html
@@ -81,3 +81,21 @@
 <details>
     <summary onclick="console.log(this.target)">Summary</summary> <!-- Compliant -->
 </details>
+
+<!-- Vue.js event bindings -->
+<!-- @keydown/@keyup shorthand: the @ is stripped by the parser, leaving bare "keydown"/"keyup" as attribute name -->
+<div onClick="doSomething();" @keydown="doSomething();"></div>           <!-- Compliant - Vue @keydown -->
+<div onClick="doSomething();" @keyup="doSomething();"></div>             <!-- Compliant - Vue @keyup -->
+<div onClick="doSomething();" @keydown.enter="doSomething();"></div>     <!-- Compliant - Vue @keydown.enter -->
+<div onClick="doSomething();" @keydown.esc="doSomething();"></div>       <!-- Compliant - Vue @keydown.esc -->
+<div onClick="doSomething();" @keydown.shift.control.z="doSomething();"></div> <!-- Compliant - Vue key combination -->
+<div onClick="doSomething();" @keyup.enter="doSomething();"></div>       <!-- Compliant - Vue @keyup.enter -->
+<div onClick="doSomething();" @keyup.esc="doSomething();"></div>         <!-- Compliant - Vue @keyup.esc -->
+<!-- v-on: long form -->
+<div onClick="doSomething();" v-on:keydown="doSomething();"></div>       <!-- Compliant - Vue v-on:keydown -->
+<div onClick="doSomething();" v-on:keyup="doSomething();"></div>         <!-- Compliant - Vue v-on:keyup -->
+<div onClick="doSomething();" v-on:keydown.enter="doSomething();"></div> <!-- Compliant - Vue v-on:keydown.enter -->
+<div onClick="doSomething();" v-on:keyup.enter="doSomething();"></div>   <!-- Compliant - Vue v-on:keyup.enter -->
+<!-- Non-compliant Vue key modifier cases -->
+<div onClick="doSomething();" @keydown.toolongkeyname="doSomething();"></div> <!-- Non-Compliant - too long key name -->
+<div onClick="doSomething();" @keydown.1.2.3.4.5.6="doSomething();"></div>   <!-- Non-Compliant - unrealistic key combination -->

--- a/sonar-html-plugin/src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.html
@@ -70,6 +70,12 @@
 <div (click)="doSomething();" (keydown.undefinedkeyname)="doSomething();"></div>    <!-- Non-Compliant - too long key name -->
 <div (click)="doSomething();" (keydown.1.2.3.4.5.6)="doSomething();"></div>         <!-- Non-Compliant - unrealistic key combination -->
 
+<!-- Angular 2+ keyup event with key name -->
+<div (click)="doSomething();" (keyup.enter)="doSomething();"></div>                 <!-- Compliant -->
+<div (click)="doSomething();" (keyup.shift.control.z)="doSomething();"></div>       <!-- Compliant -->
+<div (click)="doSomething();" (keyup.undefinedkeyname)="doSomething();"></div>      <!-- Non-Compliant - too long key name -->
+<div (click)="doSomething();" (keyup.1.2.3.4.5.6)="doSomething();"></div>           <!-- Non-Compliant - unrealistic key combination -->
+
 <lightning-button onclick={doSomething}></lightning-button>                         <!-- Compliant -->
 <lightning-button-icon onclick={doSomething}></lightning-button-icon>               <!-- Compliant -->
 <lightning-button-menu onclick={doSomething}></lightning-button-menu>               <!-- Compliant -->


### PR DESCRIPTION
Fixes: https://sonarsource.atlassian.net/browse/SONARHTML-251

## Summary

- Recognize Angular `(keyup.enter)` / `(keyup.shift.control.z)` as valid keyboard handlers (mirrors existing `(keydown.enter)` support)
- Recognize `v-on:keydown` / `v-on:keyup` (Vue long form) as valid keyboard handlers
- Recognize bare `keydown` / `keyup` attribute names from Vue's `@keydown` / `@keyup` shorthand (the `@` prefix is stripped by the HTML parser)
- Extend `KEY_DOWN_WITH_KEY_NAME` pattern to match Vue key modifiers (`@keydown.enter` → `keydown.enter`, `v-on:keydown.enter`)
- Add `KEY_UP_WITH_KEY_NAME` pattern covering Angular `(keyup.enter)`, Vue `@keyup.enter` and `v-on:keyup.enter`
- Switch from `find()` to `matches()` for key-name patterns to prevent false negatives on invalid combinations like `(keydown.enter,shift)`

## Test plan

- [x] All 297 existing plugin tests pass
- [x] Angular `(keyup.enter)`, `(keyup.shift.control.z)` — no violation when click handler present
- [x] Vue `@keydown`, `@keyup`, `@keydown.enter`, `@keyup.enter`, `v-on:keydown`, `v-on:keyup`, `v-on:keydown.enter`, `v-on:keyup.enter` — no violation when click handler present
- [x] Invalid cases still fire: too-long key names (`undefinedkeyname`), unrealistic combinations (>5 segments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
