### PR TITLE
SONARHTML-146 Explicit method on form rule

### DIFF
--- a/its/ruling/src/test/resources/expected/Web-S8699.json
+++ b/its/ruling/src/test/resources/expected/Web-S8699.json
@@ -1,0 +1,185 @@
+{
+"project:Silverpeas-Core-master/war-core/src/main/webapp/admin/jsp/TopBarSilverpeasV5.jsp": [
+227
+],
+"project:Silverpeas-Core-master/war-core/src/main/webapp/admin/jsp/cipherkey.jsp": [
+130
+],
+"project:Silverpeas-Core-master/war-core/src/main/webapp/clipboard/jsp/Idle.jsp": [
+186
+],
+"project:Silverpeas-Core-master/war-core/src/main/webapp/clipboard/jsp/IdleSilverpeasV5.jsp": [
+173
+],
+"project:Silverpeas-Core-master/war-core/src/main/webapp/genericPanelPeas/jsp/genericPanelPeas.jsp": [
+202
+],
+"project:Silverpeas-Core-master/war-core/src/main/webapp/interestCenterPeas/jsp/newICenter.jsp": [
+99
+],
+"project:Silverpeas-Core-master/war-core/src/main/webapp/jobStartPagePeas/jsp/jobStartPageNav.jsp": [
+76
+],
+"project:Silverpeas-Core-master/war-core/src/main/webapp/personalizationPeas/jsp/personalization_Notification.jsp": [
+191
+],
+"project:Silverpeas-Core-master/war-core/src/main/webapp/portlet/jsp/admin/colHeader.jsp": [
+116
+],
+"project:Silverpeas-Core-master/war-core/src/main/webapp/selectionPeas/jsp/selectionCart.jsp": [
+226
+],
+"project:Silverpeas-Core-master/war-core/src/main/webapp/socialNetwork/jsp/invitationDialog.jsp": [
+86
+],
+"project:Silverpeas-Core-master/war-core/src/main/webapp/socialNetwork/jsp/myProfil/myProfile.jsp": [
+219
+],
+"project:Silverpeas-Core-master/war-core/src/main/webapp/socialNetwork/jsp/notificationDialog.jsp": [
+91
+],
+"project:Silverpeas-Core-master/war-core/src/main/webapp/tools/domainSP2LDAP/domainSP2LDAP.jsp": [
+158
+],
+"project:Silverpeas-Core-master/war-core/src/main/webapp/webConnections/jsp/connection.jsp": [
+46
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLFormElement10.html": [
+8
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLFormElement10.xhtml": [
+10
+],
+"project:external_webkit-jb-mr1/LayoutTests/fast/dom/HTMLFormElement/adopt-assertion.html": [
+9
+],
+"project:external_webkit-jb-mr1/LayoutTests/fast/dom/HTMLFormElement/associated-elements-after-index-assertion-fail2.html": [
+15
+],
+"project:external_webkit-jb-mr1/LayoutTests/fast/dom/HTMLFormElement/htmlformelement-indexed-getter.html": [
+10
+],
+"project:external_webkit-jb-mr1/LayoutTests/fast/dom/HTMLLabelElement/form/test1.html": [
+38
+],
+"project:external_webkit-jb-mr1/LayoutTests/fast/encoding/percent-escaping.html": [
+9
+],
+"project:external_webkit-jb-mr1/PerformanceTests/SunSpider/resources/results-TEMPLATE.html": [
+46
+],
+"project:external_webkit-jb-mr1/Source/JavaScriptCore/tests/mozilla/importList.html": [
+53
+],
+"project:external_webkit-jb-mr1/Source/JavaScriptCore/tests/mozilla/menuhead.html": [
+135
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/autofill-popup-location.html": [
+18
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/bugzilla-3855.html": [
+21
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/chromium/no-autofill-on-readonly.html": [
+15,
+21,
+27
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/clear-input-file.html": [
+20
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/disabled-option-elements.html": [
+3
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/form-control-madness.html": [
+5
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/input-type-datetime-default-value.html": [
+7
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/input-type-file-autocomplete-frame-2.html": [
+4
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/liveconnect-applet-array-parameters.html": [
+10
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/log-keypress-events.html": [
+4
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/modal-dialog.html": [
+20
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/no-listbox-rendering.html": [
+10
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/onblur-remove.html": [
+26
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/onunload-form-submit-crash.html": [
+5
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/remove-input-file-onchange.html": [
+33
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/select-option-in-onload.html": [
+21
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/show-modal-dialog-test.html": [
+9
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/submit-form-with-target-twice.html": [
+10
+],
+"project:external_webkit-jb-mr1/Source/WebKit/chromium/tests/data/pageserialization/simple_page.html": [
+23
+],
+"project:external_webkit-jb-mr1/Source/WebKit/gtk/resources/error.html": [
+53
+],
+"project:external_webkit-jb-mr1/Tools/CSSTestSuiteHarness/harness/harness.html": [
+162
+],
+"project:sonar-master/plugins/sonar-core-plugin/src/main/resources/org/sonar/plugins/core/widgets/complexity.html.erb": [
+75
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/dependencies/index.html.erb": [
+28
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/issue/_assign_form.html.erb": [
+2
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/issue/_comment_form.html.erb": [
+1
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/issue/_create_form.html.erb": [
+7
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/issue/_edit_comment_form.html.erb": [
+1
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/issue/_severity_form.html.erb": [
+1
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/rules_configuration/_rule.html.erb": [
+2
+],
+"project:voten/resources/assets/js/components/CommentForm.vue": [
+38
+],
+"project:voten/resources/assets/js/components/Messages.vue": [
+226
+],
+"project:voten/resources/assets/js/components/passport/Clients.vue": [
+100,
+168
+],
+"project:voten/resources/assets/js/components/passport/PersonalAccessTokens.vue": [
+83
+],
+"project:voten/resources/views/backend/channels.blade.php": [
+16
+],
+"project:voten/resources/views/backend/users.blade.php": [
+16
+]
+}

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/FormMethodAttributeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/FormMethodAttributeCheck.java
@@ -68,46 +68,42 @@ public class FormMethodAttributeCheck extends AbstractPageCheck {
       return;
     }
     String thAttrValue = node.getAttribute("th:attr");
-    String thAttrMethodValue = thAttrValue == null ? null : extractThAttrMethodValue(thAttrValue);
-    if (thAttrMethodValue == null) {
+    if (thAttrValue == null) {
       createViolation(node, MESSAGE);
       return;
     }
-    if (isThymeleafExpression(thAttrMethodValue)) {
-      return;
-    }
-    if (!isValidMethod(thAttrMethodValue)) {
-      createViolation(node, MESSAGE);
-    }
-  }
-
-  private static String extractThAttrMethodValue(String thAttrValue) {
     Matcher matcher = TH_ATTR_METHOD_PATTERN.matcher(thAttrValue);
     if (!matcher.find()) {
-      return null;
+      createViolation(node, MESSAGE);
+      return;
     }
-    return unwrapSingleQuotes(matcher.group(1).trim());
+    String staticValue = staticThymeleafValue(matcher.group(1).trim());
+    if (staticValue == null) {
+      return;
+    }
+    if (!isValidMethod(staticValue)) {
+      createViolation(node, MESSAGE);
+    }
   }
 
-  private static String unwrapSingleQuotes(String value) {
+  private static String staticThymeleafValue(String value) {
+    if (value.startsWith("${") || value.startsWith("*{")
+      || value.startsWith("#{") || value.startsWith("@{")
+      || value.startsWith("~{")) {
+      return null;
+    }
     int len = value.length();
-    if (len >= 2 && value.charAt(0) == '\'' && value.charAt(len - 1) == '\'') {
+    if (len >= 2 && value.charAt(0) == '\'' && value.charAt(len - 1) == '\''
+      && value.indexOf('\'', 1) == len - 1) {
       return value.substring(1, len - 1);
     }
-    return value;
+    if (value.isEmpty() || PLAIN_TOKEN_PATTERN.matcher(value).matches()) {
+      return value;
+    }
+    return null;
   }
 
   private static boolean isValidMethod(String value) {
     return VALID_METHODS.contains(value.trim().toLowerCase(Locale.ROOT));
-  }
-
-  private static boolean isThymeleafExpression(String value) {
-    if (value.isEmpty()) {
-      return false;
-    }
-    return value.startsWith("${") || value.startsWith("*{")
-      || value.startsWith("#{") || value.startsWith("@{")
-      || value.startsWith("~{")
-      || !PLAIN_TOKEN_PATTERN.matcher(value).matches();
   }
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/FormMethodAttributeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/FormMethodAttributeCheck.java
@@ -1,0 +1,61 @@
+/*
+ * SonarQube HTML
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.html.checks.attributes;
+
+import java.util.Locale;
+import java.util.Set;
+import org.sonar.check.Rule;
+import org.sonar.plugins.html.api.Helpers;
+import org.sonar.plugins.html.checks.AbstractPageCheck;
+import org.sonar.plugins.html.node.Attribute;
+import org.sonar.plugins.html.node.TagNode;
+
+@Rule(key = "S8699")
+public class FormMethodAttributeCheck extends AbstractPageCheck {
+
+  private static final String METHOD_ATTRIBUTE = "method";
+  private static final Set<String> VALID_METHODS = Set.of("get", "post", "dialog");
+  private static final String MESSAGE = "Use an explicit valid \"method\" attribute on this \"<form>\" tag (\"get\", \"post\", or \"dialog\").";
+
+  @Override
+  public void startElement(TagNode node) {
+    if (!node.equalsElementName("form")) {
+      return;
+    }
+
+    Attribute methodAttribute = node.getProperty(METHOD_ATTRIBUTE);
+    if (methodAttribute == null) {
+      createViolation(node, MESSAGE);
+      return;
+    }
+
+    if (isDynamicMethod(methodAttribute)) {
+      return;
+    }
+
+    String methodValue = methodAttribute.getValue();
+    if (methodValue == null || !VALID_METHODS.contains(methodValue.trim().toLowerCase(Locale.ROOT))) {
+      createViolation(node, MESSAGE);
+    }
+  }
+
+  private boolean isDynamicMethod(Attribute methodAttribute) {
+    return !METHOD_ATTRIBUTE.equalsIgnoreCase(methodAttribute.getName())
+      || isUnifiedExpression(methodAttribute.getValue())
+      || Helpers.isDynamicValue(methodAttribute.getValue(), getHtmlSourceCode());
+  }
+}

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/FormMethodAttributeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/FormMethodAttributeCheck.java
@@ -33,6 +33,7 @@ public class FormMethodAttributeCheck extends AbstractPageCheck {
   private static final Set<String> VALID_METHODS = Set.of("get", "post", "dialog");
   private static final Pattern TH_ATTR_METHOD_PATTERN =
     Pattern.compile("(?:^|,)\\s*method\\s*=([^,]*)", Pattern.CASE_INSENSITIVE);
+  private static final Pattern PLAIN_TOKEN_PATTERN = Pattern.compile("[A-Za-z]+");
   private static final String MESSAGE = "Use an explicit valid \"method\" attribute on this \"<form>\" tag (\"get\", \"post\", or \"dialog\").";
 
   @Override
@@ -82,7 +83,18 @@ public class FormMethodAttributeCheck extends AbstractPageCheck {
 
   private static String extractThAttrMethodValue(String thAttrValue) {
     Matcher matcher = TH_ATTR_METHOD_PATTERN.matcher(thAttrValue);
-    return matcher.find() ? matcher.group(1).trim() : null;
+    if (!matcher.find()) {
+      return null;
+    }
+    return unwrapSingleQuotes(matcher.group(1).trim());
+  }
+
+  private static String unwrapSingleQuotes(String value) {
+    int len = value.length();
+    if (len >= 2 && value.charAt(0) == '\'' && value.charAt(len - 1) == '\'') {
+      return value.substring(1, len - 1);
+    }
+    return value;
   }
 
   private static boolean isValidMethod(String value) {
@@ -90,8 +102,12 @@ public class FormMethodAttributeCheck extends AbstractPageCheck {
   }
 
   private static boolean isThymeleafExpression(String value) {
+    if (value.isEmpty()) {
+      return false;
+    }
     return value.startsWith("${") || value.startsWith("*{")
       || value.startsWith("#{") || value.startsWith("@{")
-      || value.startsWith("~{");
+      || value.startsWith("~{")
+      || !PLAIN_TOKEN_PATTERN.matcher(value).matches();
   }
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/FormMethodAttributeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/FormMethodAttributeCheck.java
@@ -18,6 +18,7 @@ package org.sonar.plugins.html.checks.attributes;
 
 import java.util.Locale;
 import java.util.Set;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.api.Helpers;
@@ -30,7 +31,8 @@ public class FormMethodAttributeCheck extends AbstractPageCheck {
 
   private static final String METHOD_ATTRIBUTE = "method";
   private static final Set<String> VALID_METHODS = Set.of("get", "post", "dialog");
-  private static final Pattern TH_ATTR_METHOD_PATTERN = Pattern.compile("(^|,)\\s*method\\s*=", Pattern.CASE_INSENSITIVE);
+  private static final Pattern TH_ATTR_METHOD_PATTERN =
+    Pattern.compile("(?:^|,)\\s*method\\s*=([^,]*)", Pattern.CASE_INSENSITIVE);
   private static final String MESSAGE = "Use an explicit valid \"method\" attribute on this \"<form>\" tag (\"get\", \"post\", or \"dialog\").";
 
   @Override
@@ -41,9 +43,7 @@ public class FormMethodAttributeCheck extends AbstractPageCheck {
 
     Attribute methodAttribute = node.getProperty(METHOD_ATTRIBUTE);
     if (methodAttribute == null) {
-      if (!hasThymeleafMethod(node)) {
-        createViolation(node, MESSAGE);
-      }
+      checkThymeleafMethod(node);
       return;
     }
 
@@ -51,8 +51,7 @@ public class FormMethodAttributeCheck extends AbstractPageCheck {
       return;
     }
 
-    String methodValue = methodAttribute.getValue();
-    if (methodValue == null || !VALID_METHODS.contains(methodValue.trim().toLowerCase(Locale.ROOT))) {
+    if (!isValidMethod(methodAttribute.getValue())) {
       createViolation(node, MESSAGE);
     }
   }
@@ -63,9 +62,36 @@ public class FormMethodAttributeCheck extends AbstractPageCheck {
       || Helpers.isDynamicValue(methodAttribute.getValue(), getHtmlSourceCode());
   }
 
-  private static boolean hasThymeleafMethod(TagNode node) {
+  private void checkThymeleafMethod(TagNode node) {
+    if (node.hasProperty("th:method")) {
+      return;
+    }
     String thAttrValue = node.getAttribute("th:attr");
-    return node.hasProperty("th:method")
-      || (thAttrValue != null && TH_ATTR_METHOD_PATTERN.matcher(thAttrValue).find());
+    String thAttrMethodValue = thAttrValue == null ? null : extractThAttrMethodValue(thAttrValue);
+    if (thAttrMethodValue == null) {
+      createViolation(node, MESSAGE);
+      return;
+    }
+    if (isThymeleafExpression(thAttrMethodValue)) {
+      return;
+    }
+    if (!isValidMethod(thAttrMethodValue)) {
+      createViolation(node, MESSAGE);
+    }
+  }
+
+  private static String extractThAttrMethodValue(String thAttrValue) {
+    Matcher matcher = TH_ATTR_METHOD_PATTERN.matcher(thAttrValue);
+    return matcher.find() ? matcher.group(1).trim() : null;
+  }
+
+  private static boolean isValidMethod(String value) {
+    return value != null && VALID_METHODS.contains(value.trim().toLowerCase(Locale.ROOT));
+  }
+
+  private static boolean isThymeleafExpression(String value) {
+    return value.startsWith("${") || value.startsWith("*{")
+      || value.startsWith("#{") || value.startsWith("@{")
+      || value.startsWith("~{");
   }
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/FormMethodAttributeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/FormMethodAttributeCheck.java
@@ -86,7 +86,7 @@ public class FormMethodAttributeCheck extends AbstractPageCheck {
   }
 
   private static boolean isValidMethod(String value) {
-    return value != null && VALID_METHODS.contains(value.trim().toLowerCase(Locale.ROOT));
+    return VALID_METHODS.contains(value.trim().toLowerCase(Locale.ROOT));
   }
 
   private static boolean isThymeleafExpression(String value) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/FormMethodAttributeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/FormMethodAttributeCheck.java
@@ -18,6 +18,7 @@ package org.sonar.plugins.html.checks.attributes;
 
 import java.util.Locale;
 import java.util.Set;
+import java.util.regex.Pattern;
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.api.Helpers;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
@@ -29,6 +30,7 @@ public class FormMethodAttributeCheck extends AbstractPageCheck {
 
   private static final String METHOD_ATTRIBUTE = "method";
   private static final Set<String> VALID_METHODS = Set.of("get", "post", "dialog");
+  private static final Pattern TH_ATTR_METHOD_PATTERN = Pattern.compile("(^|,)\\s*method\\s*=", Pattern.CASE_INSENSITIVE);
   private static final String MESSAGE = "Use an explicit valid \"method\" attribute on this \"<form>\" tag (\"get\", \"post\", or \"dialog\").";
 
   @Override
@@ -64,6 +66,6 @@ public class FormMethodAttributeCheck extends AbstractPageCheck {
   private static boolean hasThymeleafMethod(TagNode node) {
     String thAttrValue = node.getAttribute("th:attr");
     return node.hasProperty("th:method")
-      || (thAttrValue != null && thAttrValue.contains("method="));
+      || (thAttrValue != null && TH_ATTR_METHOD_PATTERN.matcher(thAttrValue).find());
   }
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/FormMethodAttributeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/attributes/FormMethodAttributeCheck.java
@@ -39,7 +39,9 @@ public class FormMethodAttributeCheck extends AbstractPageCheck {
 
     Attribute methodAttribute = node.getProperty(METHOD_ATTRIBUTE);
     if (methodAttribute == null) {
-      createViolation(node, MESSAGE);
+      if (!hasThymeleafMethod(node)) {
+        createViolation(node, MESSAGE);
+      }
       return;
     }
 
@@ -57,5 +59,11 @@ public class FormMethodAttributeCheck extends AbstractPageCheck {
     return !METHOD_ATTRIBUTE.equalsIgnoreCase(methodAttribute.getName())
       || isUnifiedExpression(methodAttribute.getValue())
       || Helpers.isDynamicValue(methodAttribute.getValue(), getHtmlSourceCode());
+  }
+
+  private static boolean hasThymeleafMethod(TagNode node) {
+    String thAttrValue = node.getAttribute("th:attr");
+    return node.hasProperty("th:method")
+      || (thAttrValue != null && thAttrValue.contains("method="));
   }
 }

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S8699.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S8699.html
@@ -1,0 +1,40 @@
+<h2>Why is this an issue?</h2>
+<p>When a <code>&lt;form&gt;</code> tag omits its <code>method</code> attribute, browsers submit it with <code>GET</code> by default.
+That behavior is well defined, but it makes the form's intent implicit.</p>
+<p>Empty or invalid <code>method</code> values are also problematic because HTML falls back to <code>GET</code> for them.
+This can make the markup misleading: the source code looks intentional, but the browser will not use the declared method.</p>
+<p>Using an explicit valid method makes form behavior easier to understand and avoids accidental fallback to <code>GET</code>.</p>
+<h2>How to fix it</h2>
+<p>Add a <code>method</code> attribute to each <code>&lt;form&gt;</code> tag and use one of the HTML-valid values:
+<code>get</code>, <code>post</code>, or <code>dialog</code>.</p>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+&lt;form action="/search"&gt;
+  ...
+&lt;/form&gt;
+</pre>
+<pre data-diff-id="2" data-diff-type="noncompliant">
+&lt;form method="put"&gt;
+  ...
+&lt;/form&gt;
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+&lt;form action="/search" method="get"&gt;
+  ...
+&lt;/form&gt;
+</pre>
+<pre data-diff-id="2" data-diff-type="compliant">
+&lt;form method="post"&gt;
+  ...
+&lt;/form&gt;
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li>HTML Standard - <a href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element">The <code>form</code> element</a></li>
+  <li>HTML Standard - <a href="https://html.spec.whatwg.org/multipage/forms.html#attr-fs-method">The <code>method</code> attribute</a></li>
+  <li>MDN - <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#method">The <code>form</code> element:
+  <code>method</code></a></li>
+</ul>

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S8699.json
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S8699.json
@@ -12,7 +12,7 @@
   "defaultSeverity": "Minor",
   "ruleSpecification": "RSPEC-8699",
   "sqKey": "S8699",
-  "scope": "All",
+  "scope": "Main",
   "defaultQualityProfiles": [],
   "quickfix": "unknown",
   "code": {

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S8699.json
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S8699.json
@@ -1,0 +1,25 @@
+{
+  "title": "\"<form>\" tags should have an explicit valid \"method\" attribute",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "2min"
+  },
+  "tags": [
+    "convention"
+  ],
+  "defaultSeverity": "Minor",
+  "ruleSpecification": "RSPEC-8699",
+  "sqKey": "S8699",
+  "scope": "All",
+  "defaultQualityProfiles": [],
+  "quickfix": "unknown",
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "LOW",
+      "RELIABILITY": "LOW"
+    },
+    "attribute": "CONVENTIONAL"
+  }
+}

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/FormMethodAttributeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/FormMethodAttributeCheckTest.java
@@ -77,6 +77,8 @@ class FormMethodAttributeCheckTest {
       .next().atLine(3).withMessage(MESSAGE)
       .next().atLine(4).withMessage(MESSAGE)
       .next().atLine(5).withMessage(MESSAGE)
+      .next().atLine(6).withMessage(MESSAGE)
+      .next().atLine(7).withMessage(MESSAGE)
       .noMore();
   }
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/FormMethodAttributeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/FormMethodAttributeCheckTest.java
@@ -56,6 +56,16 @@ class FormMethodAttributeCheckTest {
   }
 
   @Test
+  void thymeleafValues() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/FormMethodAttributeCheck/thymeleaf.html"),
+      new FormMethodAttributeCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .noMore();
+  }
+
+  @Test
   void dynamicValues() {
     HtmlSourceCode cshtmlSourceCode = TestHelper.scan(
       new File("src/test/resources/checks/FormMethodAttributeCheck/dynamic.cshtml"),

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/FormMethodAttributeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/FormMethodAttributeCheckTest.java
@@ -73,6 +73,10 @@ class FormMethodAttributeCheckTest {
 
     checkMessagesVerifier.verify(sourceCode.getIssues())
       .next().atLine(1).withMessage(MESSAGE)
+      .next().atLine(2).withMessage(MESSAGE)
+      .next().atLine(3).withMessage(MESSAGE)
+      .next().atLine(4).withMessage(MESSAGE)
+      .next().atLine(5).withMessage(MESSAGE)
       .noMore();
   }
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/FormMethodAttributeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/FormMethodAttributeCheckTest.java
@@ -66,6 +66,17 @@ class FormMethodAttributeCheckTest {
   }
 
   @Test
+  void thymeleafInvalidValues() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/FormMethodAttributeCheck/thymeleaf-invalid.html"),
+      new FormMethodAttributeCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(1).withMessage(MESSAGE)
+      .noMore();
+  }
+
+  @Test
   void dynamicValues() {
     HtmlSourceCode cshtmlSourceCode = TestHelper.scan(
       new File("src/test/resources/checks/FormMethodAttributeCheck/dynamic.cshtml"),

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/FormMethodAttributeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/FormMethodAttributeCheckTest.java
@@ -1,0 +1,73 @@
+/*
+ * SonarQube HTML
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.html.checks.attributes;
+
+import java.io.File;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.sonar.plugins.html.checks.CheckMessagesVerifierRule;
+import org.sonar.plugins.html.checks.TestHelper;
+import org.sonar.plugins.html.visitor.HtmlSourceCode;
+
+class FormMethodAttributeCheckTest {
+
+  private static final String MESSAGE = "Use an explicit valid \"method\" attribute on this \"<form>\" tag (\"get\", \"post\", or \"dialog\").";
+
+  @RegisterExtension
+  public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
+
+  @Test
+  void invalid() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/FormMethodAttributeCheck/invalid.html"),
+      new FormMethodAttributeCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(2).withMessage(MESSAGE)
+      .next().atLine(5).withMessage(MESSAGE)
+      .next().atLine(8).withMessage(MESSAGE)
+      .next().atLine(11).withMessage(MESSAGE)
+      .noMore();
+  }
+
+  @Test
+  void valid() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/FormMethodAttributeCheck/valid.html"),
+      new FormMethodAttributeCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .noMore();
+  }
+
+  @Test
+  void dynamicValues() {
+    HtmlSourceCode cshtmlSourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/FormMethodAttributeCheck/dynamic.cshtml"),
+      new FormMethodAttributeCheck());
+
+    checkMessagesVerifier.verify(cshtmlSourceCode.getIssues())
+      .noMore();
+
+    HtmlSourceCode jspSourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/FormMethodAttributeCheck/dynamic.jsp"),
+      new FormMethodAttributeCheck());
+
+    checkMessagesVerifier.verify(jspSourceCode.getIssues())
+      .noMore();
+  }
+}

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/FormMethodAttributeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/FormMethodAttributeCheckTest.java
@@ -79,6 +79,7 @@ class FormMethodAttributeCheckTest {
       .next().atLine(5).withMessage(MESSAGE)
       .next().atLine(6).withMessage(MESSAGE)
       .next().atLine(7).withMessage(MESSAGE)
+      .next().atLine(8).withMessage(MESSAGE)
       .noMore();
   }
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/FormMethodAttributeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/attributes/FormMethodAttributeCheckTest.java
@@ -41,6 +41,7 @@ class FormMethodAttributeCheckTest {
       .next().atLine(5).withMessage(MESSAGE)
       .next().atLine(8).withMessage(MESSAGE)
       .next().atLine(11).withMessage(MESSAGE)
+      .next().atLine(14).withMessage(MESSAGE)
       .noMore();
   }
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlSensorTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlSensorTest.java
@@ -120,7 +120,7 @@ class HtmlSensorTest {
     assertThat(tester.highlightingTypeAt(componentKey, 29, 17)).containsOnly(TypeOfText.STRING);
     assertThat(tester.highlightingTypeAt(componentKey, 29, 0)).containsOnly(TypeOfText.KEYWORD);
 
-    assertThat(tester.allIssues()).hasSize(106);
+    assertThat(tester.allIssues()).hasSize(107);
     assertThat(tester.allAnalysisErrors()).isEmpty();
   }
 

--- a/sonar-html-plugin/src/test/resources/checks/FormMethodAttributeCheck/dynamic.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/FormMethodAttributeCheck/dynamic.cshtml
@@ -1,0 +1,1 @@
+<form method="@Model.HttpMethod"></form>

--- a/sonar-html-plugin/src/test/resources/checks/FormMethodAttributeCheck/dynamic.jsp
+++ b/sonar-html-plugin/src/test/resources/checks/FormMethodAttributeCheck/dynamic.jsp
@@ -1,0 +1,3 @@
+<form method="<%= method %>"></form>
+<form method="${method}"></form>
+<form method="#{bean.httpMethod}"></form>

--- a/sonar-html-plugin/src/test/resources/checks/FormMethodAttributeCheck/invalid.html
+++ b/sonar-html-plugin/src/test/resources/checks/FormMethodAttributeCheck/invalid.html
@@ -1,0 +1,12 @@
+<!-- Missing -->
+<form>
+</form>
+
+<form method="">
+</form>
+
+<form method>
+</form>
+
+<form method="put">
+</form>

--- a/sonar-html-plugin/src/test/resources/checks/FormMethodAttributeCheck/invalid.html
+++ b/sonar-html-plugin/src/test/resources/checks/FormMethodAttributeCheck/invalid.html
@@ -10,3 +10,6 @@
 
 <form method="put">
 </form>
+
+<form method="foo">
+</form>

--- a/sonar-html-plugin/src/test/resources/checks/FormMethodAttributeCheck/thymeleaf-invalid.html
+++ b/sonar-html-plugin/src/test/resources/checks/FormMethodAttributeCheck/thymeleaf-invalid.html
@@ -1,1 +1,5 @@
 <form th:attr="formmethod=post"></form>
+<form th:attr="method=put"></form>
+<form th:attr="method=foo"></form>
+<form th:attr="action=@{/search},method=delete"></form>
+<form th:attr="method="></form>

--- a/sonar-html-plugin/src/test/resources/checks/FormMethodAttributeCheck/thymeleaf-invalid.html
+++ b/sonar-html-plugin/src/test/resources/checks/FormMethodAttributeCheck/thymeleaf-invalid.html
@@ -5,3 +5,4 @@
 <form th:attr="method="></form>
 <form th:attr="method='put'"></form>
 <form th:attr="method='foo'"></form>
+<form th:attr="method='foo-bar'"></form>

--- a/sonar-html-plugin/src/test/resources/checks/FormMethodAttributeCheck/thymeleaf-invalid.html
+++ b/sonar-html-plugin/src/test/resources/checks/FormMethodAttributeCheck/thymeleaf-invalid.html
@@ -1,0 +1,1 @@
+<form th:attr="formmethod=post"></form>

--- a/sonar-html-plugin/src/test/resources/checks/FormMethodAttributeCheck/thymeleaf-invalid.html
+++ b/sonar-html-plugin/src/test/resources/checks/FormMethodAttributeCheck/thymeleaf-invalid.html
@@ -3,3 +3,5 @@
 <form th:attr="method=foo"></form>
 <form th:attr="action=@{/search},method=delete"></form>
 <form th:attr="method="></form>
+<form th:attr="method='put'"></form>
+<form th:attr="method='foo'"></form>

--- a/sonar-html-plugin/src/test/resources/checks/FormMethodAttributeCheck/thymeleaf.html
+++ b/sonar-html-plugin/src/test/resources/checks/FormMethodAttributeCheck/thymeleaf.html
@@ -1,0 +1,3 @@
+<form th:method="${submitMethod}"></form>
+<form th:attr="method=post"></form>
+<form th:attr="action=@{/search},method=${submitMethod}"></form>

--- a/sonar-html-plugin/src/test/resources/checks/FormMethodAttributeCheck/thymeleaf.html
+++ b/sonar-html-plugin/src/test/resources/checks/FormMethodAttributeCheck/thymeleaf.html
@@ -6,3 +6,8 @@
 <form th:attr="action=@{/search},method=${submitMethod}"></form>
 <form th:attr="method=*{submitMethod}"></form>
 <form th:attr="method=#{form.method}"></form>
+<form th:attr="method='post'"></form>
+<form th:attr="method='GET'"></form>
+<form th:attr="method=(condition) ? 'post' : 'get'"></form>
+<form th:attr="method='po' + 'st'"></form>
+<form th:attr="action=@{/x},method='dialog'"></form>

--- a/sonar-html-plugin/src/test/resources/checks/FormMethodAttributeCheck/thymeleaf.html
+++ b/sonar-html-plugin/src/test/resources/checks/FormMethodAttributeCheck/thymeleaf.html
@@ -1,3 +1,8 @@
 <form th:method="${submitMethod}"></form>
+<form th:method="put"></form>
+<form th:method="delete"></form>
 <form th:attr="method=post"></form>
+<form th:attr="method=GET"></form>
 <form th:attr="action=@{/search},method=${submitMethod}"></form>
+<form th:attr="method=*{submitMethod}"></form>
+<form th:attr="method=#{form.method}"></form>

--- a/sonar-html-plugin/src/test/resources/checks/FormMethodAttributeCheck/valid.html
+++ b/sonar-html-plugin/src/test/resources/checks/FormMethodAttributeCheck/valid.html
@@ -1,0 +1,7 @@
+<form method="post"></form>
+<form method="GET"></form>
+<form method=" Dialog "></form>
+<form :method="submitMethod"></form>
+<form [method]="submitMethod"></form>
+<form v-bind:method="submitMethod"></form>
+<form [attr.method]="submitMethod"></form>

--- a/sonar-html-plugin/src/test/resources/checks/FormMethodAttributeCheck/valid.html
+++ b/sonar-html-plugin/src/test/resources/checks/FormMethodAttributeCheck/valid.html
@@ -5,6 +5,7 @@
 <form method="gEt"></form>
 <form method=" Dialog "></form>
 <form method="dIaLoG"></form>
+<form th:method="post"></form>
 <form :method="submitMethod"></form>
 <form [method]="submitMethod"></form>
 <form v-bind:method="submitMethod"></form>

--- a/sonar-html-plugin/src/test/resources/checks/FormMethodAttributeCheck/valid.html
+++ b/sonar-html-plugin/src/test/resources/checks/FormMethodAttributeCheck/valid.html
@@ -1,6 +1,10 @@
 <form method="post"></form>
+<form method="POST"></form>
+<form method="PoSt"></form>
 <form method="GET"></form>
+<form method="gEt"></form>
 <form method=" Dialog "></form>
+<form method="dIaLoG"></form>
 <form :method="submitMethod"></form>
 <form [method]="submitMethod"></form>
 <form v-bind:method="submitMethod"></form>


### PR DESCRIPTION
**Summary**
  This PR adds `S8699`, a new HTML rule that raises an issue when a `<form>` tag does not declare an explicit valid `method` attribute.

  **Changes**
  - Implement the `S8699` analyzer rule and its rule metadata.
  - Accept `get`, `post`, and `dialog` as valid methods, case-insensitively.
  - Avoid false positives on supported dynamic/template syntaxes.

  **Functional Validation**
  An attached `sonarhtml-146-fv.zip` contains a bundled copy of `sonar-html`, a sample noncompliant HTML file, and a reproducer script.

  Run it from the extracted folder:
  1. Unzip [sonarhtml-146-fv.zip](https://github.com/user-attachments/files/28090689/sonarhtml-146-fv.zip)

  2. `cd sonarhtml-146-fv`
  3. `./run-reproducer.sh`

  Expected output:
  ```text
  Analyzed file: sample/noncompliant-form.html
  Issue count: 1
  Rule Web:S8699 at line 4: Use an explicit valid "method" attribute on this "<form>" tag ("get", "post", or "dialog").