### PR TITLE
SONARHTML-367 Set Renovate prCreation to immediate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,5 +32,6 @@
     }
   ],
   "autoApprove": true,
+  "prCreation": "immediate",
   "rebaseWhen": "never"
 }


### PR DESCRIPTION
## Summary
- set \prCreation\ to \immediate\ in Renovate config
- keeps branch creation and PR creation coupled

## Why
This avoids branch-only updates being left without PRs when checks are pending.