### PR TITLE
SONARHTML-378 Support sonar-resolve in HTML analyzer

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlSensor.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlSensor.java
@@ -59,10 +59,12 @@ import org.sonar.plugins.html.visitor.DefaultNodeVisitor;
 import org.sonar.plugins.html.visitor.HtmlAstScanner;
 import org.sonar.plugins.html.visitor.HtmlSourceCode;
 import org.sonar.plugins.html.visitor.NoSonarScanner;
+import org.sonar.plugins.html.visitor.SonarResolveScanner;
 
 public final class HtmlSensor implements Sensor {
   private static final Logger LOG = Loggers.get(HtmlSensor.class);
   private static final String[] OTHER_FILE_SUFFIXES = {"php", "php3", "php4", "php5", "phtml", "inc", "vue"};
+  private static final Version ISSUE_RESOLUTION_API_MIN_VERSION = Version.create(13, 5);
 
   private final SonarRuntime sonarRuntime;
   private final NoSonarFilter noSonarFilter;
@@ -194,6 +196,9 @@ public final class HtmlSensor implements Sensor {
     visitors.add(new PageCountLines());
     visitors.add(new ComplexityVisitor());
     visitors.add(new NoSonarScanner(noSonarFilter));
+    if (supportsIssueResolution(context)) {
+      visitors.add(new SonarResolveScanner(context));
+    }
     HtmlAstScanner scanner = new HtmlAstScanner(visitors);
 
     for (Object check : checks.all()) {
@@ -207,6 +212,11 @@ public final class HtmlSensor implements Sensor {
 
   private void addAnalysisWarnings(AbstractPageCheck check) {
     check.collectAnalysisWarnings().forEach(analysisWarnings::addUnique);
+  }
+
+  private static boolean supportsIssueResolution(SensorContext context) {
+    return context.runtime().getProduct() != SonarProduct.SONARLINT
+      && context.runtime().getApiVersion().isGreaterThanOrEqual(ISSUE_RESOLUTION_API_MIN_VERSION);
   }
 
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/SonarResolveScanner.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/SonarResolveScanner.java
@@ -16,16 +16,16 @@
  */
 package org.sonar.plugins.html.visitor;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.SensorContext;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
 import org.sonarsource.analyzer.commons.SonarResolve;
 import org.sonar.plugins.html.node.CommentNode;
 
 public class SonarResolveScanner extends DefaultNodeVisitor {
 
-  private static final Logger LOG = Loggers.get(SonarResolveScanner.class);
+  private static final Logger LOG = LoggerFactory.getLogger(SonarResolveScanner.class);
 
   private final SensorContext context;
 
@@ -36,20 +36,23 @@ public class SonarResolveScanner extends DefaultNodeVisitor {
   @Override
   public void comment(CommentNode node) {
     String[] commentLines = stripCommentDelimiters(node).split("\\R", -1);
-    for (int i = 0; i < commentLines.length; i++) {
-      int directiveLine = node.getStartLinePosition() + i;
-      String line = commentLines[i];
+    int index = 0;
+    while (index < commentLines.length) {
+      int directiveLine = node.getStartLinePosition() + index;
+      String line = commentLines[index];
       if (!startsWithDirectiveKeyword(line)) {
+        index++;
         continue;
       }
 
       SonarResolve.StreamingParser parser = new SonarResolve.StreamingParser(directiveLine);
       SonarResolve.StreamingParser.State state = parser.consumeLine(directiveLine, line);
+      int lastConsumedIndex = index;
 
-      while (state == SonarResolve.StreamingParser.State.INCOMPLETE && i + 1 < commentLines.length) {
-        i++;
-        int lineNumber = node.getStartLinePosition() + i;
-        state = parser.consumeLine(lineNumber, commentLines[i]);
+      while (state == SonarResolve.StreamingParser.State.INCOMPLETE && lastConsumedIndex + 1 < commentLines.length) {
+        lastConsumedIndex++;
+        int lineNumber = node.getStartLinePosition() + lastConsumedIndex;
+        state = parser.consumeLine(lineNumber, commentLines[lastConsumedIndex]);
       }
 
       if (state == SonarResolve.StreamingParser.State.COMPLETE) {
@@ -59,6 +62,8 @@ public class SonarResolveScanner extends DefaultNodeVisitor {
       } else if (parser.finish() == SonarResolve.StreamingParser.State.INVALID) {
         logInvalidDirective(directiveLine, parser.errorMessage());
       }
+
+      index = lastConsumedIndex + 1;
     }
   }
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/SonarResolveScanner.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/SonarResolveScanner.java
@@ -1,0 +1,92 @@
+/*
+ * SonarQube HTML
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.html.visitor;
+
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+import org.sonarsource.analyzer.commons.SonarResolve;
+import org.sonar.plugins.html.node.CommentNode;
+
+public class SonarResolveScanner extends DefaultNodeVisitor {
+
+  private static final Logger LOG = Loggers.get(SonarResolveScanner.class);
+
+  private final SensorContext context;
+
+  public SonarResolveScanner(SensorContext context) {
+    this.context = context;
+  }
+
+  @Override
+  public void comment(CommentNode node) {
+    String[] commentLines = stripCommentDelimiters(node).split("\\R", -1);
+    for (int i = 0; i < commentLines.length; i++) {
+      int directiveLine = node.getStartLinePosition() + i;
+      String line = commentLines[i];
+      if (!startsWithDirectiveKeyword(line)) {
+        continue;
+      }
+
+      SonarResolve.StreamingParser parser = new SonarResolve.StreamingParser(directiveLine);
+      SonarResolve.StreamingParser.State state = parser.consumeLine(directiveLine, line);
+
+      while (state == SonarResolve.StreamingParser.State.INCOMPLETE && i + 1 < commentLines.length) {
+        i++;
+        int lineNumber = node.getStartLinePosition() + i;
+        state = parser.consumeLine(lineNumber, commentLines[i]);
+      }
+
+      if (state == SonarResolve.StreamingParser.State.COMPLETE) {
+        saveIssueResolution(parser.result());
+      } else if (state == SonarResolve.StreamingParser.State.INVALID) {
+        logInvalidDirective(directiveLine, parser.errorMessage());
+      } else if (parser.finish() == SonarResolve.StreamingParser.State.INVALID) {
+        logInvalidDirective(directiveLine, parser.errorMessage());
+      }
+    }
+  }
+
+  private static boolean startsWithDirectiveKeyword(String line) {
+    String trimmed = line.stripLeading();
+    return trimmed.regionMatches(true, 0, SonarResolve.KEYWORD, 0, SonarResolve.KEYWORD.length());
+  }
+
+  private void saveIssueResolution(SonarResolve sonarResolve) {
+    InputFile inputFile = getHtmlSourceCode().inputFile();
+    context.newIssueResolution()
+      .on(inputFile)
+      .at(inputFile.selectLine(sonarResolve.targetLine()))
+      .status(sonarResolve.status())
+      .forRules(sonarResolve.ruleKeys())
+      .comment(sonarResolve.justification())
+      .save();
+  }
+
+  private void logInvalidDirective(int line, String errorMessage) {
+    LOG.warn("{} in file {} at line {}", errorMessage, getHtmlSourceCode().inputFile(), line);
+  }
+
+  private static String stripCommentDelimiters(CommentNode node) {
+    String code = node.getCode();
+    if (node.isHtml()) {
+      return code.substring("<!--".length(), code.length() - "-->".length());
+    }
+    return code.substring("<%--".length(), code.length() - "--%>".length());
+  }
+}

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlSensorTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlSensorTest.java
@@ -156,8 +156,8 @@ class HtmlSensorTest {
   }
 
   @Test
-  void sonar_resolve_is_saved_on_supported_runtime() {
-    tester.setRuntime(SonarRuntimeImpl.forSonarQube(Version.create(13, 6), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY));
+  void sonar_resolve_is_saved_at_minimum_supported_runtime() {
+    tester.setRuntime(SonarRuntimeImpl.forSonarQube(Version.create(13, 5), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY));
     DefaultInputFile inputFile = createInputFile("sonar-resolve.html", String.join("\n",
       "<div>",
       "<!-- sonar-resolve [fp] Web:S5256 \"reason\" -->",

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlSensorTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlSensorTest.java
@@ -42,6 +42,7 @@ import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.batch.sensor.highlighting.TypeOfText;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.batch.sensor.issue.IssueResolution;
 import org.sonar.api.batch.sensor.issue.internal.DefaultNoSonarFilter;
 import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.measures.CoreMetrics;
@@ -152,6 +153,53 @@ class HtmlSensorTest {
     assertThat(tester.allIssues()).isNotEmpty();
     assertThat(tester.cpdTokens(componentKey)).isNull();
     assertThat(tester.highlightingTypeAt(componentKey, 1, 0)).isEmpty();
+  }
+
+  @Test
+  void sonar_resolve_is_saved_on_supported_runtime() {
+    tester.setRuntime(SonarRuntimeImpl.forSonarQube(Version.create(13, 6), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY));
+    DefaultInputFile inputFile = createInputFile("sonar-resolve.html", String.join("\n",
+      "<div>",
+      "<!-- sonar-resolve [fp] Web:S5256 \"reason\" -->",
+      "</div>"));
+    tester.fileSystem().add(inputFile);
+
+    sensor.execute(tester);
+
+    assertThat(issueResolutions(inputFile)).singleElement().satisfies(issueResolution -> {
+      assertThat(issueResolution.status()).isEqualTo(IssueResolution.Status.FALSE_POSITIVE);
+      assertThat(issueResolution.ruleKeys()).containsExactly(RuleKey.of(HtmlRulesDefinition.REPOSITORY_KEY, "S5256"));
+      assertThat(issueResolution.comment()).isEqualTo("reason");
+      assertThat(issueResolution.textRange().start().line()).isEqualTo(2);
+    });
+  }
+
+  @Test
+  void sonar_resolve_is_ignored_before_supported_runtime() {
+    tester.setRuntime(SonarRuntimeImpl.forSonarQube(Version.create(13, 4), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY));
+    DefaultInputFile inputFile = createInputFile("sonar-resolve.html", String.join("\n",
+      "<div>",
+      "<!-- sonar-resolve Web:S5256 \"reason\" -->",
+      "</div>"));
+    tester.fileSystem().add(inputFile);
+
+    sensor.execute(tester);
+
+    assertThat(issueResolutions(inputFile)).isEmpty();
+  }
+
+  @Test
+  void sonar_resolve_is_ignored_in_sonarlint() {
+    tester.setRuntime(SonarRuntimeImpl.forSonarLint(Version.create(13, 6)));
+    DefaultInputFile inputFile = createInputFile("sonar-resolve.html", String.join("\n",
+      "<div>",
+      "<!-- sonar-resolve Web:S5256 \"reason\" -->",
+      "</div>"));
+    tester.fileSystem().add(inputFile);
+
+    sensor.execute(tester);
+
+    assertThat(issueResolutions(inputFile)).isEmpty();
   }
 
   @Test
@@ -280,6 +328,20 @@ class HtmlSensorTest {
       .initMetadata(new String(Files.readAllBytes(dir.resolve(fileName)), StandardCharsets.UTF_8))
       .setCharset(StandardCharsets.UTF_8)
       .build();
+  }
+
+  private DefaultInputFile createInputFile(String fileName, String contents) {
+    return new TestInputFileBuilder("key", fileName)
+      .setModuleBaseDir(TEST_DIR)
+      .setContents(contents)
+      .setLanguage(HtmlConstants.LANGUAGE_KEY)
+      .setType(InputFile.Type.MAIN)
+      .setCharset(StandardCharsets.UTF_8)
+      .build();
+  }
+
+  private List<IssueResolution> issueResolutions(DefaultInputFile inputFile) {
+    return tester.getIssueResolutions().getOrDefault(inputFile.key(), Collections.emptyList());
   }
 
   private static class RecordingAnalysisWarnings implements AnalysisWarnings {

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/visitor/SonarResolveScannerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/visitor/SonarResolveScannerTest.java
@@ -79,6 +79,29 @@ class SonarResolveScannerTest {
   }
 
   @Test
+  void scan_case_insensitive_accept_status_with_multiple_rule_keys() throws IOException {
+    String content = String.join("\n",
+      "<table>",
+      "<!--",
+      "SoNaR-ReSoLvE [AcCePt] Web:S5256, Web:S1827 \"accepted for both rules\"",
+      "-->",
+      "</table>");
+
+    SensorContextTester tester = newSensorContext();
+    InputFile inputFile = createInputFile("accept-multiple-rules.html", content);
+    scan(tester, inputFile, content);
+
+    assertThat(issueResolutions(tester, inputFile)).singleElement().satisfies(issueResolution -> {
+      assertThat(issueResolution.status()).isEqualTo(IssueResolution.Status.DEFAULT);
+      assertThat(issueResolution.ruleKeys()).containsExactlyInAnyOrder(
+        RuleKey.of(HtmlRulesDefinition.REPOSITORY_KEY, "S5256"),
+        RuleKey.of(HtmlRulesDefinition.REPOSITORY_KEY, "S1827"));
+      assertThat(issueResolution.comment()).isEqualTo("accepted for both rules");
+      assertThat(issueResolution.textRange().start().line()).isEqualTo(3);
+    });
+  }
+
+  @Test
   void scan_multiline_jsp_directive() throws IOException {
     String content = String.join("\n",
       "<%--",

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/visitor/SonarResolveScannerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/visitor/SonarResolveScannerTest.java
@@ -123,6 +123,40 @@ class SonarResolveScannerTest {
   }
 
   @Test
+  void scan_multiline_html_directive_preserves_justification_indentation() throws IOException {
+    String content = String.join("\n",
+      "<table>",
+      "<!--",
+      "sonar-resolve Web:S5256 \"first",
+      "    second",
+      "  third\"",
+      "-->",
+      "</table>");
+
+    SensorContextTester tester = newSensorContext();
+    InputFile inputFile = createInputFile("multiline-indented.html", content);
+    scan(tester, inputFile, content);
+
+    assertResolution(issueResolutions(tester, inputFile).get(0), "S5256", "first\n    second\n  third", 3);
+  }
+
+  @Test
+  void scan_multiline_jsp_directive_preserves_justification_indentation() throws IOException {
+    String content = String.join("\n",
+      "<%--",
+      "sonar-resolve Web:S5256 \"first",
+      "    second",
+      "  third\"",
+      "--%>");
+
+    SensorContextTester tester = newSensorContext();
+    InputFile inputFile = createInputFile("multiline-indented.jsp", content);
+    scan(tester, inputFile, content);
+
+    assertResolution(issueResolutions(tester, inputFile).get(0), "S5256", "first\n    second\n  third", 2);
+  }
+
+  @Test
   void scan_directives_with_multiple_justification_delimiters() throws IOException {
     String content = String.join("\n",
       "<table>",

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/visitor/SonarResolveScannerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/visitor/SonarResolveScannerTest.java
@@ -23,8 +23,12 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.batch.fs.InputFile;
@@ -41,6 +45,7 @@ import org.sonar.plugins.html.node.Node;
 import org.sonar.plugins.html.rules.HtmlRulesDefinition;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 class SonarResolveScannerTest {
 
@@ -94,38 +99,16 @@ class SonarResolveScannerTest {
     });
   }
 
-  @Test
-  void invalid_directive_logs_warning_and_skips_resolution() throws IOException {
-    String content = String.join("\n",
-      "<table>",
-      "<!-- sonar-resolve Web:S5256 \"reason -->",
-      "</table>");
-
-    SensorContextTester tester = newSensorContext();
-    InputFile inputFile = createInputFile("invalid.html", content);
-    scan(tester, inputFile, content);
-
-    assertThat(issueResolutions(tester, inputFile)).isEmpty();
-    assertThat(logTester.logs()).anySatisfy(log -> assertThat(log)
-      .contains("Invalid sonar-resolve directive: unterminated justification")
-      .contains("line 2"));
+  @ParameterizedTest
+  @MethodSource("singleLineInvalidDirectiveCases")
+  void invalid_single_line_directives_log_warning(String directive, String expectedErrorMessage) throws IOException {
+    assertInvalidDirectiveLogsWarning(expectedErrorMessage, directive);
   }
 
-  @Test
-  void immediately_invalid_directive_logs_warning_and_skips_resolution() throws IOException {
-    String content = String.join("\n",
-      "<table>",
-      "<!-- sonar-resolve [accepted] Web:S5256 \"reason\" -->",
-      "</table>");
-
-    SensorContextTester tester = newSensorContext();
-    InputFile inputFile = createInputFile("invalid-status.html", content);
-    scan(tester, inputFile, content);
-
-    assertThat(issueResolutions(tester, inputFile)).isEmpty();
-    assertThat(logTester.logs()).anySatisfy(log -> assertThat(log)
-      .contains("Invalid sonar-resolve directive: invalid status '[accepted]'")
-      .contains("line 2"));
+  @ParameterizedTest
+  @MethodSource("multiLineInvalidDirectiveCases")
+  void invalid_multi_line_directives_log_warning(String[] directiveLines, String expectedErrorMessage) throws IOException {
+    assertInvalidDirectiveLogsWarning(expectedErrorMessage, directiveLines);
   }
 
   @Test
@@ -158,23 +141,6 @@ class SonarResolveScannerTest {
     assertThat(logTester.logs()).noneMatch(log -> log.contains("Invalid sonar-resolve directive"));
   }
 
-  @Test
-  void malformed_directive_start_still_logs_warning() throws IOException {
-    String content = String.join("\n",
-      "<table>",
-      "<!-- sonar-resolve[fp] Web:S5256 \"reason\" -->",
-      "</table>");
-
-    SensorContextTester tester = newSensorContext();
-    InputFile inputFile = createInputFile("missing-space.html", content);
-    scan(tester, inputFile, content);
-
-    assertThat(issueResolutions(tester, inputFile)).isEmpty();
-    assertThat(logTester.logs()).anySatisfy(log -> assertThat(log)
-      .contains("Invalid sonar-resolve directive: expected whitespace after 'sonar-resolve'")
-      .contains("line 2"));
-  }
-
   private static void scan(SensorContextTester tester, InputFile inputFile, String content) throws IOException {
     List<Node> nodeList;
     try (Reader reader = new StringReader(content)) {
@@ -189,6 +155,51 @@ class SonarResolveScannerTest {
   private static SensorContextTester newSensorContext() {
     return SensorContextTester.create(Paths.get("."))
       .setRuntime(SonarRuntimeImpl.forSonarQube(Version.create(13, 6), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY));
+  }
+
+  private void assertInvalidDirectiveLogsWarning(String expectedErrorMessage, String... directiveLines) throws IOException {
+    SensorContextTester tester = newSensorContext();
+    String content = htmlCommentContent(directiveLines);
+    InputFile inputFile = createInputFile("invalid.html", content);
+    scan(tester, inputFile, content);
+
+    assertThat(issueResolutions(tester, inputFile)).isEmpty();
+    assertThat(logTester.logs()).singleElement().satisfies(log -> assertThat(log)
+      .contains(expectedErrorMessage)
+      .contains("line 2"));
+  }
+
+  private static String htmlCommentContent(String... directiveLines) {
+    StringBuilder content = new StringBuilder("<table>\n<!-- ").append(directiveLines[0]);
+    for (int i = 1; i < directiveLines.length; i++) {
+      content.append('\n').append(directiveLines[i]);
+    }
+    return content.append(" -->\n</table>").toString();
+  }
+
+  private static Stream<Arguments> singleLineInvalidDirectiveCases() {
+    return Stream.of(
+      arguments("sonar-resolve[fp] Web:S5256 \"reason\"", "Invalid sonar-resolve directive: expected whitespace after 'sonar-resolve'"),
+      arguments("sonar-resolve \"reason\"", "Invalid sonar-resolve directive: missing rule key"),
+      arguments("sonar-resolve WebS5256 \"reason\"", "Invalid sonar-resolve directive: invalid rule key 'WebS5256'"),
+      arguments("sonar-resolve [accepted] Web:S5256 \"reason\"", "Invalid sonar-resolve directive: invalid status '[accepted]'"),
+      arguments("sonar-resolve [fp Web:S5256 \"reason\"", "Invalid sonar-resolve directive: unterminated status"),
+      arguments("sonar-resolve Web:S5256, Web:S5256 \"reason\"", "Invalid sonar-resolve directive: duplicate rule key 'Web:S5256'"),
+      arguments("sonar-resolve Web:S5256, \"reason\"", "Invalid sonar-resolve directive: invalid rule key list"),
+      arguments("sonar-resolve Web:S5256", "Invalid sonar-resolve directive: missing justification"),
+      arguments("sonar-resolve Web:S5256 <reason>", "Invalid sonar-resolve directive: missing justification"),
+      arguments("sonar-resolve Web:S5256 \"reason", "Invalid sonar-resolve directive: unterminated justification"),
+      arguments("sonar-resolve Web:S5256 [reason", "Invalid sonar-resolve directive: unterminated justification"));
+  }
+
+  private static Stream<Arguments> multiLineInvalidDirectiveCases() {
+    return Stream.of(
+      arguments(new String[] {"sonar-resolve", "\"reason\""}, "Invalid sonar-resolve directive: missing rule key"),
+      arguments(new String[] {"sonar-resolve [f", "p] Web:S5256 \"reason\""}, "Invalid sonar-resolve directive: invalid status '[f\np]'"),
+      arguments(new String[] {"sonar-resolve [fp", "Web:S5256 \"reason\""}, "Invalid sonar-resolve directive: unterminated status"),
+      arguments(new String[] {"sonar-resolve Web:S5256,", "\"reason\""}, "Invalid sonar-resolve directive: invalid rule key list"),
+      arguments(new String[] {"sonar-resolve Web:S5256 \"reason", "still reason"}, "Invalid sonar-resolve directive: unterminated justification"),
+      arguments(new String[] {"sonar-resolve Web:S5256 [reason", "still reason"}, "Invalid sonar-resolve directive: unterminated justification"));
   }
 
   private static InputFile createInputFile(String fileName, String content) {

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/visitor/SonarResolveScannerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/visitor/SonarResolveScannerTest.java
@@ -1,0 +1,207 @@
+/*
+ * SonarQube HTML
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.html.visitor;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.sonar.api.SonarEdition;
+import org.sonar.api.SonarQubeSide;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
+import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.batch.sensor.issue.IssueResolution;
+import org.sonar.api.internal.SonarRuntimeImpl;
+import org.sonar.api.rule.RuleKey;
+import org.sonar.api.testfixtures.log.LogTesterJUnit5;
+import org.sonar.api.utils.Version;
+import org.sonar.plugins.html.api.HtmlConstants;
+import org.sonar.plugins.html.lex.PageLexer;
+import org.sonar.plugins.html.node.Node;
+import org.sonar.plugins.html.rules.HtmlRulesDefinition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SonarResolveScannerTest {
+
+  @RegisterExtension
+  public LogTesterJUnit5 logTester = new LogTesterJUnit5();
+
+  @Test
+  void scan_multiple_html_directives() throws IOException {
+    String content = String.join("\n",
+      "<table>",
+      "<!--",
+      "sonar-resolve Web:S5256 \"accept reason\"",
+      "sonar-resolve [fp] Web:S1827 \"false positive reason\"",
+      "-->",
+      "</table>");
+
+    SensorContextTester tester = newSensorContext();
+    InputFile inputFile = createInputFile("multiple.html", content);
+    scan(tester, inputFile, content);
+
+    List<IssueResolution> issueResolutions = issueResolutions(tester, inputFile);
+    assertThat(issueResolutions).hasSize(2);
+    assertThat(issueResolutions.get(0).status()).isEqualTo(IssueResolution.Status.DEFAULT);
+    assertThat(issueResolutions.get(0).ruleKeys()).containsExactly(RuleKey.of(HtmlRulesDefinition.REPOSITORY_KEY, "S5256"));
+    assertThat(issueResolutions.get(0).comment()).isEqualTo("accept reason");
+    assertThat(issueResolutions.get(0).textRange().start().line()).isEqualTo(3);
+    assertThat(issueResolutions.get(1).status()).isEqualTo(IssueResolution.Status.FALSE_POSITIVE);
+    assertThat(issueResolutions.get(1).ruleKeys()).containsExactly(RuleKey.of(HtmlRulesDefinition.REPOSITORY_KEY, "S1827"));
+    assertThat(issueResolutions.get(1).comment()).isEqualTo("false positive reason");
+    assertThat(issueResolutions.get(1).textRange().start().line()).isEqualTo(4);
+  }
+
+  @Test
+  void scan_multiline_jsp_directive() throws IOException {
+    String content = String.join("\n",
+      "<%--",
+      "SONAR-RESOLVE",
+      "[FP] Web:S5256 \"first",
+      "second\"",
+      "--%>");
+
+    SensorContextTester tester = newSensorContext();
+    InputFile inputFile = createInputFile("multiline.jsp", content);
+    scan(tester, inputFile, content);
+
+    assertThat(issueResolutions(tester, inputFile)).singleElement().satisfies(issueResolution -> {
+      assertThat(issueResolution.status()).isEqualTo(IssueResolution.Status.FALSE_POSITIVE);
+      assertThat(issueResolution.ruleKeys()).containsExactly(RuleKey.of(HtmlRulesDefinition.REPOSITORY_KEY, "S5256"));
+      assertThat(issueResolution.comment()).isEqualTo("first\nsecond");
+      assertThat(issueResolution.textRange().start().line()).isEqualTo(2);
+    });
+  }
+
+  @Test
+  void invalid_directive_logs_warning_and_skips_resolution() throws IOException {
+    String content = String.join("\n",
+      "<table>",
+      "<!-- sonar-resolve Web:S5256 \"reason -->",
+      "</table>");
+
+    SensorContextTester tester = newSensorContext();
+    InputFile inputFile = createInputFile("invalid.html", content);
+    scan(tester, inputFile, content);
+
+    assertThat(issueResolutions(tester, inputFile)).isEmpty();
+    assertThat(logTester.logs()).anySatisfy(log -> assertThat(log)
+      .contains("Invalid sonar-resolve directive: unterminated justification")
+      .contains("line 2"));
+  }
+
+  @Test
+  void immediately_invalid_directive_logs_warning_and_skips_resolution() throws IOException {
+    String content = String.join("\n",
+      "<table>",
+      "<!-- sonar-resolve [accepted] Web:S5256 \"reason\" -->",
+      "</table>");
+
+    SensorContextTester tester = newSensorContext();
+    InputFile inputFile = createInputFile("invalid-status.html", content);
+    scan(tester, inputFile, content);
+
+    assertThat(issueResolutions(tester, inputFile)).isEmpty();
+    assertThat(logTester.logs()).anySatisfy(log -> assertThat(log)
+      .contains("Invalid sonar-resolve directive: invalid status '[accepted]'")
+      .contains("line 2"));
+  }
+
+  @Test
+  void regular_comments_are_ignored() throws IOException {
+    String content = String.join("\n",
+      "<table>",
+      "<!-- regular comment -->",
+      "</table>");
+
+    SensorContextTester tester = newSensorContext();
+    InputFile inputFile = createInputFile("regular-comment.html", content);
+    scan(tester, inputFile, content);
+
+    assertThat(issueResolutions(tester, inputFile)).isEmpty();
+    assertThat(logTester.logs()).noneMatch(log -> log.contains("Invalid sonar-resolve directive"));
+  }
+
+  @Test
+  void comments_with_embedded_keyword_are_ignored() throws IOException {
+    String content = String.join("\n",
+      "<table>",
+      "<!-- keep sonar-resolve Web:S5256 \"reason\" as documentation -->",
+      "</table>");
+
+    SensorContextTester tester = newSensorContext();
+    InputFile inputFile = createInputFile("embedded-keyword.html", content);
+    scan(tester, inputFile, content);
+
+    assertThat(issueResolutions(tester, inputFile)).isEmpty();
+    assertThat(logTester.logs()).noneMatch(log -> log.contains("Invalid sonar-resolve directive"));
+  }
+
+  @Test
+  void malformed_directive_start_still_logs_warning() throws IOException {
+    String content = String.join("\n",
+      "<table>",
+      "<!-- sonar-resolve[fp] Web:S5256 \"reason\" -->",
+      "</table>");
+
+    SensorContextTester tester = newSensorContext();
+    InputFile inputFile = createInputFile("missing-space.html", content);
+    scan(tester, inputFile, content);
+
+    assertThat(issueResolutions(tester, inputFile)).isEmpty();
+    assertThat(logTester.logs()).anySatisfy(log -> assertThat(log)
+      .contains("Invalid sonar-resolve directive: expected whitespace after 'sonar-resolve'")
+      .contains("line 2"));
+  }
+
+  private static void scan(SensorContextTester tester, InputFile inputFile, String content) throws IOException {
+    List<Node> nodeList;
+    try (Reader reader = new StringReader(content)) {
+      nodeList = new PageLexer().parse(reader);
+    }
+
+    HtmlAstScanner scanner = new HtmlAstScanner(Collections.emptyList());
+    scanner.addVisitor(new SonarResolveScanner(tester));
+    scanner.scan(nodeList, new HtmlSourceCode(inputFile));
+  }
+
+  private static SensorContextTester newSensorContext() {
+    return SensorContextTester.create(Paths.get("."))
+      .setRuntime(SonarRuntimeImpl.forSonarQube(Version.create(13, 6), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY));
+  }
+
+  private static InputFile createInputFile(String fileName, String content) {
+    return new TestInputFileBuilder("key", fileName)
+      .setModuleBaseDir(Paths.get("."))
+      .setContents(content)
+      .setLanguage(HtmlConstants.LANGUAGE_KEY)
+      .setType(InputFile.Type.MAIN)
+      .setCharset(StandardCharsets.UTF_8)
+      .build();
+  }
+
+  private static List<IssueResolution> issueResolutions(SensorContextTester tester, InputFile inputFile) {
+    return tester.getIssueResolutions().getOrDefault(inputFile.key(), Collections.emptyList());
+  }
+}

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/visitor/SonarResolveScannerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/visitor/SonarResolveScannerTest.java
@@ -99,6 +99,32 @@ class SonarResolveScannerTest {
     });
   }
 
+  @Test
+  void scan_directives_with_multiple_justification_delimiters() throws IOException {
+    String content = String.join("\n",
+      "<table>",
+      "<!--",
+      "sonar-resolve Web:S110 `backtick`",
+      "sonar-resolve Web:S111 'single quote'",
+      "sonar-resolve Web:S112 (parentheses)",
+      "sonar-resolve Web:S113 [square bracket]",
+      "sonar-resolve Web:S114 {brace}",
+      "-->",
+      "</table>");
+
+    SensorContextTester tester = newSensorContext();
+    InputFile inputFile = createInputFile("delimiters.html", content);
+    scan(tester, inputFile, content);
+
+    List<IssueResolution> issueResolutions = issueResolutions(tester, inputFile);
+    assertThat(issueResolutions).hasSize(5);
+    assertResolution(issueResolutions.get(0), "S110", "backtick", 3);
+    assertResolution(issueResolutions.get(1), "S111", "single quote", 4);
+    assertResolution(issueResolutions.get(2), "S112", "parentheses", 5);
+    assertResolution(issueResolutions.get(3), "S113", "square bracket", 6);
+    assertResolution(issueResolutions.get(4), "S114", "brace", 7);
+  }
+
   @ParameterizedTest
   @MethodSource("singleLineInvalidDirectiveCases")
   void invalid_single_line_directives_log_warning(String directive, String expectedErrorMessage) throws IOException {
@@ -155,6 +181,13 @@ class SonarResolveScannerTest {
   private static SensorContextTester newSensorContext() {
     return SensorContextTester.create(Paths.get("."))
       .setRuntime(SonarRuntimeImpl.forSonarQube(Version.create(13, 6), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY));
+  }
+
+  private static void assertResolution(IssueResolution issueResolution, String ruleKey, String comment, int line) {
+    assertThat(issueResolution.status()).isEqualTo(IssueResolution.Status.DEFAULT);
+    assertThat(issueResolution.ruleKeys()).containsExactly(RuleKey.of(HtmlRulesDefinition.REPOSITORY_KEY, ruleKey));
+    assertThat(issueResolution.comment()).isEqualTo(comment);
+    assertThat(issueResolution.textRange().start().line()).isEqualTo(line);
   }
 
   private void assertInvalidDirectiveLogsWarning(String expectedErrorMessage, String... directiveLines) throws IOException {


### PR DESCRIPTION
Part of MMF-4313

## Summary
- add a `SonarResolveScanner` that parses `sonar-resolve` directives from HTML and JSP comments
- wire issue resolution support in `HtmlSensor` only for SonarQube runtimes with API version `13.5+`
- cover valid directives, malformed directives, ordinary comments, runtime gating, delimiter variants, and indented multiline justifications with unit tests

## Related
- MMF-5422

## Testing
- `mvn test -Dtest=SonarResolveScannerTest -pl sonar-html-plugin`
- `mvn test -Dtest=HtmlSensorTest,SonarResolveScannerTest -pl sonar-html-plugin`
- `mvn test -pl sonar-html-plugin`
