### PR TITLE
SONARHTML-383 Split SonarLint ITS into dedicated module

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
           ARTIFACTORY_URL: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_URL }}
           ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
         run: |
-          mvn -f its/plugin/pom.xml verify -Pqa -Dsonar.runtimeVersion=${{ matrix.sq-version }} -Dmaven.test.redirectTestOutputToFile=false -B -e -V
+          mvn -f its/pom.xml -pl plugin,sonarlint-tests verify -Pqa -Dsonar.runtimeVersion=${{ matrix.sq-version }} -Dmaven.test.redirectTestOutputToFile=false -B -e -V
 
   ruling:
     if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -29,7 +29,7 @@ jobs:
           # Update root pom.xml version
           sed -i "s/<version>.*-SNAPSHOT<\/version>/<version>${snapshot_version}<\/version>/" pom.xml
           # Update parent version references in submodules
-          for pom in sonar-html-plugin/pom.xml coverage-report/pom.xml its/pom.xml its/plugin/pom.xml its/ruling/pom.xml; do
+          for pom in sonar-html-plugin/pom.xml coverage-report/pom.xml its/pom.xml its/plugin/pom.xml its/sonarlint-tests/pom.xml its/ruling/pom.xml; do
             if [ -f "$pom" ]; then
               # Only update the parent version reference (first occurrence)
               sed -i "0,/<version>.*-SNAPSHOT<\/version>/s/<version>.*-SNAPSHOT<\/version>/<version>${snapshot_version}<\/version>/" "$pom"

--- a/its/plugin/pom.xml
+++ b/its/plugin/pom.xml
@@ -35,34 +35,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.sonarsource.sonarlint.core</groupId>
-      <artifactId>sonarlint-core</artifactId>
-      <version>11.3.0.85510</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.sonarsource.sonarlint.core</groupId>
-      <artifactId>sonarlint-core-test-utils</artifactId>
-      <version>11.3.0.85510</version>
-    </dependency>
-    <dependency>
-      <groupId>org.sonarsource.sonarlint.core</groupId>
-      <artifactId>sonarlint-rpc-protocol</artifactId>
-      <version>11.3.0.85510</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <scope>test</scope>
-      <version>4.3.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>

--- a/its/plugin/src/test/java/com/sonar/it/web/HtmlTestSuite.java
+++ b/its/plugin/src/test/java/com/sonar/it/web/HtmlTestSuite.java
@@ -44,7 +44,6 @@ import static java.util.Collections.singletonList;
   FileSuffixesTest.class,
   StandardMeasuresTest.class,
   VariousTest.class,
-  SonarLintIntegrationTest.class,
   PhpFilesTest.class
 })
 public class HtmlTestSuite {

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -15,6 +15,7 @@
 
   <modules>
     <module>plugin</module>
+    <module>sonarlint-tests</module>
     <module>ruling</module>
   </modules>
 

--- a/its/sonarlint-tests/pom.xml
+++ b/its/sonarlint-tests/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.sonarsource.html</groupId>
+    <artifactId>html-its</artifactId>
+    <version>3.28-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>it-html-plugin-sonarlint-tests</artifactId>
+
+  <name>SonarQube HTML Plugin :: ITs :: SonarLint Tests</name>
+  <inceptionYear>2026</inceptionYear>
+  <organization>
+    <name>SonarSource</name>
+    <url>http://www.sonarsource.com</url>
+  </organization>
+
+  <properties>
+    <surefire.argLine>-server</surefire.argLine>
+    <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
+    <gitRepositoryName>sonar-html</gitRepositoryName>
+    <sonarlint.version>11.3.0.85510</sonarlint.version>
+  </properties>
+
+  <!--
+  Keep sonar-html-plugin out of the test classpath.
+  The QA profile copies the built plugin artifact below so SonarLint loads the packaged analyzer.
+  -->
+  <dependencies>
+    <dependency>
+      <groupId>org.sonarsource.sonarlint.core</groupId>
+      <artifactId>sonarlint-core</artifactId>
+      <version>${sonarlint.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.sonarsource.sonarlint.core</groupId>
+      <artifactId>sonarlint-core-test-utils</artifactId>
+      <version>${sonarlint.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.sonarsource.sonarlint.core</groupId>
+      <artifactId>sonarlint-rpc-protocol</artifactId>
+      <version>${sonarlint.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.3.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${assertj.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/its/sonarlint-tests/src/test/java/com/sonar/it/web/SonarLintIntegrationTest.java
+++ b/its/sonarlint-tests/src/test/java/com/sonar/it/web/SonarLintIntegrationTest.java
@@ -19,22 +19,22 @@ package com.sonar.it.web;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-import com.sonar.orchestrator.locator.FileLocation;
-import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.io.TempDir;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.file.DidOpenFileParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.file.DidUpdateFileSystemParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.issue.RaisedIssueDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.ClientFileDto;
-import org.junit.jupiter.api.io.TempDir;
-
 import org.sonarsource.sonarlint.core.test.utils.SonarLintBackendFixture;
 import org.sonarsource.sonarlint.core.test.utils.SonarLintTestRpcServer;
 import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTest;
@@ -44,6 +44,7 @@ import org.sonarsource.sonarlint.core.test.utils.plugins.Plugin;
 class SonarLintIntegrationTest {
 
   private static final String CONFIG_SCOPE_ID = "CONFIG_SCOPE_ID";
+  private static final Pattern PLUGIN_FILENAME = Pattern.compile("sonar-html-plugin-[0-9.]*(?:-SNAPSHOT)?\\.jar");
   private SonarLintBackendFixture.FakeSonarLintRpcClient client;
   private SonarLintTestRpcServer backend;
 
@@ -61,13 +62,13 @@ class SonarLintIntegrationTest {
       assertThat(results.get(2).getRuleKey()).isEqualTo("Web:PageWithoutTitleCheck");
     });
 
-    triggerAnalysisByFileChanged(fileDTO, "<!DOCTYPE html><html lang=\"en\"><head><title>Title</title></head>\n<body>\n<a href=\"foo.png\">a</a>\n</body>\n</html>\n");
+    triggerAnalysisByFileChanged(
+      fileDTO,
+      "<!DOCTYPE html><html lang=\"en\"><head><title>Title</title></head>\n<body>\n<a href=\"foo.png\">a</a>\n</body>\n</html>\n"
+    );
 
-    assertResults(results -> {
-      assertThat(results).isEmpty();
-    });
+    assertResults(results -> assertThat(results).isEmpty());
   }
-
 
   private static ClientFileDto createFile(Path folderPath, String fileName, String content) {
     var filePath = folderPath.resolve(fileName);
@@ -120,13 +121,28 @@ class SonarLintIntegrationTest {
       .withStandaloneEmbeddedPluginAndEnabledLanguage(
         new Plugin(
           Set.of(org.sonarsource.sonarlint.core.rpc.protocol.common.Language.HTML),
-          FileLocation.byWildcardMavenFilename(new File("../../sonar-html-plugin/target"), "sonar-html-plugin-*.jar").getFile().toPath(),
+          pluginArtifact(),
           "",
           ""
         )
       )
       .withUnboundConfigScope(CONFIG_SCOPE_ID)
       .start(client);
+  }
+
+  private static Path pluginArtifact() {
+    try {
+      var target = Path.of("../../sonar-html-plugin/target").toRealPath();
+      try (var stream = Files.walk(target, 1)) {
+        return stream
+          .filter(Files::isRegularFile)
+          .filter(path -> PLUGIN_FILENAME.matcher(path.getFileName().toString()).matches())
+          .max(Comparator.comparing(path -> path.toFile().lastModified()))
+          .orElseThrow(() -> new IllegalStateException("Cannot find plugin artifact in " + target));
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 
   private void assertResults(Consumer<List<RaisedIssueDto>> assertionLambda) {
@@ -138,4 +154,3 @@ class SonarLintIntegrationTest {
       });
   }
 }
-


### PR DESCRIPTION
## Summary
Move the SonarLint integration test out of the legacy JUnit 4 ITS module into its own JUnit 5 module so QA runs it again.

## Changes
- add `its/sonarlint-tests` with the SonarLint and JUnit 5 dependencies and move `SonarLintIntegrationTest` there
- remove SonarLint-specific dependencies and suite wiring from `its/plugin`
- update QA CI to run `mvn -f its/pom.xml -pl plugin,sonarlint-tests verify ...`
- include `its/sonarlint-tests/pom.xml` in the version bump workflow

## Testing
- `mvn -pl sonar-html-plugin -am install -DskipTests -B -e -V`
- `mvn -f its/sonarlint-tests/pom.xml verify -Pqa -Dsonar.runtimeVersion=LATEST_RELEASE -Dmaven.test.redirectTestOutputToFile=false -B -e -V`
- `mvn -f its/pom.xml -pl plugin,sonarlint-tests verify -Pqa -Dsonar.runtimeVersion=LATEST_RELEASE -Dmaven.test.redirectTestOutputToFile=false -B -e -V`

## Regression Check
- reverting the `AnalysisWarningsWrapper` wiring from #661 and rerunning `its/sonarlint-tests` makes `SonarLintIntegrationTest` fail
- SonarLint cannot instantiate `HtmlSensor`: `No qualifying bean of type 'org.sonar.api.notifications.AnalysisWarnings' available`
- this shows the SonarLint ITS added here would have caught the regression fixed in #661