### PR TITLE
SONARHTML-368 Apply monorepo grouping rule to maven updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,12 @@
   ],
   "packageRules": [
     {
+      "description": "Group npm and maven updates per source repository (monorepo), fallback to per dependency",
+      "matchManagers": ["npm", "maven"],
+      "groupName": "{{#if sourceRepo}}{{sourceRepo}} monorepo{{else}}{{depName}}{{/if}}",
+      "groupSlug": "{{#if sourceRepo}}{{sourceRepo}}{{else}}{{depName}}{{/if}}"
+    },
+    {
       "matchManagers": ["github-actions"],
       "pinDigests": false,
       "groupName": "all github actions",


### PR DESCRIPTION
## Summary
- override inherited global grouping by using a monorepo-aware grouping rule
- group by sourceRepo when available, fallback to dependency name

## Managers
- applies to maven (and is future-proofed for 
pm)