### PR TITLE
SONARHTML-255 Track single quotes in tag boundary matcher

### DIFF
--- a/its/ruling/src/test/resources/expected/Web-InputWithoutLabelCheck.json
+++ b/its/ruling/src/test/resources/expected/Web-InputWithoutLabelCheck.json
@@ -8,6 +8,7 @@
 119
 ],
 "project:Silverpeas-Core-master/war-core/src/main/webapp/admin/jsp/DomainsBarSilverpeasV5.jsp": [
+285,
 389
 ],
 "project:Silverpeas-Core-master/war-core/src/main/webapp/admin/jsp/ExploitationSilverTrace.jsp": [
@@ -85,8 +86,7 @@
 ],
 "project:Silverpeas-Core-master/war-core/src/main/webapp/attachment/jsp/displayAttachedFiles.jsp": [
 1082,
-1083,
-1097
+1083
 ],
 "project:Silverpeas-Core-master/war-core/src/main/webapp/communicationUser/jsp/discussion.jsp": [
 150
@@ -759,6 +759,7 @@
 124
 ],
 "project:custom/S6843.html": [
+1,
 2,
 3
 ],
@@ -2267,6 +2268,9 @@
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/autocompletion-fire-onchange.html": [
 35
 ],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/autofill-popup-location.html": [
+18
+],
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/autofill-popup-width-and-item-direction.html": [
 32,
 33
@@ -2286,6 +2290,9 @@
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/chromium/select-close-popup-value-change.html": [
 13
 ],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/chromium/suggestions-popup-font-change.html": [
+18
+],
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/clear-input-file.html": [
 21
 ],
@@ -2296,11 +2303,20 @@
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/display-none-option.html": [
 7
 ],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/drag-caret.html": [
+2
+],
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/drag-move-in-search-field.html": [
 5
 ],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/drop-text-acquires-style.html": [
+8
+],
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/empty-title-popup.html": [
 3
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/find-count-matches-after-text-control.html": [
+14
 ],
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/focus-change-between-key-events.html": [
 23
@@ -2309,6 +2325,9 @@
 21,
 22,
 26
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/focusringcolor-change-on-theme-change.html": [
+1
 ],
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/form-control-madness.html": [
 6,
@@ -2350,6 +2369,9 @@
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/ime-keydown-preventdefault.html": [
 6,
 9
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/input-empty-on-focus.html": [
+2
 ],
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/input-number-localization.html": [
 17,
@@ -2393,6 +2415,9 @@
 60,
 61
 ],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/input-type-file-autocomplete-frame-2.html": [
+4
+],
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/input-type-file-drag-drop.html": [
 3,
 6,
@@ -2425,6 +2450,13 @@
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/log-keypress-events.html": [
 5
 ],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/modal-dialog-blur.html": [
+31
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/modal-dialog.html": [
+21,
+22
+],
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/nested-plug-ins.html": [
 26,
 29,
@@ -2439,6 +2471,12 @@
 26,
 43,
 59
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/onblur-remove.html": [
+27
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/onfocus-alert-blinking-caret.html": [
+7
 ],
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/onsearch-enter.html": [
 3
@@ -2462,6 +2500,14 @@
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/password-ctrl-click-lose-focus.html": [
 20,
 21
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/plain-text-paste.html": [
+33,
+37,
+41,
+45,
+49,
+53
 ],
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/pop-up-alignment-and-direction.html": [
 16
@@ -2555,6 +2601,10 @@
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/selection-start-after-inserting-line-break-in-textarea.html": [
 5
 ],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/show-modal-dialog-test.html": [
+11,
+14
+],
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/slider-thumb-tracking.html": [
 25,
 27
@@ -2562,10 +2612,16 @@
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/stale-scrollbar-client-crash.html": [
 27
 ],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/submit-form-with-target-twice.html": [
+10
+],
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/tabbing-input-google.html": [
 22,
 22,
 22
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/text-field-autoscroll.html": [
+20
 ],
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/textarea-after-stylesheet-link.html": [
 15
@@ -2615,9 +2671,28 @@
 221,
 253
 ],
+"project:external_webkit-jb-mr1/Tools/QueueStatusServer/templates/releasepatch.html": [
+2,
+2
+],
+"project:external_webkit-jb-mr1/Tools/QueueStatusServer/templates/submittoews.html": [
+2
+],
 "project:external_webkit-jb-mr1/Tools/QueueStatusServer/templates/updatestatus.html": [
+2,
+5,
+9,
+13,
 17,
 19
+],
+"project:external_webkit-jb-mr1/Tools/QueueStatusServer/templates/updatesvnrevision.html": [
+2,
+5
+],
+"project:external_webkit-jb-mr1/Tools/QueueStatusServer/templates/updateworkitems.html": [
+2,
+5
 ],
 "project:external_webkit-jb-mr1/Tools/Scripts/webkitpy/tool/commands/data/rebaselineserver/index.html": [
 45,
@@ -2629,6 +2704,25 @@
 22,
 26,
 28
+],
+"project:external_webkit-jb-mr1/Tools/TestWebKitAPI/Tests/WebKit2/simple-form.html": [
+9
+],
+"project:external_webkit-jb-mr1/Tools/TestWebKitAPI/Tests/WebKit2/spacebar-scrolling.html": [
+25
+],
+"project:external_webkit-jb-mr1/Tools/iExploder/iexploder-1.3.2/htdocs/index.html": [
+17,
+17,
+25,
+25
+],
+"project:external_webkit-jb-mr1/Tools/iExploder/iexploder-1.7.2/src/index.html": [
+78,
+79,
+88,
+88,
+95
 ],
 "project:external_webkit-jb-mr1/Tools/iExploder/iexploder-1.7.2/testcases/testcase-Opera-9.80_Linux_x86_64_en_Presto-2.6.30_Version-10.61-16704-3_108,3.html": [
 3
@@ -2735,36 +2829,19 @@
 "project:phpMyAdmin-4.0.4-english/view_operations.php": [
 91
 ],
-"project:sonar-master/plugins/sonar-core-plugin/src/main/resources/org/sonar/plugins/core/widgets/events.html.erb": [
-59
-],
-"project:sonar-master/plugins/sonar-core-plugin/src/main/resources/org/sonar/plugins/core/widgets/hotspots/hotspot_most_violated_rules.html.erb": [
-42
-],
-"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/account/_per_project_notifications.html.erb": [
-57
-],
 "project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/action_plans/_new.html.erb": [
 13,
 20,
 29
-],
-"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/alerts/_edit.html.erb": [
-8,
-13
 ],
 "project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/alerts/_new.html.erb": [
 6,
 19,
 25
 ],
-"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/autocomplete/_text_field.html.erb": [
-1
-],
 "project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/bulk_deletion/index.html.erb": [
 23,
-48,
-64
+48
 ],
 "project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/cloud/index.html.erb": [
 25
@@ -2864,20 +2941,9 @@
 2,
 7
 ],
-"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/project/_key_modules.html.erb": [
-7
-],
-"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/project/history.html.erb": [
-82,
-110,
-128
-],
 "project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/project/key.html.erb": [
 32,
 37
-],
-"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/project/profile.html.erb": [
-22
 ],
 "project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/project_roles/edit_groups.html.erb": [
 17,
@@ -2916,12 +2982,6 @@
 "project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/roles/projects.html.erb": [
 76
 ],
-"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/rules_configuration/_active_rule_note.html.erb": [
-45
-],
-"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/rules_configuration/_rule_note.html.erb": [
-42
-],
 "project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/rules_configuration/edit.html.erb": [
 31,
 37,
@@ -2935,15 +2995,6 @@
 "project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/server_id_configuration/index.html.erb": [
 33,
 48
-],
-"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/settings/_type_LICENSE.html.erb": [
-8
-],
-"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/settings/_type_METRIC.html.erb": [
-4
-],
-"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/updatecenter/available.html.erb": [
-103
 ],
 "project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/users/new.html.erb": [
 8,

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/HtmlElementEndMatcher.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/HtmlElementEndMatcher.java
@@ -1,0 +1,118 @@
+/*
+ * SonarQube HTML
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.html.lex;
+
+import org.sonar.sslr.channel.CodeReader;
+import org.sonar.sslr.channel.EndMatcher;
+
+/*
+ * Detects the end `>` of an HTML element, on top of the basic `<` ... `>` nesting count from
+ * the generic EndTokenMatcher. The generic matcher gets fooled by `<` or `>` characters that
+ * appear inside attribute values or inside JSP/ERB scriptlets; this one tracks three extra
+ * states to avoid that.
+ *
+ * Double-quoted attribute value.
+ *   Opens on `"`, closes on the next `"`. Same as the generic matcher.
+ *
+ * Single-quoted attribute value.
+ *   Opens on `'` only when the previous non-whitespace char is `=`, so a stray apostrophe in
+ *   text or in code (like `Ask'Once` or `l'evenement`) doesn't open a scope. Closes only when
+ *   the next char is an attribute terminator: whitespace, `>`, `/`, `=`, `"`, or EOF. The
+ *   terminator gate is what keeps EL string literals like `${'foo'}` from closing the
+ *   surrounding attribute — the inner `'` is followed by `}`, which isn't a terminator.
+ *
+ * JSP/ERB scriptlet.
+ *   A `<%` opens an opaque sub-scope — both at the top level and inside an attribute value,
+ *   so a scriptlet embedded in an attribute (`<input value='<%= ... %>' />`) is also handled.
+ *   Quote tracking is suspended and `<` / `>` inside the scriptlet are ignored for nesting.
+ *   The scope closes on the matching `%>`. This is what stops Ruby/Java char literals like
+ *   `'x'` inside `<%= ... %>` from being mistaken for HTML attribute quotes.
+ */
+class HtmlElementEndMatcher implements EndMatcher {
+
+  private final CodeReader codeReader;
+  private int activeQuote;
+  private int previousChar;
+  private int previousNonWhitespace;
+  private int nesting;
+  private int jspNesting;
+
+  HtmlElementEndMatcher(CodeReader codeReader) {
+    this.codeReader = codeReader;
+  }
+
+  @Override
+  public boolean match(int endFlag) {
+    boolean enteringJsp = previousChar == '<' && endFlag == '%' && jspNesting == 0;
+    boolean exitingJsp = previousChar == '%' && endFlag == '>' && jspNesting > 0;
+
+    boolean result = false;
+    if (enteringJsp) {
+      jspNesting++;
+      // The preceding '<' only incremented nesting when we were outside any quote scope; undo
+      // it in that case so the <%...%> doesn't leave a residue.
+      if (activeQuote == 0) {
+        nesting--;
+      }
+    } else if (jspNesting > 0) {
+      if (exitingJsp) {
+        jspNesting--;
+      }
+    } else {
+      updateQuoteState(endFlag);
+      if (activeQuote == 0) {
+        if (endFlag == '<') {
+          nesting++;
+        } else if (endFlag == '>') {
+          nesting--;
+          result = nesting < 0;
+        }
+      }
+    }
+
+    previousChar = endFlag;
+    if (!Character.isWhitespace(endFlag)) {
+      previousNonWhitespace = endFlag;
+    }
+    return result;
+  }
+
+  private void updateQuoteState(int endFlag) {
+    if (endFlag == '"') {
+      if (activeQuote == 0) {
+        activeQuote = endFlag;
+      } else if (activeQuote == endFlag) {
+        activeQuote = 0;
+      }
+    } else if (endFlag == '\'') {
+      if (activeQuote == 0 && previousNonWhitespace == '=') {
+        activeQuote = endFlag;
+      } else if (activeQuote == endFlag && isAttributeTerminator(charAfterPeek())) {
+        activeQuote = 0;
+      }
+    }
+  }
+
+  private char charAfterPeek() {
+    char[] lookahead = codeReader.peek(2);
+    return lookahead.length >= 2 ? lookahead[1] : '\0';
+  }
+
+  private static boolean isAttributeTerminator(char c) {
+    return c == '\0' || c == '>' || c == '/' || c == '=' || c == '"' || Character.isWhitespace(c);
+  }
+}

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/NormalElementTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/NormalElementTokenizer.java
@@ -19,6 +19,7 @@ package org.sonar.plugins.html.lex;
 import java.util.List;
 import org.sonar.plugins.html.node.Node;
 import org.sonar.sslr.channel.CodeReader;
+import org.sonar.sslr.channel.EndMatcher;
 
 public class NormalElementTokenizer extends ElementTokenizer {
 
@@ -36,6 +37,11 @@ public class NormalElementTokenizer extends ElementTokenizer {
       i++;
     }
     return isValidTagNameStartChar(codeReader, i) && super.consume(codeReader, nodeList);
+  }
+
+  @Override
+  protected EndMatcher getEndMatcher(CodeReader codeReader) {
+    return new HtmlElementEndMatcher(codeReader);
   }
 
   /**

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/NestedJavaScriptCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/scripting/NestedJavaScriptCheckTest.java
@@ -19,6 +19,8 @@ package org.sonar.plugins.html.checks.scripting;
 import java.io.File;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.sonar.plugins.html.checks.CheckMessagesVerifierRule;
 import org.sonar.plugins.html.checks.TestHelper;
 import org.sonar.plugins.html.visitor.HtmlSourceCode;
@@ -28,17 +30,15 @@ class NestedJavaScriptCheckTest {
   @RegisterExtension
   public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
 
-  @Test
-  void no_violations_should_be_reported_for_correct_script_tags() {
+  @ParameterizedTest
+  @ValueSource(strings = {
+    "CorrectScriptTags.html",
+    "CorrectScriptTags.vue",
+    "SingleQuotedAttributeWithLessThan.vue",
+  })
+  void no_violations_on_well_formed_script_tags(String fixture) {
     NestedJavaScriptCheck check = new NestedJavaScriptCheck();
-    HtmlSourceCode sourceCode = TestHelper.scan(new File("src/test/resources/checks/NestedJavaScriptCheck/CorrectScriptTags.html"), check);
-    checkMessagesVerifier.verify(sourceCode.getIssues()).noMore();
-  }
-
-  @Test
-  void no_violations_should_be_reported_for_correct_script_tags_in_vue_templates() {
-    NestedJavaScriptCheck check = new NestedJavaScriptCheck();
-    HtmlSourceCode sourceCode = TestHelper.scan(new File("src/test/resources/checks/NestedJavaScriptCheck/CorrectScriptTags.vue"), check);
+    HtmlSourceCode sourceCode = TestHelper.scan(new File("src/test/resources/checks/NestedJavaScriptCheck/" + fixture), check);
     checkMessagesVerifier.verify(sourceCode.getIssues()).noMore();
   }
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/PageLexerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/PageLexerTest.java
@@ -612,6 +612,75 @@ class PageLexerTest {
     assertThat(nodeList.get(0).getCode()).isEqualTo("<?php\n/* it's a test */\n$x = 1;\n?>");
   }
 
+  @Test
+  void tag_with_lt_inside_single_quoted_attribute_does_not_extend_boundary() {
+    List<Node> nodes = new PageLexer().parse(new StringReader("<input :disabled='x<1' /><p>hello</p>"));
+    assertThat(nodes).extracting(Node::getCode).containsExactly("<input :disabled='x<1' />", "<p>", "hello", "</p>");
+    assertThat(((TagNode) nodes.get(0)).hasEnd()).isTrue();
+  }
+
+  @Test
+  void jsp_scriptlet_with_stray_apostrophe_does_not_swallow_end_token() {
+    String jsp = "<%\n/* Add l'evenement */\nString s = \"x\";\n%><p>hello</p>";
+    List<Node> nodes = new PageLexer().parse(new StringReader(jsp));
+    assertThat(nodes).extracting(Node::getNodeType).containsExactly(NodeType.EXPRESSION, NodeType.TAG, NodeType.TEXT, NodeType.TAG);
+    assertThat(nodes.get(0).getCode()).endsWith("%>");
+    assertThat(((TagNode) nodes.get(1)).getNodeName()).isEqualTo("p");
+  }
+
+  @Test
+  void el_string_literal_inside_single_quoted_attribute_does_not_close_outer_scope() {
+    String src = "<a rel='<c:url value=\"x\"><c:param value=\"${'Attachment'}\"/></c:url>' href=\"#\">\n<p>after</p>";
+    List<Node> nodes = new PageLexer().parse(new StringReader(src));
+    assertThat(nodes).extracting(Node::getNodeType).containsExactly(NodeType.TAG, NodeType.TEXT, NodeType.TAG, NodeType.TEXT, NodeType.TAG);
+    assertThat(((TagNode) nodes.get(0)).getNodeName()).isEqualTo("a");
+    assertThat(((TagNode) nodes.get(2)).getNodeName()).isEqualTo("p");
+  }
+
+  @Test
+  void jsp_scriptlet_with_java_char_literal_does_not_swallow_html() {
+    String jsp = "<% if (c == '/') { out.println(\"x\"); } %><p>after</p>";
+    List<Node> nodes = new PageLexer().parse(new StringReader(jsp));
+    assertThat(nodes).extracting(Node::getNodeType).containsExactly(NodeType.EXPRESSION, NodeType.TAG, NodeType.TEXT, NodeType.TAG);
+    assertThat(nodes.get(0).getCode()).endsWith("%>");
+    assertThat(((TagNode) nodes.get(1)).getNodeName()).isEqualTo("p");
+  }
+
+  @Test
+  void tag_with_two_single_quoted_attributes_both_close_correctly() {
+    List<Node> nodes = new PageLexer().parse(new StringReader("<input a='x' b='y<z'><p>x</p>"));
+    assertThat(nodes).extracting(Node::getCode).containsExactly("<input a='x' b='y<z'>", "<p>", "x", "</p>");
+    TagNode input = (TagNode) nodes.get(0);
+    assertThat(input.getNodeName()).isEqualTo("input");
+    assertThat(input.getAttributes()).extracting(a -> a.getName() + "=" + a.getValue())
+      .containsExactly("a=x", "b=y<z");
+  }
+
+  @Test
+  void unterminated_single_quoted_attribute_at_eof_does_not_loop() {
+    List<Node> nodes = new PageLexer().parse(new StringReader("<input attr='no-end"));
+    assertThat(nodes).hasSize(1);
+    assertThat(((TagNode) nodes.get(0)).getNodeName()).isEqualTo("input");
+  }
+
+  @Test
+  void jsp_directive_with_apostrophe_inside_double_quoted_value_unchanged() {
+    String jsp = "<%@ taglib uri=\"x'y\" %><p>x</p>";
+    List<Node> nodes = new PageLexer().parse(new StringReader(jsp));
+    assertThat(nodes).extracting(Node::getNodeType).containsExactly(NodeType.DIRECTIVE, NodeType.TAG, NodeType.TEXT, NodeType.TAG);
+    assertThat(nodes.get(0).getCode()).endsWith("%>");
+    assertThat(((TagNode) nodes.get(1)).getNodeName()).isEqualTo("p");
+  }
+
+  @Test
+  void jsp_scriptlet_inside_single_quoted_attribute_is_opaque() {
+    String src = "<input value='<% if (c == '/') { out.println(\"x\"); } %>' /><p>after</p>";
+    List<Node> nodes = new PageLexer().parse(new StringReader(src));
+    assertThat(nodes).extracting(Node::getCode).containsExactly(
+      "<input value='<% if (c == '/') { out.println(\"x\"); } %>' />",
+      "<p>", "after", "</p>");
+  }
+
   private void assertSingleTag(String code) {
     StringReader reader = new StringReader(code);
     List<Node> nodeList = new PageLexer().parse(reader);

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/VueLexerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/VueLexerTest.java
@@ -49,7 +49,10 @@ class VueLexerTest {
             Arguments.of("<template><foo/><bar/><baz/></template><template><qux/></template>", 3),
             Arguments.of("<template><template><template><template></template></template></template></template>", 6),
             Arguments.of("<template><foo/><bar/>", 2),
-            Arguments.of("<foo/><bar/></template>", 0)
+            Arguments.of("<foo/><bar/></template>", 0),
+            Arguments.of("<template><Comp :disabled='x<1' /></template><script>let f = () => 0</script>", 1),
+            Arguments.of("<template><Comp :on='a>b' /></template>", 1),
+            Arguments.of("<template><Comp :x='\"y<z\"' /></template>", 1)
     );
   }
 

--- a/sonar-html-plugin/src/test/resources/checks/NestedJavaScriptCheck/SingleQuotedAttributeWithLessThan.vue
+++ b/sonar-html-plugin/src/test/resources/checks/NestedJavaScriptCheck/SingleQuotedAttributeWithLessThan.vue
@@ -1,0 +1,11 @@
+<template>
+    <div class="container">
+        <section>
+            <CheckerSearch v-model="searchValue"  @search="handleSearch" :disabled='searchValue.length<1' />
+        </section>
+    </div>
+</template>
+
+<script>
+    setTimeout(() => {  })
+</script>


### PR DESCRIPTION
## Summary
Fix S4645 false positive on Vue SFCs where a single-quoted attribute contains `<` (e.g. `:disabled='searchValue.length<1'`). The shared element-boundary matcher only tracked double quotes, so `<` inside `'...'` was counted as a nested tag and the surrounding HTML structure got swallowed.

## Changes
- New `HtmlElementEndMatcher` used only by `NormalElementTokenizer`. The shared `AbstractTokenizer.EndTokenMatcher` is left untouched so JSP/PHP/directive parsing is unaffected.
- The new matcher tracks single-quoted attribute values and treats `<%...%>` as an opaque sub-scope, so `'` in surrounding code (EL string literals, Java/Ruby char literals) doesn't fool the boundary detection.
- New regression tests in `PageLexerTest` and `NestedJavaScriptCheckTest`; ruling integration test is byte-identical to master on the full corpus.

## Functional Validation
Attached: `SONARHTML-255-fv.zip`

Unzip and run:
    ./run.sh

Expected output is in `expected-output.txt`. The README shows the
before/after comparison so you can reproduce the difference directly.

