### PR TITLE
SONARHTML-382 Fix SonarLint AnalysisWarnings injection

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/HtmlPlugin.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/HtmlPlugin.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.sonar.api.Plugin;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.plugins.html.api.HtmlConstants;
+import org.sonar.plugins.html.core.AnalysisWarningsWrapper;
 import org.sonar.plugins.html.core.Html;
 import org.sonar.plugins.html.core.HtmlSensor;
 import org.sonar.plugins.html.core.Jsp;
@@ -51,6 +52,7 @@ public final class HtmlPlugin implements Plugin {
       JspQualityProfile.class,
 
       // web sensor
+      AnalysisWarningsWrapper.class,
       HtmlSensor.class
     );
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/AnalysisWarningsWrapper.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/AnalysisWarningsWrapper.java
@@ -1,0 +1,46 @@
+/*
+ * SonarQube HTML
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.html.core;
+
+import javax.annotation.Nullable;
+import org.sonar.api.notifications.AnalysisWarnings;
+import org.sonar.api.scanner.ScannerSide;
+import org.sonarsource.api.sonarlint.SonarLintSide;
+
+@ScannerSide
+@SonarLintSide(lifespan = SonarLintSide.INSTANCE)
+public final class AnalysisWarningsWrapper {
+
+  private final AnalysisWarnings analysisWarnings;
+
+  /**
+   * This constructor is used when {@link AnalysisWarnings} is not available, e.g. SonarLint.
+   */
+  public AnalysisWarningsWrapper() {
+    this.analysisWarnings = null;
+  }
+
+  public AnalysisWarningsWrapper(@Nullable AnalysisWarnings analysisWarnings) {
+    this.analysisWarnings = analysisWarnings;
+  }
+
+  public void addUnique(String text) {
+    if (analysisWarnings != null) {
+      analysisWarnings.addUnique(text);
+    }
+  }
+}

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlSensor.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlSensor.java
@@ -41,7 +41,6 @@ import org.sonar.api.measures.CoreMetrics;
 import org.sonar.api.measures.FileLinesContext;
 import org.sonar.api.measures.FileLinesContextFactory;
 import org.sonar.api.measures.Metric;
-import org.sonar.api.notifications.AnalysisWarnings;
 import org.sonar.api.utils.Version;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
@@ -70,15 +69,15 @@ public final class HtmlSensor implements Sensor {
   private final NoSonarFilter noSonarFilter;
   private final Checks<Object> checks;
   private final FileLinesContextFactory fileLinesContextFactory;
-  private final AnalysisWarnings analysisWarnings;
+  private final AnalysisWarningsWrapper analysisWarnings;
 
   public HtmlSensor(SonarRuntime sonarRuntime, NoSonarFilter noSonarFilter, FileLinesContextFactory fileLinesContextFactory,
-    CheckFactory checkFactory, AnalysisWarnings analysisWarnings) {
+    CheckFactory checkFactory, AnalysisWarningsWrapper analysisWarnings) {
     this.sonarRuntime = sonarRuntime;
     this.noSonarFilter = noSonarFilter;
     this.checks = checkFactory.create(HtmlRulesDefinition.REPOSITORY_KEY).addAnnotatedChecks(CheckClasses.getCheckClasses());
     this.fileLinesContextFactory = fileLinesContextFactory;
-    this.analysisWarnings = analysisWarnings;
+    this.analysisWarnings = analysisWarnings == null ? new AnalysisWarningsWrapper() : analysisWarnings;
   }
 
   @Override

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlSensor.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlSensor.java
@@ -77,7 +77,7 @@ public final class HtmlSensor implements Sensor {
     this.noSonarFilter = noSonarFilter;
     this.checks = checkFactory.create(HtmlRulesDefinition.REPOSITORY_KEY).addAnnotatedChecks(CheckClasses.getCheckClasses());
     this.fileLinesContextFactory = fileLinesContextFactory;
-    this.analysisWarnings = analysisWarnings == null ? new AnalysisWarningsWrapper() : analysisWarnings;
+    this.analysisWarnings = analysisWarnings;
   }
 
   @Override

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/HtmlPluginTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/HtmlPluginTest.java
@@ -22,6 +22,13 @@ import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.utils.Version;
+import org.sonar.plugins.html.core.AnalysisWarningsWrapper;
+import org.sonar.plugins.html.core.Html;
+import org.sonar.plugins.html.core.HtmlSensor;
+import org.sonar.plugins.html.core.Jsp;
+import org.sonar.plugins.html.rules.HtmlRulesDefinition;
+import org.sonar.plugins.html.rules.JspQualityProfile;
+import org.sonar.plugins.html.rules.SonarWayProfile;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -33,6 +40,15 @@ class HtmlPluginTest {
     Plugin.Context context = new Plugin.Context(SonarRuntimeImpl.forSonarQube(Version.create(7, 9), SonarQubeSide.SERVER, SonarEdition.COMMUNITY));
 
     new HtmlPlugin().define(context);
-    assertThat(context.getExtensions()).hasSize(8);
+    assertThat(context.getExtensions())
+      .contains(
+        Html.class,
+        Jsp.class,
+        HtmlRulesDefinition.class,
+        SonarWayProfile.class,
+        JspQualityProfile.class,
+        AnalysisWarningsWrapper.class,
+        HtmlSensor.class)
+      .hasSize(9);
   }
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlSensorTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlSensorTest.java
@@ -92,7 +92,7 @@ class HtmlSensorTest {
     when(fileLinesContextFactory.createFor(Mockito.any(InputFile.class))).thenReturn(mock(FileLinesContext.class));
     analysisWarnings = new RecordingAnalysisWarnings();
     sensor = new HtmlSensor(sonarRuntime, new DefaultNoSonarFilter(), fileLinesContextFactory, checkFactory,
-      analysisWarnings);
+      new AnalysisWarningsWrapper(analysisWarnings));
     tester = SensorContextTester.create(TEST_DIR).setRuntime(sonarRuntime);
   }
 
@@ -232,7 +232,7 @@ class HtmlSensorTest {
     DefaultSensorDescriptor sensorDescriptor = new DefaultSensorDescriptor();
     SonarRuntime sonarRuntime = SonarRuntimeImpl.forSonarLint(Version.create(6, 5));
     new HtmlSensor(sonarRuntime, null, null, new CheckFactory(new DefaultActiveRules(Collections.emptyList())),
-      new RecordingAnalysisWarnings()).describe(sensorDescriptor);
+      new AnalysisWarningsWrapper()).describe(sensorDescriptor);
     assertThat(sensorDescriptor.name()).isEqualTo("HTML");
     assertThat(sensorDescriptor.languages()).isEmpty();
   }
@@ -249,7 +249,7 @@ class HtmlSensorTest {
     };
     SonarRuntime sonarRuntime = SonarRuntimeImpl.forSonarQube(Version.create(9, 3), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY);
     new HtmlSensor(sonarRuntime, null, null, new CheckFactory(new DefaultActiveRules(Collections.emptyList())),
-      new RecordingAnalysisWarnings()).describe(sensorDescriptor);
+      new AnalysisWarningsWrapper()).describe(sensorDescriptor);
     assertThat(sensorDescriptor.name()).isEqualTo("HTML");
     assertThat(sensorDescriptor.languages()).isEmpty();
     assertTrue(called[0]);


### PR DESCRIPTION
## Summary
- replace raw AnalysisWarnings injection in HtmlSensor with an AnalysisWarningsWrapper
- register the wrapper as a plugin extension so SonarQube gets delegated warnings while SonarLint can instantiate the no-op path
- update plugin and sensor tests for the new wiring

## Testing
- mvn -pl sonar-html-plugin -Dtest=HtmlPluginTest,HtmlSensorTest test