### PR TITLE
Disable grouping by default in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,15 +12,13 @@
   ],
   "packageRules": [
     {
-      "description": "Don't group maven updates",
-      "matchManagers": ["maven"],
+      "description": "Don't group updates by default",
+      "matchPackageNames": ["*"],
       "groupName": null
     },
     {
       "matchManagers": ["github-actions"],
-      "pinDigests": false,
-      "groupName": "all github actions",
-      "groupSlug": "all-github-actions"
+      "pinDigests": false
     },
     {
       "matchManagers": ["github-actions"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,11 @@
   ],
   "packageRules": [
     {
+      "description": "Don't group maven updates",
+      "matchManagers": ["maven"],
+      "groupName": null
+    },
+    {
       "matchManagers": ["github-actions"],
       "pinDigests": false,
       "groupName": "all github actions",


### PR DESCRIPTION
## Summary
- add an explicit Renovate override to disable grouping for maven updates
- keep existing Renovate behavior unchanged for other managers

## Why
The shared preset groups Maven dependencies by default. This override forces Maven updates to be ungrouped.