### PR TITLE
SONARHTML-170 Suppress S5256 false positives on Razor layout tables

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
@@ -23,6 +23,10 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 public class Helpers {
+
+  private static final Pattern RAZOR_FRAGMENT_RENDERING = Pattern.compile(
+    "@(?:RenderBody|RenderSection|RenderPage|(?:await\\s+)?Html\\.(?:Render)?Partial(?:Async)?)\\b");
+
   private Helpers() {
   }
 
@@ -85,5 +89,45 @@ public class Helpers {
   private static boolean startsWithIgnoreCase(String value, String prefix) {
     return value.length() >= prefix.length()
       && value.regionMatches(true, 0, prefix, 0, prefix.length());
+  }
+  
+  /**
+   * Returns true when the source file uses Razor syntax, regardless of the
+   * back-end language. Razor ships with two extensions: {@code .cshtml}
+   * (C#) and {@code .vbhtml} (VB.NET). Both share the same {@code @}-based
+   * template syntax and can therefore exhibit the same false positives in
+   * rules that only look at HTML structure.
+   *
+   * @param code the source under analysis
+   * @return true if the file is a Razor view, false otherwise
+   */
+  public static boolean isRazorFile(HtmlSourceCode code) {
+    String filename = code.inputFile().filename();
+    return filename.endsWith(".cshtml") || filename.endsWith(".vbhtml");
+  }
+
+  /**
+   * Returns true when the given text contains a Razor expression that
+   * injects markup produced elsewhere — a layout body, a named section,
+   * or a partial view. These are the Razor counterparts to Thymeleaf's
+   * {@code th:insert}/{@code th:include}/{@code th:replace}: the structure
+   * around them cannot be judged in isolation, because the missing parts
+   * live in a different file.
+   *
+   * Recognised forms:
+   * <ul>
+   *   <li>{@code @RenderBody()}</li>
+   *   <li>{@code @RenderSection("name")} / {@code @RenderSection("name", required: false)}</li>
+   *   <li>{@code @RenderPage("path")}</li>
+   *   <li>{@code @Html.Partial(...)} / {@code @Html.RenderPartial(...)}</li>
+   *   <li>{@code @Html.PartialAsync(...)} / {@code @Html.RenderPartialAsync(...)}</li>
+   *   <li>{@code @await Html.PartialAsync(...)} / {@code @await Html.RenderPartialAsync(...)}</li>
+   * </ul>
+   *
+   * @param text the text fragment to inspect
+   * @return true if {@code text} renders a Razor fragment, false otherwise
+   */
+  public static boolean containsRazorFragmentRendering(String text) {
+    return text != null && RAZOR_FRAGMENT_RENDERING.matcher(text).find();
   }
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
@@ -37,9 +37,8 @@ public class Helpers {
   private static final Pattern RAZOR_CODE_BLOCK_INDICATOR = Pattern.compile("(?<!@)@\\{");
 
   private static final Pattern RAZOR_FRAGMENT_STATEMENT = Pattern.compile(
-    "\\b(?:Html\\.(?:Render)?Partial(?:Async)?" +
-      "|Html\\.RenderAction" +
-      "|Component\\.Invoke(?:Async)?)" +
+    "\\b(?:Html\\.RenderPartial(?:Async)?" +
+      "|Html\\.RenderAction)" +
       "\\s*\\(");
 
   private Helpers() {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
@@ -24,8 +24,23 @@ import java.util.regex.Pattern;
 
 public class Helpers {
 
-  private static final Pattern RAZOR_FRAGMENT_RENDERING = Pattern.compile(
-    "@(?:RenderBody|RenderSection|RenderPage|(?:await\\s+)?Html\\.(?:Render)?Partial(?:Async)?)\\b");
+  private static final Pattern RAZOR_COMMENT = Pattern.compile("@\\*[\\s\\S]*?\\*@");
+
+  private static final Pattern RAZOR_FRAGMENT_EXPRESSION = Pattern.compile(
+    "(?<!@)@\\(?\\s*(?:await\\s+)?" +
+      "(?:Html\\.(?:Render)?Partial(?:Async)?" +
+      "|Html\\.RenderAction" +
+      "|Component\\.Invoke(?:Async)?" +
+      "|RenderBody|RenderSection|RenderPage)" +
+      "\\b");
+
+  private static final Pattern RAZOR_CODE_BLOCK_INDICATOR = Pattern.compile("(?<!@)@\\{");
+
+  private static final Pattern RAZOR_FRAGMENT_STATEMENT = Pattern.compile(
+    "\\b(?:Html\\.(?:Render)?Partial(?:Async)?" +
+      "|Html\\.RenderAction" +
+      "|Component\\.Invoke(?:Async)?)" +
+      "\\s*\\(");
 
   private Helpers() {
   }
@@ -109,6 +124,24 @@ public class Helpers {
    * @return true if {@code text} renders a Razor fragment, false otherwise
    */
   public static boolean containsRazorFragmentRendering(String text) {
-    return RAZOR_FRAGMENT_RENDERING.matcher(text).find();
+    String stripped = RAZOR_COMMENT.matcher(text).replaceAll("");
+    if (RAZOR_FRAGMENT_EXPRESSION.matcher(stripped).find()) {
+      return true;
+    }
+    return RAZOR_CODE_BLOCK_INDICATOR.matcher(stripped).find()
+      && RAZOR_FRAGMENT_STATEMENT.matcher(stripped).find();
+  }
+
+  /**
+   * Returns true when the given tag is a Razor fragment-rendering tag-helper:
+   * {@code <partial .../>} or {@code <vc:my-component .../>}.
+   *
+   * @param node the tag to inspect
+   * @return true if {@code node} renders a Razor fragment via tag-helper, false otherwise
+   */
+  public static boolean isRazorFragmentTagHelper(TagNode node) {
+    String name = node.getNodeName();
+    return name != null
+      && ("partial".equalsIgnoreCase(name) || name.regionMatches(true, 0, "vc:", 0, 3));
   }
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
@@ -128,6 +128,6 @@ public class Helpers {
    * @return true if {@code text} renders a Razor fragment, false otherwise
    */
   public static boolean containsRazorFragmentRendering(String text) {
-    return text != null && RAZOR_FRAGMENT_RENDERING.matcher(text).find();
+    return RAZOR_FRAGMENT_RENDERING.matcher(text).find();
   }
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
@@ -142,6 +142,7 @@ public class Helpers {
   public static boolean isRazorFragmentTagHelper(TagNode node) {
     String name = node.getNodeName();
     return name != null
-      && ("partial".equalsIgnoreCase(name) || name.regionMatches(true, 0, "vc:", 0, 3));
+      && ("partial".equalsIgnoreCase(name)
+        || (name.length() > 3 && name.regionMatches(true, 0, "vc:", 0, 3)));
   }
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
@@ -92,11 +92,7 @@ public class Helpers {
   }
   
   /**
-   * Returns true when the source file uses Razor syntax, regardless of the
-   * back-end language. Razor ships with two extensions: {@code .cshtml}
-   * (C#) and {@code .vbhtml} (VB.NET). Both share the same {@code @}-based
-   * template syntax and can therefore exhibit the same false positives in
-   * rules that only look at HTML structure.
+   * Returns true when the source file uses Razor syntax (.cshtml or .vbhtml).
    *
    * @param code the source under analysis
    * @return true if the file is a Razor view, false otherwise
@@ -107,22 +103,7 @@ public class Helpers {
   }
 
   /**
-   * Returns true when the given text contains a Razor expression that
-   * injects markup produced elsewhere — a layout body, a named section,
-   * or a partial view. These are the Razor counterparts to Thymeleaf's
-   * {@code th:insert}/{@code th:include}/{@code th:replace}: the structure
-   * around them cannot be judged in isolation, because the missing parts
-   * live in a different file.
-   *
-   * Recognised forms:
-   * <ul>
-   *   <li>{@code @RenderBody()}</li>
-   *   <li>{@code @RenderSection("name")} / {@code @RenderSection("name", required: false)}</li>
-   *   <li>{@code @RenderPage("path")}</li>
-   *   <li>{@code @Html.Partial(...)} / {@code @Html.RenderPartial(...)}</li>
-   *   <li>{@code @Html.PartialAsync(...)} / {@code @Html.RenderPartialAsync(...)}</li>
-   *   <li>{@code @await Html.PartialAsync(...)} / {@code @await Html.RenderPartialAsync(...)}</li>
-   * </ul>
+   * Returns true when the given text contains a Razor expression that renders a body, section, page, or partial.
    *
    * @param text the text fragment to inspect
    * @return true if {@code text} renders a Razor fragment, false otherwise

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheck.java
@@ -57,9 +57,7 @@ public class TableWithoutHeaderCheck extends AbstractPageCheck {
   }
 
   /**
-   * Records every {@code <table>} ancestor of the given text node, so that
-   * the violation can later be suppressed for tables whose interior is
-   * provided by a Razor layout, section, or partial view.
+   * Marks every {@code <table>} ancestor of the given text node as containing a Razor fragment-rendering expression.
    *
    * @param textNode a text node that already matched a Razor fragment-rendering pattern
    */

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheck.java
@@ -19,6 +19,7 @@ package org.sonar.plugins.html.checks.sonar;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.api.Helpers;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
@@ -68,9 +69,10 @@ public class TableWithoutHeaderCheck extends AbstractPageCheck {
    * {@code <td>}/{@code <th>}/caption/etc. render cell content, not headers, and must not suppress
    * the enclosing table's violation.
    *
-   * @param parent the immediate parent of the placeholder (TextNode or tag-helper)
+   * @param parent the immediate parent of the placeholder (TextNode or tag-helper), or null when the
+   *               placeholder is at document root (PageLexer leaves the parent unset for top-level nodes)
    */
-  private void markNearestTable(TagNode parent) {
+  private void markNearestTable(@Nullable TagNode parent) {
     if (parent == null || !isStructuralTableContext(parent)) {
       return;
     }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheck.java
@@ -16,22 +16,60 @@
  */
 package org.sonar.plugins.html.checks.sonar;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.sonar.check.Rule;
+import org.sonar.plugins.html.api.Helpers;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
 import org.sonar.plugins.html.node.Attribute;
+import org.sonar.plugins.html.node.Node;
+import org.sonar.plugins.html.node.NodeType;
 import org.sonar.plugins.html.node.TagNode;
+import org.sonar.plugins.html.node.TextNode;
 
 @Rule(key = "S5256")
 public class TableWithoutHeaderCheck extends AbstractPageCheck {
 
   private static final Set<String> THYMELEAF_FRAGMENT_INSERTION_KEYWORDS = Set.of("th:insert", "th:include", "th:replace");
 
+  private final Set<TagNode> tablesWithRazorFragmentRendering = new HashSet<>();
+
+  @Override
+  public void startDocument(List<Node> nodes) {
+    tablesWithRazorFragmentRendering.clear();
+    if (!Helpers.isRazorFile(getHtmlSourceCode())) {
+      return;
+    }
+    for (Node node : nodes) {
+      if (node.getNodeType() == NodeType.TEXT && Helpers.containsRazorFragmentRendering(node.getCode())) {
+        markEnclosingTables((TextNode) node);
+      }
+    }
+  }
+
   @Override
   public void startElement(TagNode node) {
-    if (isTable(node) && !isLayout(node) && !isHidden(node) && !hasHeader(node) && !hasThymeleafFragmentInsertion(node)) {
+    if (isTable(node) && !isLayout(node) && !isHidden(node) && !hasHeader(node)
+      && !hasThymeleafFragmentInsertion(node) && !tablesWithRazorFragmentRendering.contains(node)) {
       createViolation(node, "Add \"<th>\" headers to this \"<table>\".");
+    }
+  }
+
+  /**
+   * Records every {@code <table>} ancestor of the given text node, so that
+   * the violation can later be suppressed for tables whose interior is
+   * provided by a Razor layout, section, or partial view.
+   *
+   * @param textNode a text node that already matched a Razor fragment-rendering pattern
+   */
+  private void markEnclosingTables(TextNode textNode) {
+    TagNode parent = textNode.getParent();
+    while (parent != null) {
+      if (isTable(parent)) {
+        tablesWithRazorFragmentRendering.add(parent);
+      }
+      parent = parent.getParent();
     }
   }
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheck.java
@@ -64,7 +64,7 @@ public class TableWithoutHeaderCheck extends AbstractPageCheck {
   /**
    * Marks the nearest enclosing {@code <table>} as containing a Razor fragment-rendering placeholder,
    * but only when the placeholder sits at a structural table position
-   * ({@code <table>}, {@code <thead>}, {@code <tbody>}, or {@code <tr>}). Placeholders inside
+   * ({@code <table>}, {@code <thead>}, {@code <tbody>}, {@code <tfoot>}, or {@code <tr>}). Placeholders inside
    * {@code <td>}/{@code <th>}/caption/etc. render cell content, not headers, and must not suppress
    * the enclosing table's violation.
    *
@@ -88,6 +88,7 @@ public class TableWithoutHeaderCheck extends AbstractPageCheck {
     return "TABLE".equalsIgnoreCase(name)
       || "THEAD".equalsIgnoreCase(name)
       || "TBODY".equalsIgnoreCase(name)
+      || "TFOOT".equalsIgnoreCase(name)
       || "TR".equalsIgnoreCase(name);
   }
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheck.java
@@ -43,7 +43,12 @@ public class TableWithoutHeaderCheck extends AbstractPageCheck {
     }
     for (Node node : nodes) {
       if (node.getNodeType() == NodeType.TEXT && Helpers.containsRazorFragmentRendering(node.getCode())) {
-        markEnclosingTables((TextNode) node);
+        markNearestTable(((TextNode) node).getParent());
+      } else if (node.getNodeType() == NodeType.TAG) {
+        TagNode tag = (TagNode) node;
+        if (!tag.isEndElement() && Helpers.isRazorFragmentTagHelper(tag)) {
+          markNearestTable(tag.getParent());
+        }
       }
     }
   }
@@ -57,18 +62,33 @@ public class TableWithoutHeaderCheck extends AbstractPageCheck {
   }
 
   /**
-   * Marks every {@code <table>} ancestor of the given text node as containing a Razor fragment-rendering expression.
+   * Marks the nearest enclosing {@code <table>} as containing a Razor fragment-rendering placeholder,
+   * but only when the placeholder sits at a structural table position
+   * ({@code <table>}, {@code <thead>}, {@code <tbody>}, or {@code <tr>}). Placeholders inside
+   * {@code <td>}/{@code <th>}/caption/etc. render cell content, not headers, and must not suppress
+   * the enclosing table's violation.
    *
-   * @param textNode a text node that already matched a Razor fragment-rendering pattern
+   * @param parent the immediate parent of the placeholder (TextNode or tag-helper)
    */
-  private void markEnclosingTables(TextNode textNode) {
-    TagNode parent = textNode.getParent();
-    while (parent != null) {
-      if (isTable(parent)) {
-        tablesWithRazorFragmentRendering.add(parent);
-      }
-      parent = parent.getParent();
+  private void markNearestTable(TagNode parent) {
+    if (parent == null || !isStructuralTableContext(parent)) {
+      return;
     }
+    TagNode table = parent;
+    while (table != null && !isTable(table)) {
+      table = table.getParent();
+    }
+    if (table != null) {
+      tablesWithRazorFragmentRendering.add(table);
+    }
+  }
+
+  private static boolean isStructuralTableContext(TagNode node) {
+    String name = node.getNodeName();
+    return "TABLE".equalsIgnoreCase(name)
+      || "THEAD".equalsIgnoreCase(name)
+      || "TBODY".equalsIgnoreCase(name)
+      || "TR".equalsIgnoreCase(name);
   }
 
   private static boolean isTable(TagNode node) {

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheckTest.java
@@ -43,4 +43,35 @@ class TableWithoutHeaderCheckTest {
         .next().atLine(78);
 
   }
+
+  @Test
+  void razor_layout_fragment_rendering_is_compliant() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/TableWithoutHeaderCheck/razor.cshtml"),
+      new TableWithoutHeaderCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(48).withMessage("Add \"<th>\" headers to this \"<table>\".");
+  }
+
+  @Test
+  void razor_vbhtml_layout_fragment_rendering_is_compliant() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/TableWithoutHeaderCheck/razor.vbhtml"),
+      new TableWithoutHeaderCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(7).withMessage("Add \"<th>\" headers to this \"<table>\".");
+  }
+
+  @Test
+  void razor_like_text_in_plain_html_still_raises() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/TableWithoutHeaderCheck/razor-tokens-in-plain-html.html"),
+      new TableWithoutHeaderCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(2).withMessage("Add \"<th>\" headers to this \"<table>\".")
+      .next().atLine(6).withMessage("Add \"<th>\" headers to this \"<table>\".");
+  }
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheckTest.java
@@ -18,6 +18,8 @@ package org.sonar.plugins.html.checks.sonar;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.sonar.plugins.html.checks.CheckMessagesVerifierRule;
 import org.sonar.plugins.html.checks.TestHelper;
 import org.sonar.plugins.html.visitor.HtmlSourceCode;
@@ -95,19 +97,17 @@ class TableWithoutHeaderCheckTest {
       .next().atLine(2).withMessage("Add \"<th>\" headers to this \"<table>\".");
   }
 
-  @Test
-  void razor_code_block_fragment_rendering_is_compliant() {
+  @ParameterizedTest
+  @ValueSource(strings = {
+    "razor-code-block.cshtml",
+    "razor-partial-tag-helper.cshtml",
+    "razor-explicit-expression.cshtml",
+    "razor-view-component.cshtml",
+    "razor-tfoot-fragment.cshtml",
+  })
+  void razor_fragment_rendering_at_structural_position_is_compliant(String fixture) {
     HtmlSourceCode sourceCode = TestHelper.scan(
-      new File("src/test/resources/checks/TableWithoutHeaderCheck/razor-code-block.cshtml"),
-      new TableWithoutHeaderCheck());
-
-    checkMessagesVerifier.verify(sourceCode.getIssues());
-  }
-
-  @Test
-  void razor_partial_tag_helper_is_compliant() {
-    HtmlSourceCode sourceCode = TestHelper.scan(
-      new File("src/test/resources/checks/TableWithoutHeaderCheck/razor-partial-tag-helper.cshtml"),
+      new File("src/test/resources/checks/TableWithoutHeaderCheck/" + fixture),
       new TableWithoutHeaderCheck());
 
     checkMessagesVerifier.verify(sourceCode.getIssues());
@@ -121,24 +121,6 @@ class TableWithoutHeaderCheckTest {
 
     checkMessagesVerifier.verify(sourceCode.getIssues())
       .next().atLine(2).withMessage("Add \"<th>\" headers to this \"<table>\".");
-  }
-
-  @Test
-  void razor_explicit_expression_fragment_rendering_is_compliant() {
-    HtmlSourceCode sourceCode = TestHelper.scan(
-      new File("src/test/resources/checks/TableWithoutHeaderCheck/razor-explicit-expression.cshtml"),
-      new TableWithoutHeaderCheck());
-
-    checkMessagesVerifier.verify(sourceCode.getIssues());
-  }
-
-  @Test
-  void razor_view_component_fragment_rendering_is_compliant() {
-    HtmlSourceCode sourceCode = TestHelper.scan(
-      new File("src/test/resources/checks/TableWithoutHeaderCheck/razor-view-component.cshtml"),
-      new TableWithoutHeaderCheck());
-
-    checkMessagesVerifier.verify(sourceCode.getIssues());
   }
 
   @Test
@@ -159,15 +141,6 @@ class TableWithoutHeaderCheckTest {
 
     checkMessagesVerifier.verify(sourceCode.getIssues())
       .next().atLine(2).withMessage("Add \"<th>\" headers to this \"<table>\".");
-  }
-
-  @Test
-  void razor_tfoot_fragment_rendering_is_compliant() {
-    HtmlSourceCode sourceCode = TestHelper.scan(
-      new File("src/test/resources/checks/TableWithoutHeaderCheck/razor-tfoot-fragment.cshtml"),
-      new TableWithoutHeaderCheck());
-
-    checkMessagesVerifier.verify(sourceCode.getIssues());
   }
 
   @Test

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheckTest.java
@@ -160,4 +160,23 @@ class TableWithoutHeaderCheckTest {
     checkMessagesVerifier.verify(sourceCode.getIssues())
       .next().atLine(2).withMessage("Add \"<th>\" headers to this \"<table>\".");
   }
+
+  @Test
+  void razor_tfoot_fragment_rendering_is_compliant() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/TableWithoutHeaderCheck/razor-tfoot-fragment.cshtml"),
+      new TableWithoutHeaderCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues());
+  }
+
+  @Test
+  void razor_bare_vc_prefix_does_not_suppress() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/TableWithoutHeaderCheck/razor-bare-vc-prefix.cshtml"),
+      new TableWithoutHeaderCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(2).withMessage("Add \"<th>\" headers to this \"<table>\".");
+  }
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheckTest.java
@@ -51,7 +51,7 @@ class TableWithoutHeaderCheckTest {
       new TableWithoutHeaderCheck());
 
     checkMessagesVerifier.verify(sourceCode.getIssues())
-      .next().atLine(48).withMessage("Add \"<th>\" headers to this \"<table>\".");
+      .next().atLine(39).withMessage("Add \"<th>\" headers to this \"<table>\".");
   }
 
   @Test
@@ -73,5 +73,91 @@ class TableWithoutHeaderCheckTest {
     checkMessagesVerifier.verify(sourceCode.getIssues())
       .next().atLine(2).withMessage("Add \"<th>\" headers to this \"<table>\".")
       .next().atLine(6).withMessage("Add \"<th>\" headers to this \"<table>\".");
+  }
+
+  @Test
+  void razor_partial_in_td_still_raises() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/TableWithoutHeaderCheck/razor-partial-in-td.cshtml"),
+      new TableWithoutHeaderCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(2).withMessage("Add \"<th>\" headers to this \"<table>\".");
+  }
+
+  @Test
+  void razor_nested_tables_only_suppresses_the_nearest() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/TableWithoutHeaderCheck/razor-nested-tables.cshtml"),
+      new TableWithoutHeaderCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(2).withMessage("Add \"<th>\" headers to this \"<table>\".");
+  }
+
+  @Test
+  void razor_code_block_fragment_rendering_is_compliant() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/TableWithoutHeaderCheck/razor-code-block.cshtml"),
+      new TableWithoutHeaderCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues());
+  }
+
+  @Test
+  void razor_partial_tag_helper_is_compliant() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/TableWithoutHeaderCheck/razor-partial-tag-helper.cshtml"),
+      new TableWithoutHeaderCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues());
+  }
+
+  @Test
+  void razor_partial_tag_helper_in_td_still_raises() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/TableWithoutHeaderCheck/razor-partial-tag-helper-in-td.cshtml"),
+      new TableWithoutHeaderCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(2).withMessage("Add \"<th>\" headers to this \"<table>\".");
+  }
+
+  @Test
+  void razor_explicit_expression_fragment_rendering_is_compliant() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/TableWithoutHeaderCheck/razor-explicit-expression.cshtml"),
+      new TableWithoutHeaderCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues());
+  }
+
+  @Test
+  void razor_view_component_fragment_rendering_is_compliant() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/TableWithoutHeaderCheck/razor-view-component.cshtml"),
+      new TableWithoutHeaderCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues());
+  }
+
+  @Test
+  void razor_server_side_comment_does_not_suppress() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/TableWithoutHeaderCheck/razor-commented-render.cshtml"),
+      new TableWithoutHeaderCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(2).withMessage("Add \"<th>\" headers to this \"<table>\".");
+  }
+
+  @Test
+  void razor_escaped_at_does_not_suppress() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/TableWithoutHeaderCheck/razor-escaped-at.cshtml"),
+      new TableWithoutHeaderCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(2).withMessage("Add \"<th>\" headers to this \"<table>\".");
   }
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheckTest.java
@@ -164,4 +164,16 @@ class TableWithoutHeaderCheckTest {
       .next().atLine(8).withMessage("Add \"<th>\" headers to this \"<table>\".")
       .next().atLine(14).withMessage("Add \"<th>\" headers to this \"<table>\".");
   }
+
+  @Test
+  void razor_code_block_without_rendering_does_not_suppress() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/TableWithoutHeaderCheck/razor-code-block-no-rendering.cshtml"),
+      new TableWithoutHeaderCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(2).withMessage("Add \"<th>\" headers to this \"<table>\".")
+      .next().atLine(8).withMessage("Add \"<th>\" headers to this \"<table>\".")
+      .next().atLine(15).withMessage("Add \"<th>\" headers to this \"<table>\".");
+  }
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheckTest.java
@@ -152,4 +152,16 @@ class TableWithoutHeaderCheckTest {
     checkMessagesVerifier.verify(sourceCode.getIssues())
       .next().atLine(2).withMessage("Add \"<th>\" headers to this \"<table>\".");
   }
+
+  @Test
+  void razor_code_block_assigning_partial_result_does_not_suppress() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/TableWithoutHeaderCheck/razor-code-block-assigned-result.cshtml"),
+      new TableWithoutHeaderCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(2).withMessage("Add \"<th>\" headers to this \"<table>\".")
+      .next().atLine(8).withMessage("Add \"<th>\" headers to this \"<table>\".")
+      .next().atLine(14).withMessage("Add \"<th>\" headers to this \"<table>\".");
+  }
 }

--- a/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor-bare-vc-prefix.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor-bare-vc-prefix.cshtml
@@ -1,0 +1,4 @@
+<!-- Non-compliant: <vc:> with no component name is not a real view-component and must not suppress -->
+<table>
+  <vc: />
+</table>

--- a/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor-code-block-assigned-result.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor-code-block-assigned-result.cshtml
@@ -1,0 +1,18 @@
+<!-- Non-compliant: helpers that return content do not render when their result is assigned -->
+<table>
+  @{
+    var rows = Html.Partial("_Rows");
+  }
+</table>
+
+<table>
+  @{
+    var rows = await Html.PartialAsync("_Rows");
+  }
+</table>
+
+<table>
+  @{
+    var rows = await Component.InvokeAsync("RowsComponent");
+  }
+</table>

--- a/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor-code-block-no-rendering.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor-code-block-no-rendering.cshtml
@@ -1,0 +1,17 @@
+<!-- Non-compliant: @{ ... } block with no fragment-rendering helper must not suppress -->
+<table>
+  @{
+    ViewBag.Title = "Users";
+  }
+</table>
+
+<table>
+  @{
+    var count = 5;
+    var label = "row";
+  }
+</table>
+
+<table>
+  @{ Layout = "_Layout"; }
+</table>

--- a/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor-code-block.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor-code-block.cshtml
@@ -1,0 +1,14 @@
+<!-- Compliant: fragment rendering inside @{ ... } Razor code blocks -->
+<table>
+  @{ Html.RenderPartial("_Rows"); }
+</table>
+
+<table>
+  @{
+    Html.RenderPartial("_Rows");
+  }
+</table>
+
+<table>
+  @{ await Html.RenderPartialAsync("_Rows"); }
+</table>

--- a/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor-commented-render.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor-commented-render.cshtml
@@ -1,0 +1,4 @@
+<!-- Non-Compliant: the @* ... *@ is a Razor server-side comment and must not suppress the rule -->
+<table>
+  @* @RenderBody() *@
+</table>

--- a/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor-escaped-at.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor-escaped-at.cshtml
@@ -1,0 +1,4 @@
+<!-- Non-Compliant: @@ is an escaped literal '@', not a Razor expression -->
+<table>
+  @@RenderBody()
+</table>

--- a/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor-explicit-expression.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor-explicit-expression.cshtml
@@ -1,0 +1,12 @@
+<!-- Compliant: explicit-expression Razor forms -->
+<table>
+  @(Html.Partial("_Rows"))
+</table>
+
+<table>
+  @(await Html.PartialAsync("_Rows"))
+</table>
+
+<table>
+  @(RenderBody())
+</table>

--- a/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor-nested-tables.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor-nested-tables.cshtml
@@ -1,0 +1,10 @@
+<!-- Non-Compliant outer table: fragment is rendered inside the inner table only -->
+<table>
+  <tr>
+    <td>
+      <table>
+        @RenderBody()
+      </table>
+    </td>
+  </tr>
+</table>

--- a/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor-partial-in-td.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor-partial-in-td.cshtml
@@ -1,0 +1,6 @@
+<!-- Non-Compliant: partial renders cell content, not headers, so the table still lacks <th> -->
+<table>
+  <tr>
+    <td>@Html.Partial("_Cell")</td>
+  </tr>
+</table>

--- a/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor-partial-tag-helper-in-td.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor-partial-tag-helper-in-td.cshtml
@@ -1,0 +1,6 @@
+<!-- Non-Compliant: <partial> tag-helper renders cell content (placed inside <td>) -->
+<table>
+  <tr>
+    <td><partial name="_Cell" /></td>
+  </tr>
+</table>

--- a/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor-partial-tag-helper.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor-partial-tag-helper.cshtml
@@ -1,0 +1,13 @@
+<!-- Compliant: <partial> tag-helper at a structural table position -->
+<table>
+  <partial name="_Rows" />
+</table>
+
+<table>
+  <thead>
+    <partial name="_Headers" />
+  </thead>
+  <tbody>
+    <tr><td>row</td></tr>
+  </tbody>
+</table>

--- a/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor-tfoot-fragment.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor-tfoot-fragment.cshtml
@@ -1,0 +1,13 @@
+<!-- Compliant: fragment rendered inside <tfoot> is a valid structural table position -->
+<table>
+  <tfoot>
+    @RenderSection("Totals", required: false)
+  </tfoot>
+</table>
+
+<!-- Compliant: partial tag-helper inside <tfoot> -->
+<table>
+  <tfoot>
+    <partial name="_Totals" />
+  </tfoot>
+</table>

--- a/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor-tokens-in-plain-html.html
+++ b/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor-tokens-in-plain-html.html
@@ -1,0 +1,8 @@
+<!-- Non-Compliant: plain HTML file, Razor-looking text is just text and must not suppress the rule -->
+<table>
+  @RenderBody()
+</table>
+
+<table>
+  @Html.Partial("foo")
+</table>

--- a/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor-view-component.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor-view-component.cshtml
@@ -1,0 +1,14 @@
+<!-- Compliant: view-component tag-helper -->
+<table>
+  <vc:my-rows />
+</table>
+
+<!-- Compliant: Component.InvokeAsync via explicit expression -->
+<table>
+  @(await Component.InvokeAsync("Rows"))
+</table>
+
+<!-- Compliant: Html.RenderAction inside a Razor code block -->
+<table>
+  @{ Html.RenderAction("Rows"); }
+</table>

--- a/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor.cshtml
@@ -24,7 +24,7 @@
 </table>
 
 <table>
-  @Html.RenderPartial("_TableContents")
+  @{ Html.RenderPartial("_TableContents"); }
 </table>
 
 <table>
@@ -32,16 +32,7 @@
 </table>
 
 <table>
-  @await Html.RenderPartialAsync("_TableContents")
-</table>
-
-<!-- Compliant: rendering nested deeper inside the table -->
-<table>
-  <tbody>
-    <tr>
-      <td>@Html.Partial("_Row")</td>
-    </tr>
-  </tbody>
+  @{ await Html.RenderPartialAsync("_TableContents"); }
 </table>
 
 <!-- Non-Compliant: no headers, no fragment rendering -->

--- a/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor.cshtml
@@ -1,0 +1,62 @@
+<!-- Compliant: layout table whose body is rendered from a child view -->
+<table>
+  @RenderBody()
+</table>
+
+<!-- Compliant: layout table whose headers come from a named section -->
+<table>
+  <thead>
+    @RenderSection("headers", required: false)
+  </thead>
+  <tbody>
+    <tr><td>row</td></tr>
+  </tbody>
+</table>
+
+<!-- Compliant: layout table that delegates to a separate page -->
+<table>
+  @RenderPage("~/Views/Shared/_TableRows.cshtml")
+</table>
+
+<!-- Compliant: layout table that includes a partial view -->
+<table>
+  @Html.Partial("_TableContents")
+</table>
+
+<table>
+  @Html.RenderPartial("_TableContents")
+</table>
+
+<table>
+  @await Html.PartialAsync("_TableContents")
+</table>
+
+<table>
+  @await Html.RenderPartialAsync("_TableContents")
+</table>
+
+<!-- Compliant: rendering nested deeper inside the table -->
+<table>
+  <tbody>
+    <tr>
+      <td>@Html.Partial("_Row")</td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Non-Compliant: no headers, no fragment rendering -->
+<table>
+  <tr>
+    <td>value</td>
+  </tr>
+</table>
+
+<!-- Compliant: regular table with headers, Razor expression unrelated to fragment rendering -->
+<table>
+  <tr>
+    <th>@Model.Title</th>
+  </tr>
+  <tr>
+    <td>@Model.Value</td>
+  </tr>
+</table>

--- a/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor.vbhtml
+++ b/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/razor.vbhtml
@@ -1,0 +1,9 @@
+<!-- Compliant: vbhtml Razor view, body comes from the child view -->
+<table>
+  @RenderBody()
+</table>
+
+<!-- Non-Compliant: vbhtml without fragment rendering -->
+<table>
+  <tr><td>value</td></tr>
+</table>


### PR DESCRIPTION
## Summary
S5256 (*tables should have headers*) raises false positives on Razor layout pages, where the `<table>` sits in the layout and the `<th>` rows are injected by `@RenderBody`, `@RenderSection`, or `@Html.Partial`/`@Html.RenderPartial` from a child view. This PR adds a symmetric exemption to the existing Thymeleaf fragment-insertion logic.

## Changes
- `TableWithoutHeaderCheck.startDocument` pre-scans `.cshtml`/`.vbhtml` files for `TextNode`s containing Razor fragment-rendering expressions (`@RenderBody`, `@RenderSection`, `@RenderPage`, `@Html.(Render)?Partial(Async)?`, with or without `await`); every `<table>` ancestor of such a node is exempted from S5256.
- Reusable helpers added to `Helpers`: `isRazorFile(HtmlSourceCode)` and `containsRazorFragmentRendering(String)`.
- New unit tests + `.cshtml` / `.vbhtml` / `.html` fixtures covering the FP cases and the non-suppression invariants (real bug in a Razor file, Razor-looking text in a plain `.html` file).

## Functional Validation
Attached: [SONARHTML-170-fv.zip](https://github.com/user-attachments/files/28154579/SONARHTML-170-fv.zip)

Unzip and run:

    ./run.sh

Expected output is in `expected-output.txt`. The README shows the before/after comparison so you can reproduce the difference directly.
