### PR TITLE
SONARHTML-168 Sync S5725 message wording

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/ResourceIntegrityCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/ResourceIntegrityCheck.java
@@ -26,7 +26,7 @@ import org.sonar.plugins.html.node.TagNode;
 @Rule(key = "S5725")
 public class ResourceIntegrityCheck extends AbstractPageCheck {
 
-  private static final String MESSAGE = "Make sure not using resource integrity feature is safe here.";
+  private static final String MESSAGE = "Make sure using artifacts without integrity checks is safe here.";
   private static final Set<String> LINK_REL_VALUES = Set.of("stylesheet", "preload", "modulepreload");
 
   @Override

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/security/ResourceIntegrityCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/security/ResourceIntegrityCheckTest.java
@@ -25,6 +25,8 @@ import org.sonar.plugins.html.visitor.HtmlSourceCode;
 
 class ResourceIntegrityCheckTest {
 
+  private static final String MESSAGE = "Make sure using artifacts without integrity checks is safe here.";
+
   @RegisterExtension
   public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
 
@@ -33,20 +35,20 @@ class ResourceIntegrityCheckTest {
     HtmlSourceCode sourceCode = TestHelper.scan(new File("src/test/resources/checks/resourceIntegrityCheck.html"), new ResourceIntegrityCheck());
 
     checkMessagesVerifier.verify(sourceCode.getIssues())
-      .next().atLocation(1, 0, 1, 47).withMessage("Make sure not using resource integrity feature is safe here.")
-      .next().atLocation(2, 0, 2, 41).withMessage("Make sure not using resource integrity feature is safe here.")
-      .next().atLocation(3, 0, 3, 46).withMessage("Make sure not using resource integrity feature is safe here.")
-      .next().atLocation(4, 0, 4, 61).withMessage("Make sure not using resource integrity feature is safe here.")
-      .next().atLocation(18, 0, 18, 64).withMessage("Make sure not using resource integrity feature is safe here.")
-      .next().atLocation(19, 0, 19, 58).withMessage("Make sure not using resource integrity feature is safe here.")
-      .next().atLocation(20, 0, 20, 63).withMessage("Make sure not using resource integrity feature is safe here.")
-      .next().atLocation(21, 0, 21, 64).withMessage("Make sure not using resource integrity feature is safe here.")
-      .next().atLocation(24, 0, 24, 72).withMessage("Make sure not using resource integrity feature is safe here.")
-      .next().atLocation(25, 0, 25, 67).withMessage("Make sure not using resource integrity feature is safe here.")
-      .next().atLocation(26, 0, 26, 72).withMessage("Make sure not using resource integrity feature is safe here.")
-      .next().atLocation(29, 0, 29, 67).withMessage("Make sure not using resource integrity feature is safe here.")
-      .next().atLocation(30, 0, 30, 61).withMessage("Make sure not using resource integrity feature is safe here.")
-      .next().atLocation(31, 0, 31, 67).withMessage("Make sure not using resource integrity feature is safe here.");
+      .next().atLocation(1, 0, 1, 47).withMessage(MESSAGE)
+      .next().atLocation(2, 0, 2, 41).withMessage(MESSAGE)
+      .next().atLocation(3, 0, 3, 46).withMessage(MESSAGE)
+      .next().atLocation(4, 0, 4, 61).withMessage(MESSAGE)
+      .next().atLocation(18, 0, 18, 64).withMessage(MESSAGE)
+      .next().atLocation(19, 0, 19, 58).withMessage(MESSAGE)
+      .next().atLocation(20, 0, 20, 63).withMessage(MESSAGE)
+      .next().atLocation(21, 0, 21, 64).withMessage(MESSAGE)
+      .next().atLocation(24, 0, 24, 72).withMessage(MESSAGE)
+      .next().atLocation(25, 0, 25, 67).withMessage(MESSAGE)
+      .next().atLocation(26, 0, 26, 72).withMessage(MESSAGE)
+      .next().atLocation(29, 0, 29, 67).withMessage(MESSAGE)
+      .next().atLocation(30, 0, 30, 61).withMessage(MESSAGE)
+      .next().atLocation(31, 0, 31, 67).withMessage(MESSAGE);
   }
 
 }


### PR DESCRIPTION
## Summary
This updates the remaining S5725 analyzer message to match the RSPEC wording already synced in rule metadata.

## Changes
- Update `ResourceIntegrityCheck` to use the new S5725 message text
- Update `ResourceIntegrityCheckTest` to expect the new wording for all reported issues
- Keep the repeated expected message in one test constant to avoid future drift

## Functional Validation
Attached: `SONARHTML-168-fv.zip`

Unzip and run:
    ./run.sh

Expected output is in `expected-output.txt`. The README shows the
before/after comparison so you can reproduce the difference directly.
