### PR TITLE
SONARHTML-372 USER-1915 fix(S6823,S6844): Improve framework support and ARIA handling

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtils.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtils.java
@@ -47,7 +47,7 @@ public class AccessibilityUtils {
   }
 
   public static boolean isFocusableElement(TagNode element) {
-    String tabindex = element.getAttribute("tabindex");
+    String tabindex = element.getPropertyValue("tabindex");
     try {
       if (isInteractiveElement(element)) {
         return tabindex == null || Double.parseDouble(tabindex) >= 0;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsShouldNotBeUsedAsButtonsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsShouldNotBeUsedAsButtonsCheck.java
@@ -30,19 +30,39 @@ public class AnchorsShouldNotBeUsedAsButtonsCheck extends AbstractPageCheck {
     return Pattern.matches(pattern, value);
   }
 
+  private static boolean hasButtonRole(TagNode node) {
+    String role = node.getAttribute("role");
+    return role != null && "button".equalsIgnoreCase(role.trim());
+  }
+
+  private static boolean hasKeyboardHandler(TagNode node) {
+    return node.getAttribute("onkeydown") != null ||
+      node.getAttribute("onkeyup") != null ||
+      node.getAttribute("onkeypress") != null;
+  }
+
   @Override
   public void startElement(TagNode node) {
-    if ("a".equalsIgnoreCase(node.getNodeName())) {
-      String onClickAttribute = node.getAttribute("onclick");
+    if (!"a".equalsIgnoreCase(node.getNodeName())) {
+      return;
+    }
+    String onClickAttribute = node.getAttribute("onclick");
+    if (onClickAttribute == null) {
+      return;
+    }
+    String hrefAttribute = node.getAttribute("href");
+    boolean hasInvalidHref = hrefAttribute == null || hrefAttribute.isBlank() || "#".equals(hrefAttribute) || isAJavascriptHandler(hrefAttribute);
 
-      if (onClickAttribute == null) {
-        return;
-      }
-      String hrefAttribute = node.getAttribute("href");
+    if (!hasInvalidHref) {
+      return;
+    }
 
-      if (hrefAttribute == null || hrefAttribute.isBlank() || "#".equals(hrefAttribute) || isAJavascriptHandler(hrefAttribute)) {
-        createViolation(node, "Anchor tags should not be used as buttons.");
+    if (hasButtonRole(node)) {
+      if (!hasKeyboardHandler(node)) {
+        createViolation(node, "Anchor tags with role=\"button\" must also handle keyboard events for accessibility.");
       }
+    } else {
+      createViolation(node, "Anchor tags should not be used as buttons.");
     }
   }
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsShouldNotBeUsedAsButtonsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsShouldNotBeUsedAsButtonsCheck.java
@@ -31,14 +31,24 @@ public class AnchorsShouldNotBeUsedAsButtonsCheck extends AbstractPageCheck {
   }
 
   private static boolean hasButtonRole(TagNode node) {
-    String role = node.getAttribute("role");
-    return role != null && "button".equalsIgnoreCase(role.trim());
+    return "button".equalsIgnoreCase(node.getPropertyValue("role"));
   }
 
   private static boolean hasKeyboardHandler(TagNode node) {
-    return node.getAttribute("onkeydown") != null ||
-      node.getAttribute("onkeyup") != null ||
-      node.getAttribute("onkeypress") != null;
+    return hasEventHandler(node, "keydown") ||
+      hasEventHandler(node, "keyup") ||
+      hasEventHandler(node, "keypress");
+  }
+
+  private static boolean hasEventHandler(TagNode node, String eventName) {
+    // Standard HTML: onkeydown, onkeyup, onkeypress
+    // Angular: (keydown), on-keydown, ng-keydown
+    // Vue: v-on:keydown (shorthand @keydown has @ stripped by the parser)
+    return node.getAttribute("on" + eventName) != null
+      || node.getAttribute("(" + eventName + ")") != null
+      || node.getAttribute("on-" + eventName) != null
+      || node.getAttribute("ng-" + eventName) != null
+      || node.getAttribute("v-on:" + eventName) != null;
   }
 
   @Override

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsShouldNotBeUsedAsButtonsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsShouldNotBeUsedAsButtonsCheck.java
@@ -43,12 +43,13 @@ public class AnchorsShouldNotBeUsedAsButtonsCheck extends AbstractPageCheck {
   private static boolean hasEventHandler(TagNode node, String eventName) {
     // Standard HTML: onkeydown, onkeyup, onkeypress
     // Angular: (keydown), on-keydown, ng-keydown
-    // Vue: v-on:keydown (shorthand @keydown has @ stripped by the parser)
+    // Vue: v-on:keydown (shorthand @keydown has @ stripped by parser, leaving bare "keydown")
     return node.getAttribute("on" + eventName) != null
       || node.getAttribute("(" + eventName + ")") != null
       || node.getAttribute("on-" + eventName) != null
       || node.getAttribute("ng-" + eventName) != null
-      || node.getAttribute("v-on:" + eventName) != null;
+      || node.getAttribute("v-on:" + eventName) != null
+      || node.getAttribute(eventName) != null;
   }
 
   @Override

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaActiveDescendantHasTabIndexCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaActiveDescendantHasTabIndexCheck.java
@@ -28,7 +28,7 @@ public class AriaActiveDescendantHasTabIndexCheck extends AbstractPageCheck {
     var ariaActiveDescendant = node.getAttribute("aria-activedescendant");
 
     if (ariaActiveDescendant != null) {
-      var tabIndex = node.getAttribute("tabindex");
+      var tabIndex = node.getPropertyValue("tabindex");
 
       if ((tabIndex == null || tabIndex.isBlank()) && !HtmlConstants.isInteractiveElement(node)) {
         createViolation(node, "An element that manages focus with `aria-activedescendant` must have a tabindex.");

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheck.java
@@ -35,7 +35,7 @@ public class NoNoninteractiveTabIndexCheck extends AbstractPageCheck {
       return;
     }
 
-    var tabIndex = node.getAttribute("tabindex");
+    var tabIndex = node.getPropertyValue("tabindex");
     if (tabIndex == null) {
       return;
     }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AnchorsShouldNotBeUsedAsButtonsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AnchorsShouldNotBeUsedAsButtonsCheckTest.java
@@ -38,6 +38,9 @@ class AnchorsShouldNotBeUsedAsButtonsCheckTest {
       .next().atLine(1).withMessage("Anchor tags should not be used as buttons.")
       .next().atLine(2)
       .next().atLine(3)
-      .next().atLine(4);
+      .next().atLine(4)
+      .next().atLine(13).withMessage("Anchor tags with role=\"button\" must also handle keyboard events for accessibility.")
+      .next().atLine(14)
+      .next().atLine(15);
   }
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheckTest.java
@@ -38,6 +38,9 @@ class NoNoninteractiveTabIndexCheckTest {
       .next().atLine(18).withMessage("\"tabIndex\" should only be declared on interactive elements.")
       .next().atLine(19)
       .next().atLine(20)
+      .next().atLine(23)
+      .next().atLine(24)
+      .next().atLine(25)
       .noMore();
   }
 }

--- a/sonar-html-plugin/src/test/resources/checks/AnchorsShouldNotBeUsedAsButtonsCheck/file.html
+++ b/sonar-html-plugin/src/test/resources/checks/AnchorsShouldNotBeUsedAsButtonsCheck/file.html
@@ -24,3 +24,4 @@
 <a role="button" href="#" onClick="foo" (keydown)="handleKey($event)"/>
 <a role="button" href="#" onClick="foo" v-on:keydown="handleKey"/>
 <a role="button" onClick="foo" on-keydown="handleKey(event)"/>
+<a role="button" href="#" onClick="foo" keydown="handleKey"/>

--- a/sonar-html-plugin/src/test/resources/checks/AnchorsShouldNotBeUsedAsButtonsCheck/file.html
+++ b/sonar-html-plugin/src/test/resources/checks/AnchorsShouldNotBeUsedAsButtonsCheck/file.html
@@ -20,3 +20,7 @@
 <!-- role="button" with valid href: always compliant (valid navigation link with button styling) -->
 <a role="button" href="page.html" onClick="doAction()"/>
 <a role="BUTTON" href="/path" onClick="doAction()"/>
+<!-- role="button" with framework keyboard bindings: Compliant -->
+<a role="button" href="#" onClick="foo" (keydown)="handleKey($event)"/>
+<a role="button" href="#" onClick="foo" v-on:keydown="handleKey"/>
+<a role="button" onClick="foo" on-keydown="handleKey(event)"/>

--- a/sonar-html-plugin/src/test/resources/checks/AnchorsShouldNotBeUsedAsButtonsCheck/file.html
+++ b/sonar-html-plugin/src/test/resources/checks/AnchorsShouldNotBeUsedAsButtonsCheck/file.html
@@ -9,3 +9,14 @@
 <a href="#section" onClick="javascript"/>
 <a href=""/>
 <a/>
+<!-- role="button" without keyboard handler: Noncompliant with specific message -->
+<a role="button" href="#" onClick="foo"/> <!-- Noncompliant -->
+<a role="button" href="javascript:void(0)" onClick="foo"/> <!-- Noncompliant -->
+<a role="button" onClick="foo"/> <!-- Noncompliant -->
+<!-- role="button" WITH keyboard handler: Compliant -->
+<a role="button" href="#" onClick="foo" onkeydown="handleKey(event)"/>
+<a role="button" onClick="foo" onkeyup="handleKey(event)"/>
+<a role="button" href="javascript:void(0)" onClick="foo" onkeypress="handleKey(event)"/>
+<!-- role="button" with valid href: always compliant (valid navigation link with button styling) -->
+<a role="button" href="page.html" onClick="doAction()"/>
+<a role="BUTTON" href="/path" onClick="doAction()"/>

--- a/sonar-html-plugin/src/test/resources/checks/AriaActiveDescendantHasTabIndexCheck/file.html
+++ b/sonar-html-plugin/src/test/resources/checks/AriaActiveDescendantHasTabIndexCheck/file.html
@@ -19,3 +19,9 @@
     <div id="descendantId"></div>
 </div>
 <input aria-activedescendant="foo" tabIndex=""/>
+<!-- Framework bindings should be recognized as valid tabindex -->
+<div aria-activedescendant="foo" [attr.tabindex]="0"></div>
+<div aria-activedescendant="foo" [tabindex]="0"></div>
+<div aria-activedescendant="foo" :tabindex="0"></div>
+<div aria-activedescendant="foo" v-bind:tabindex="0"></div>
+<div aria-activedescendant="foo" attr.tabindex="0"></div>

--- a/sonar-html-plugin/src/test/resources/checks/NoNoninteractiveTabIndexCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/NoNoninteractiveTabIndexCheck.html
@@ -18,3 +18,8 @@
 <div tabIndex="0" />
 <div tabIndex="42" />
 <div role="article" tabIndex="42" />
+
+<!-- Framework bindings: should now be detected -->
+<div [tabindex]="0" />
+<div [attr.tabindex]="0" />
+<div :tabindex="0" />


### PR DESCRIPTION
## Summary

Addresses feedback from Revenu Quebec accessibility audit (USER-1915):

- **S6823 (AriaActiveDescendantHasTabIndexCheck)**: Changed `getAttribute("tabindex")` to `getPropertyValue("tabindex")` so Angular `[attr.tabindex]`, Vue `:tabindex`, and similar framework bindings are properly recognized. Previously these produced false positives.
- **AccessibilityUtils.isFocusableElement**: Same fix applied to the shared utility used by multiple rules.
- **S6844 (AnchorsShouldNotBeUsedAsButtonsCheck)**: When an anchor has `role="button"`, require a keyboard handler for the pattern to be acceptable. Per the W3C APG, `<a role="button">` without Space key handling has broken keyboard semantics. Uses `getPropertyValue("role")` for framework bindings and detects keyboard handlers across frameworks: standard (`onkeydown`), Angular (`(keydown)`, `on-keydown`, `ng-keydown`), Vue (`v-on:keydown`, `@keydown` stripped form). Anchors without `role="button"` are still flagged as before.
- **S6845 (NoNoninteractiveTabIndexCheck)**: Same `getAttribute` → `getPropertyValue` fix for tabindex, so Angular/Vue-bound tabindex on non-interactive elements is detected.

## Test plan

- [x] Added framework binding test cases for S6823 (Angular `[attr.tabindex]`, `[tabindex]`, Vue `:tabindex`, `v-bind:tabindex`)
- [x] Added `role="button"` test cases for S6844: without keyboard handler (flagged), with keyboard handler across frameworks (compliant), with valid href (compliant)
- [x] Added framework binding test cases for S6845 (`[tabindex]`, `[attr.tabindex]`, `:tabindex`)
- [x] All 340 existing tests pass
- [ ] CI green