### PR TITLE
SONARHTML-246 Splice embedded HTML from PHP strings into the analysis pipeline

### DIFF
--- a/its/ruling/src/test/resources/expected/Web-S6841.json
+++ b/its/ruling/src/test/resources/expected/Web-S6841.json
@@ -1490,8 +1490,11 @@
 11
 ],
 "project:phpMyAdmin-4.0.4-english/libraries/sql_query_form.lib.php": [
+250,
 310,
 313,
-318
+318,
+346,
+365
 ]
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/EmbeddedHtmlCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/EmbeddedHtmlCheck.java
@@ -1,0 +1,44 @@
+/*
+ * SonarQube HTML
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.html.checks;
+
+/**
+ * Callback opt-in for checks that want to receive visitor events
+ * ({@code startElement}, {@code endElement}, {@code characters}, …) for HTML
+ * nodes extracted from PHP string literals by {@code PhpEmbeddedHtmlExtractor}.
+ *
+ * <p><b>What this controls:</b> visitor callbacks only. A check that does
+ * <em>not</em> implement this interface will not receive {@code startElement}
+ * etc. for nodes whose {@link org.sonar.plugins.html.node.Node#isEmbedded()}
+ * flag is {@code true}.
+ *
+ * <p><b>What this does not control:</b> AST visibility. The full node list —
+ * including embedded nodes — is still passed to every check's
+ * {@link org.sonar.plugins.html.visitor.DefaultNodeVisitor#startDocument(java.util.List)},
+ * and the parent/child hierarchy remains intact. Non-opted-in checks can
+ * therefore still observe embedded nodes by iterating the {@code startDocument}
+ * list or calling {@link org.sonar.plugins.html.node.Node#getChildren()}, and
+ * can call {@link org.sonar.plugins.html.node.Node#isEmbedded()} to filter when
+ * needed.
+ *
+ * <p>Only standalone single-element or single-attribute checks should opt in.
+ * Checks that reconstruct a DOM from the full node list or that rely on sibling
+ * or ancestor relationships should <em>not</em> opt in; they already reach
+ * embedded nodes through the tree.
+ */
+public interface EmbeddedHtmlCheck {
+}

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaProptypesCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaProptypesCheck.java
@@ -25,12 +25,13 @@ import org.sonar.plugins.html.api.Helpers;
 import org.sonar.plugins.html.api.accessibility.Aria;
 import org.sonar.plugins.html.api.accessibility.AriaProperty;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
+import org.sonar.plugins.html.checks.EmbeddedHtmlCheck;
 import org.sonar.plugins.html.api.accessibility.Aria.AriaPropertyValues;
 import org.sonar.plugins.html.api.accessibility.Aria.AriaPropertyType;
 import org.sonar.plugins.html.node.TagNode;
 
 @Rule(key = "S6793")
-public class AriaProptypesCheck extends AbstractPageCheck {
+public class AriaProptypesCheck extends AbstractPageCheck implements EmbeddedHtmlCheck {
 
   @Override
   public void startElement(TagNode element) {
@@ -45,7 +46,7 @@ public class AriaProptypesCheck extends AbstractPageCheck {
       }
 
       var value = attribute.getValue();
-      if (Helpers.isDynamicValue(value, getHtmlSourceCode())) {
+      if (Helpers.containsDynamicValue(value, getHtmlSourceCode())) {
         continue;
       }
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaRoleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaRoleCheck.java
@@ -22,14 +22,15 @@ import org.sonar.check.Rule;
 import org.sonar.plugins.html.api.Helpers;
 import org.sonar.plugins.html.api.accessibility.AriaRole;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
+import org.sonar.plugins.html.checks.EmbeddedHtmlCheck;
 import org.sonar.plugins.html.node.TagNode;
 
 @Rule(key = "S6821")
-public class AriaRoleCheck extends AbstractPageCheck {
+public class AriaRoleCheck extends AbstractPageCheck implements EmbeddedHtmlCheck {
   @Override
   public void startElement(TagNode element) {
     var role = element.getAttribute("role");
-    if (role == null || Helpers.isDynamicValue(role, getHtmlSourceCode())) {
+    if (role == null || Helpers.containsDynamicValue(role, getHtmlSourceCode())) {
       return;
     }
     var values = role.split(" ");

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ElementWithRoleShouldHaveRequiredPropertiesCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ElementWithRoleShouldHaveRequiredPropertiesCheck.java
@@ -24,15 +24,16 @@ import org.sonar.plugins.html.api.accessibility.Aria;
 import org.sonar.plugins.html.api.accessibility.AriaRole;
 import org.sonar.plugins.html.api.accessibility.Aria.RoleDefinition;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
+import org.sonar.plugins.html.checks.EmbeddedHtmlCheck;
 import org.sonar.plugins.html.node.TagNode;
 
 @Rule(key = "S6807")
-public class ElementWithRoleShouldHaveRequiredPropertiesCheck extends AbstractPageCheck {
+public class ElementWithRoleShouldHaveRequiredPropertiesCheck extends AbstractPageCheck implements EmbeddedHtmlCheck {
   @Override
   public void startElement(TagNode element) {
     var roleName = element.getAttribute("role");
 
-    if (roleName == null || Helpers.isDynamicValue(roleName, getHtmlSourceCode())) {
+    if (roleName == null || Helpers.containsDynamicValue(roleName, getHtmlSourceCode())) {
       return;
     }
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/FocusableInteractiveElementsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/FocusableInteractiveElementsCheck.java
@@ -31,10 +31,11 @@ import java.util.Set;
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.api.Helpers;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
+import org.sonar.plugins.html.checks.EmbeddedHtmlCheck;
 import org.sonar.plugins.html.node.TagNode;
 
 @Rule(key = "S6852")
-public class FocusableInteractiveElementsCheck extends AbstractPageCheck {
+public class FocusableInteractiveElementsCheck extends AbstractPageCheck implements EmbeddedHtmlCheck {
 
   private static final String MESSAGE_TEMPLATE = "Elements with the \"%s\" interactive role must be focusable.";
 
@@ -47,7 +48,7 @@ public class FocusableInteractiveElementsCheck extends AbstractPageCheck {
   @Override
   public void startElement(TagNode element) {
     var role = element.getAttribute("role");
-    if (role == null || Helpers.isDynamicValue(role, getHtmlSourceCode())) {
+    if (role == null || Helpers.containsDynamicValue(role, getHtmlSourceCode())) {
       return;
     }
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoRedundantRolesCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoRedundantRolesCheck.java
@@ -30,11 +30,12 @@ import org.sonar.check.RuleProperty;
 import org.sonar.plugins.html.api.Helpers;
 import org.sonar.plugins.html.api.accessibility.AriaRole;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
+import org.sonar.plugins.html.checks.EmbeddedHtmlCheck;
 import org.sonar.plugins.html.node.Node;
 import org.sonar.plugins.html.node.TagNode;
 
 @Rule(key = "S6822")
-public class NoRedundantRolesCheck extends AbstractPageCheck {
+public class NoRedundantRolesCheck extends AbstractPageCheck implements EmbeddedHtmlCheck {
 
   private static final String DEFAULT_ALLOWED_REDUNDANT_ROLES = "nav=navigation";
   @RuleProperty(
@@ -54,7 +55,7 @@ public class NoRedundantRolesCheck extends AbstractPageCheck {
   public void startElement(TagNode element) {
     var implicitRole = getImplicitRole(element);
     var explicitRoleRaw = element.getAttribute("role");
-    if (explicitRoleRaw == null || Helpers.isDynamicValue(explicitRoleRaw, getHtmlSourceCode())) {
+    if (explicitRoleRaw == null || Helpers.containsDynamicValue(explicitRoleRaw, getHtmlSourceCode())) {
       return;
     }
     var explicitRole = AriaRole.of(explicitRoleRaw.toLowerCase(Locale.ROOT));

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/TabIndexNoPositiveCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/TabIndexNoPositiveCheck.java
@@ -18,10 +18,11 @@ package org.sonar.plugins.html.checks.accessibility;
 
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
+import org.sonar.plugins.html.checks.EmbeddedHtmlCheck;
 import org.sonar.plugins.html.node.TagNode;
 
 @Rule(key = "S6841")
-public class TabIndexNoPositiveCheck extends AbstractPageCheck {
+public class TabIndexNoPositiveCheck extends AbstractPageCheck implements EmbeddedHtmlCheck {
 
   @Override
   public void startElement(TagNode element) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/ElementTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/ElementTokenizer.java
@@ -175,9 +175,6 @@ class ElementTokenizer extends AbstractTokenizer<List<Node>> {
     element.setNodeName(sbNodeName.toString());
   }
 
-  /**
-   * Unescape the quotes from the attribute value.
-   */
   private static String unescapeQuotes(String value, char ch) {
     return value.replaceAll("\\\\" + ch, Character.toString(ch));
   }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/PageLexer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/PageLexer.java
@@ -17,6 +17,7 @@
 package org.sonar.plugins.html.lex;
 
 import java.io.Reader;
+import java.io.StringReader;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -72,7 +73,7 @@ public class PageLexer {
    * Void elements can't have any content
    * See https://html.spec.whatwg.org/multipage/syntax.html#void-elements
    */
-  private static final Set<String> VOID_ELEMENTS = new HashSet<>(Arrays.asList("area", "base", "br", "col", "embed",
+  static final Set<String> VOID_ELEMENTS = new HashSet<>(Arrays.asList("area", "base", "br", "col", "embed",
     "hr", "img", "input", "link", "meta", "param", "source", "track", "wbr"));
 
   private static final Set<String> METADATA_CONTENT = new HashSet<>(Arrays.asList("base", "link", "meta", "noscript",
@@ -116,6 +117,7 @@ public class PageLexer {
 
   /**
    * Parse the input into a list of tokens, with parent/child relations between the tokens.
+   * HTML found inside PHP string literals is also extracted and included in the returned list.
    */
   public List<Node> parse(Reader reader) {
 
@@ -129,8 +131,22 @@ public class PageLexer {
     ChannelDispatcher<List<Node>> channelDispatcher = ChannelDispatcher.builder().addChannels((Channel[]) tokenizers.toArray(new Channel[tokenizers.size()])).build();
     channelDispatcher.consume(codeReader, nodeList);
 
-    createNodeHierarchy(nodeList);
+    List<Node> expanded = PhpEmbeddedHtmlExtractor.expand(nodeList);
+    createNodeHierarchy(expanded);
 
+    return expanded;
+  }
+
+  /**
+   * Parse a source string into a list of tokens without building parent/child relations.
+   */
+  List<Node> parseWithoutHierarchy(String source) {
+    CodeReader codeReader = new CodeReader(new StringReader(source));
+    List<Node> nodeList = new ArrayList<>();
+    ChannelDispatcher<List<Node>> channelDispatcher = ChannelDispatcher.builder()
+      .addChannels((Channel[]) tokenizers.toArray(new Channel[tokenizers.size()]))
+      .build();
+    channelDispatcher.consume(codeReader, nodeList);
     return nodeList;
   }
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/PhpEmbeddedHtmlExtractor.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/PhpEmbeddedHtmlExtractor.java
@@ -1,0 +1,766 @@
+/*
+ * SonarQube HTML
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.html.lex;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.sonar.plugins.html.node.Attribute;
+import org.sonar.plugins.html.node.DirectiveNode;
+import org.sonar.plugins.html.node.Node;
+import org.sonar.plugins.html.node.NodeType;
+import org.sonar.plugins.html.node.TagNode;
+import org.sonar.plugins.html.node.TextNode;
+
+/**
+ * Extracts HTML nodes from PHP string literals embedded inside PHP directives
+ * and splices them into the main node list so that all visitors receive the
+ * full analysis lifecycle (startElement/characters/endElement/...) for the
+ * embedded HTML, with accurate file-coordinate positions.
+ */
+final class PhpEmbeddedHtmlExtractor {
+
+  private static final Pattern INTERPOLATION = Pattern.compile(
+    "\\{\\$[^}]+\\}|\\$\\{?[a-zA-Z_]\\w*\\}?");
+  // Accept tags (<a, </a), DOCTYPE declarations (<!DOCTYPE), and HTML comments (<!--).
+  private static final Pattern EMBEDDED_HTML = Pattern.compile("<\\s*[/!a-zA-Z]");
+  private static final String DYNAMIC_PLACEHOLDER = "${dynamic}";
+  // initial slack for embedded nodes per directive
+  private static final int EXTRA_CAPACITY = 8;
+  // shared sentinel: heredoc bodies have no per-character source-column map
+  private static final int[][] EMPTY_COLUMNS = new int[0][];
+
+  /**
+   * Returns a new list with embedded HTML nodes spliced in after each PHP directive
+   * that contains HTML in string literals. The directive node itself is preserved.
+   *
+   * @param nodes flat list produced by the channel-dispatcher tokenizers
+   * @return a new list with the same nodes plus any embedded HTML spliced in
+   *         right after each PHP directive that contained it
+   */
+  static List<Node> expand(List<Node> nodes) {
+    List<Node> result = new ArrayList<>(nodes.size() + EXTRA_CAPACITY);
+    for (Node node : nodes) {
+      result.add(node);
+      if (node instanceof DirectiveNode directive && isPhpDirective(directive)) {
+        spliceEmbedded(directive, result);
+      }
+    }
+    return result;
+  }
+
+  private static void spliceEmbedded(DirectiveNode directive, List<Node> result) {
+    List<Node> directiveEmbedded = new ArrayList<>();
+    String code = directive.getCode();
+    // Pull every PHP string literal out of the directive.
+    List<StringLiteral> literals = extractLiterals(directive);
+    int prevHtmlIdx = -1;
+    for (int i = 0; i < literals.size(); i++) {
+      StringLiteral literal = literals.get(i);
+      String sanitized = sanitizeIfInterpolated(literal);
+      // Skip literals that carry no HTML.
+      if (!EMBEDDED_HTML.matcher(sanitized).find()) {
+        continue;
+      }
+      // Bridge the gap to the previous HTML literal in this directive.
+      if (prevHtmlIdx >= 0) {
+        bridgeGap(directive, code, literals, prevHtmlIdx, i, directiveEmbedded);
+      }
+      // Re-lex as HTML, rebase positions to file coordinates.
+      List<Node> embedded = reLex(sanitized);
+      rebasePositions(embedded, literal);
+      directiveEmbedded.addAll(embedded);
+      prevHtmlIdx = i;
+    }
+    // Close any tag left open across the directive's literals.
+    balanceUnclosedTags(directiveEmbedded);
+    // Stamp every spliced node so the scanner can route them only to checks
+    // that opt in via EmbeddedHtmlCheck.
+    for (Node node : directiveEmbedded) {
+      node.setEmbedded(true);
+    }
+    // Splice the embedded HTML right after the directive node.
+    result.addAll(directiveEmbedded);
+  }
+
+  private static String sanitizeIfInterpolated(StringLiteral literal) {
+    return literal.interpolated()
+      ? sanitizeInterpolations(literal.value())
+      : literal.value();
+  }
+
+  private static void bridgeGap(DirectiveNode directive, String code, List<StringLiteral> literals,
+                                int prevHtmlIdx, int currentIdx, List<Node> sink) {
+    StringLiteral prev = literals.get(prevHtmlIdx);
+    StringLiteral current = literals.get(currentIdx);
+    List<StringLiteral> intermediates = literals.subList(prevHtmlIdx + 1, currentIdx);
+    if (isPureConcatenation(code, prev.rawEnd(), current.rawStart(), intermediates)) {
+      // Pure concat: surface skipped literals as real text.
+      for (StringLiteral inter : intermediates) {
+        if (!inter.value().isEmpty()) {
+          sink.add(literalTextNode(inter));
+        }
+      }
+    } else {
+      // Runtime expression: opaque non-blank placeholder.
+      sink.add(dynamicGapText(directive));
+    }
+  }
+
+  /**
+   * Returns {@code true} when the raw directive code from {@code from} to
+   * {@code to} contains nothing that could change runtime output beyond pure
+   * string concatenation. Allowed tokens are whitespace, the PHP concatenation
+   * operator {@code .}, grouping parentheses, line and block comments, and the
+   * source spans of {@code intermediates} (literals that were extracted but
+   * carry no HTML and are therefore subtracted from the gap).
+   *
+   * @param code          the directive's raw code
+   * @param from          inclusive position to start scanning at
+   * @param to            exclusive position to stop scanning at
+   * @param intermediates literals fully contained inside {@code [from, to)};
+   *                      their source spans are skipped during the scan
+   * @return {@code true} iff no PHP expression sits between the two anchoring
+   *         HTML-bearing literals
+   */
+  private static boolean isPureConcatenation(String code, int from, int to, List<StringLiteral> intermediates) {
+    int idx = 0;
+    int pos = from;
+    while (pos < to) {
+      if (idx < intermediates.size() && pos == intermediates.get(idx).rawStart()) {
+        pos = intermediates.get(idx).rawEnd();
+        idx++;
+      } else {
+        int advanced = advancePastTrivialToken(code, pos, to);
+        if (advanced < 0) {
+          return false;
+        }
+        pos = advanced;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Advances past one whitespace/concat/comment token starting at {@code pos}.
+   * Returns the new position, or {@code -1} when {@code code.charAt(pos)} is
+   * not a token the pure-concatenation scan allows.
+   */
+  private static int advancePastTrivialToken(String code, int pos, int to) {
+    char ch = code.charAt(pos);
+    if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' || ch == '.' || ch == '(' || ch == ')') {
+      return pos + 1;
+    }
+    if (ch == '#' || (ch == '/' && pos + 1 < to && code.charAt(pos + 1) == '/')) {
+      int p = pos;
+      while (p < to && code.charAt(p) != '\n') {
+        p++;
+      }
+      return p;
+    }
+    if (ch == '/' && pos + 1 < to && code.charAt(pos + 1) == '*') {
+      int p = pos + 2;
+      while (p + 1 < to && !(code.charAt(p) == '*' && code.charAt(p + 1) == '/')) {
+        p++;
+      }
+      return Math.min(to, p + 2);
+    }
+    return -1;
+  }
+
+  static boolean isPhpDirective(DirectiveNode node) {
+    String name = node.getNodeName();
+    if (name == null) {
+      return false;
+    }
+    name = name.toLowerCase(Locale.ROOT);
+    return name.startsWith("?php") || name.equals("?=");
+  }
+
+  /**
+   * Scans the directive's raw code and extracts every string literal with its
+   * file-coordinate origin (line/column of the first content character).
+   *
+   * <p>Handles double-quoted strings, single-quoted strings, heredoc, nowdoc,
+   * line comments ({@code //}, {@code #}), and block comments ({@code /* }).
+   *
+   * @param node the PHP directive whose raw code is scanned
+   * @return the string literals found in {@code node.getCode()}, in source order,
+   *         each carrying its decoded value and the source coordinates of its
+   *         first content character
+   */
+  static List<StringLiteral> extractLiterals(DirectiveNode node) {
+    List<StringLiteral> result = new ArrayList<>();
+    String code = node.getCode();
+    Cursor c = new Cursor(0, node.getStartLinePosition(), node.getStartColumnPosition());
+    while (c.pos < code.length()) {
+      StringLiteral literal = readNextLiteral(code, c);
+      if (literal != null) {
+        result.add(literal);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Advances {@code c} past whitespace, comments, and any non-literal token,
+   * returning the next extracted {@link StringLiteral} or {@code null} when the
+   * cursor stops at a position that does not start a literal (e.g. EOF).
+   */
+  private static StringLiteral readNextLiteral(String code, Cursor c) {
+    int len = code.length();
+    while (c.pos < len) {
+      char ch = code.charAt(c.pos);
+      if (ch == '\n') {
+        c.line++;
+        c.col = 0;
+        c.pos++;
+      } else if (ch == '#' || (ch == '/' && c.pos + 1 < len && code.charAt(c.pos + 1) == '/')) {
+        skipLineComment(code, c);
+      } else if (ch == '/' && c.pos + 1 < len && code.charAt(c.pos + 1) == '*') {
+        skipBlockComment(code, c);
+      } else if (ch == '<' && c.pos + 2 < len && code.charAt(c.pos + 1) == '<' && code.charAt(c.pos + 2) == '<') {
+        int rawStart = c.pos;
+        return readHeredocOrNowdoc(code, c, rawStart);
+      } else if (ch == '"') {
+        int rawStart = c.pos;
+        return readDoubleQuotedString(code, c, rawStart);
+      } else if (ch == '\'') {
+        int rawStart = c.pos;
+        return readSingleQuotedString(code, c, rawStart);
+      } else {
+        c.col++;
+        c.pos++;
+      }
+    }
+    return null;
+  }
+
+  private static void skipLineComment(String code, Cursor c) {
+    while (c.pos < code.length() && code.charAt(c.pos) != '\n') {
+      c.col++;
+      c.pos++;
+    }
+  }
+
+  private static void skipBlockComment(String code, Cursor c) {
+    c.col += 2;
+    c.pos += 2;
+    int len = code.length();
+    while (c.pos + 1 < len && !(code.charAt(c.pos) == '*' && code.charAt(c.pos + 1) == '/')) {
+      if (code.charAt(c.pos) == '\n') {
+        c.line++;
+        c.col = 0;
+      } else {
+        c.col++;
+      }
+      c.pos++;
+    }
+    if (c.pos + 1 < len) {
+      c.col += 2;
+      c.pos += 2;
+    }
+  }
+
+  private static StringLiteral readHeredocOrNowdoc(String code, Cursor c, int rawStart) {
+    // skip <<<
+    c.col += 3;
+    c.pos += 3;
+    skipSpaces(code, c);
+    boolean nowdoc = c.pos < code.length() && code.charAt(c.pos) == '\'';
+    if (nowdoc) {
+      c.col++;
+      c.pos++;
+    }
+    String label = readHeredocLabel(code, c);
+    if (label.isEmpty()) {
+      return null;
+    }
+    if (nowdoc && c.pos < code.length() && code.charAt(c.pos) == '\'') {
+      c.col++;
+      c.pos++;
+    }
+    skipUntilNewline(code, c);
+    consumeNewline(code, c);
+    return readHeredocBody(code, c, label, !nowdoc, rawStart);
+  }
+
+  private static void skipSpaces(String code, Cursor c) {
+    while (c.pos < code.length() && code.charAt(c.pos) == ' ') {
+      c.col++;
+      c.pos++;
+    }
+  }
+
+  private static void skipUntilNewline(String code, Cursor c) {
+    while (c.pos < code.length() && code.charAt(c.pos) != '\n') {
+      c.col++;
+      c.pos++;
+    }
+  }
+
+  private static void consumeNewline(String code, Cursor c) {
+    if (c.pos < code.length()) {
+      c.line++;
+      c.col = 0;
+      c.pos++;
+    }
+  }
+
+  private static String readHeredocLabel(String code, Cursor c) {
+    StringBuilder label = new StringBuilder();
+    while (c.pos < code.length() && code.charAt(c.pos) != '\'' && code.charAt(c.pos) != '"'
+      && code.charAt(c.pos) != '\n' && !Character.isWhitespace(code.charAt(c.pos))) {
+      label.append(code.charAt(c.pos));
+      c.col++;
+      c.pos++;
+    }
+    return label.toString();
+  }
+
+  /**
+   * Returns {@code null} when EOF is reached before the closing label is seen
+   * (malformed heredoc / typo in terminator); the caller drops the literal so
+   * downstream re-lexing does not swallow the rest of the directive as HTML.
+   *
+   * @param code         the directive's raw code
+   * @param c            cursor positioned at the first body character (just past
+   *                     the {@code <<<LABEL\n} header)
+   * @param label        the closing label that terminates the body
+   * @param interpolated {@code true} for heredoc (variable interpolation
+   *                     applies), {@code false} for nowdoc (literal body)
+   * @param rawStart     position of the opening {@code <<<} in the directive's
+   *                     raw code, used to anchor the gap-analysis pass that
+   *                     decides whether a dynamic placeholder is needed
+   *                     between two HTML-bearing literals
+   * @return the heredoc/nowdoc body literal, or {@code null} if EOF is reached
+   *         before the closing label is seen
+   */
+  private static StringLiteral readHeredocBody(String code, Cursor c, String label, boolean interpolated, int rawStart) {
+    int bodyLine = c.line;
+    int bodyCol = c.col;
+    StringBuilder body = new StringBuilder();
+    int len = code.length();
+    boolean terminatorFound = false;
+    while (c.pos < len) {
+      int lineStart = c.pos;
+      int indentLen = measureLineIndent(code, c, len);
+      if (isHeredocTerminatorLine(code, c, label, len)) {
+        if (indentLen > 0 && !body.isEmpty()) {
+          body = stripHeredocIndent(body, indentLen);
+        }
+        skipUntilNewline(code, c);
+        consumeNewline(code, c);
+        terminatorFound = true;
+        break;
+      }
+      c.pos = lineStart;
+      copyBodyLine(code, c, body, len);
+    }
+    if (!terminatorFound) {
+      return null;
+    }
+    return new StringLiteral(body.toString(), bodyLine, bodyCol, interpolated, EMPTY_COLUMNS, rawStart, c.pos);
+  }
+
+  private static int measureLineIndent(String code, Cursor c, int len) {
+    int indentLen = 0;
+    while (c.pos < len && (code.charAt(c.pos) == ' ' || code.charAt(c.pos) == '\t')) {
+      c.pos++;
+      indentLen++;
+    }
+    return indentLen;
+  }
+
+  private static boolean isHeredocTerminatorLine(String code, Cursor c, String label, int len) {
+    return code.regionMatches(c.pos, label, 0, label.length())
+      && isHeredocEnd(code, c.pos + label.length(), len);
+  }
+
+  private static void copyBodyLine(String code, Cursor c, StringBuilder body, int len) {
+    while (c.pos < len && code.charAt(c.pos) != '\n') {
+      body.append(code.charAt(c.pos));
+      c.col++;
+      c.pos++;
+    }
+    if (c.pos < len) {
+      body.append('\n');
+      c.line++;
+      c.col = 0;
+      c.pos++;
+    }
+  }
+
+  private static boolean isHeredocEnd(String code, int afterLabel, int len) {
+    return afterLabel >= len || code.charAt(afterLabel) == ';'
+      || code.charAt(afterLabel) == '\n' || code.charAt(afterLabel) == '\r';
+  }
+
+  private static StringBuilder stripHeredocIndent(StringBuilder body, int indentLen) {
+    String[] lines = body.toString().split("\n", -1);
+    StringBuilder stripped = new StringBuilder(body.length());
+    for (int li = 0; li < lines.length; li++) {
+      String line = lines[li];
+      stripped.append(line.length() >= indentLen ? line.substring(indentLen) : line);
+      if (li < lines.length - 1) {
+        stripped.append('\n');
+      }
+    }
+    return stripped;
+  }
+
+  private static StringLiteral readDoubleQuotedString(String code, Cursor c, int rawStart) {
+    // skip opening "
+    c.col++;
+    c.pos++;
+    int contentLine = c.line;
+    int contentCol = c.col;
+    LiteralBuilder builder = new LiteralBuilder();
+    int len = code.length();
+    while (c.pos < len) {
+      char cc = code.charAt(c.pos);
+      if (cc == '\\' && c.pos + 1 < len) {
+        appendDoubleEscape(code.charAt(c.pos + 1), cc, builder, c);
+      } else if (cc == '"') {
+        c.col++;
+        c.pos++;
+        break;
+      } else {
+        appendLiteralChar(builder, c, cc);
+      }
+    }
+    return new StringLiteral(builder.text(), contentLine, contentCol, true, builder.sourceColumns(), rawStart, c.pos);
+  }
+
+  private static void appendLiteralChar(LiteralBuilder builder, Cursor c, char cc) {
+    builder.append(cc, c.col);
+    if (cc == '\n') {
+      c.line++;
+      c.col = 0;
+    } else {
+      c.col++;
+    }
+    c.pos++;
+  }
+
+  /**
+   * Decodes a PHP double-quoted escape sequence. {@code \n}, {@code \r} and
+   * {@code \t} are emitted as a single space rather than the corresponding
+   * control character so that the re-lex line counter is not advanced past the
+   * literal's true source line.
+   *
+   * @param next      the character following the leading backslash
+   * @param backslash the leading backslash itself, written verbatim for unknown
+   *                  escape sequences
+   * @param builder   accumulator for the decoded literal value and its per-char
+   *                  source-column map
+   * @param c         cursor positioned at the backslash; advanced past the
+   *                  escape sequence (one or two source chars) on return
+   */
+  private static void appendDoubleEscape(char next, char backslash, LiteralBuilder builder, Cursor c) {
+    int srcCol = c.col;
+    char decoded;
+    switch (next) {
+      case '"':
+        decoded = '"';
+        break;
+      case '\\':
+        decoded = '\\';
+        break;
+      case '$':
+        decoded = '$';
+        break;
+      case 'n', 'r', 't':
+        decoded = ' ';
+        break;
+      default:
+        builder.append(backslash, srcCol);
+        c.col++;
+        c.pos++;
+        return;
+    }
+    builder.append(decoded, srcCol);
+    c.col += 2;
+    c.pos += 2;
+  }
+
+  private static StringLiteral readSingleQuotedString(String code, Cursor c, int rawStart) {
+    // skip opening '
+    c.col++;
+    c.pos++;
+    int contentLine = c.line;
+    int contentCol = c.col;
+    LiteralBuilder builder = new LiteralBuilder();
+    int len = code.length();
+    while (c.pos < len) {
+      char cc = code.charAt(c.pos);
+      if (cc == '\\' && c.pos + 1 < len) {
+        appendSingleEscape(code.charAt(c.pos + 1), cc, builder, c);
+      } else if (cc == '\'') {
+        c.col++;
+        c.pos++;
+        break;
+      } else {
+        appendLiteralChar(builder, c, cc);
+      }
+    }
+    // Single-quoted strings do not interpolate variables in PHP, so the
+    // sanitisation pass that rewrites $var / {$expr} into a dynamic marker is
+    // skipped to avoid silently hiding real attribute values.
+    return new StringLiteral(builder.text(), contentLine, contentCol, false, builder.sourceColumns(), rawStart, c.pos);
+  }
+
+  private static void appendSingleEscape(char next, char backslash, LiteralBuilder builder, Cursor c) {
+    if (next == '\\' || next == '\'') {
+      builder.append(next, c.col);
+      c.col += 2;
+      c.pos += 2;
+    } else {
+      builder.append(backslash, c.col);
+      c.col++;
+      c.pos++;
+    }
+  }
+
+  static String sanitizeInterpolations(String value) {
+    return INTERPOLATION.matcher(value).replaceAll(Matcher.quoteReplacement(DYNAMIC_PLACEHOLDER));
+  }
+
+  static List<Node> reLex(String sanitized) {
+    return new PageLexer().parseWithoutHierarchy(sanitized);
+  }
+
+  /**
+   * Rebases re-lexed node positions from local (1-based line within sanitized string)
+   * to file-absolute coordinates using the literal's per-character source-column map
+   * when available, otherwise falling back to a flat offset.
+   *
+   * @param embedded nodes produced by re-lexing the sanitized literal; their
+   *                 line/column positions are mutated in place
+   * @param literal  the originating literal, providing the file-coordinate base
+   *                 and the per-character source-column map
+   */
+  static void rebasePositions(List<Node> embedded, StringLiteral literal) {
+    int baseLine = literal.lineOffset();
+    int baseCol = literal.columnOffset();
+    int[][] map = literal.sourceColumns();
+    for (Node node : embedded) {
+      int localStart = node.getStartLinePosition();
+      int localEnd = node.getEndLinePosition();
+      node.setStartLinePosition(baseLine + localStart - 1);
+      node.setEndLinePosition(baseLine + localEnd - 1);
+      node.setStartColumnPosition(sourceCol(map, localStart, node.getStartColumnPosition(), baseCol));
+      node.setEndColumnPosition(sourceCol(map, localEnd, node.getEndColumnPosition(), baseCol));
+      if (node instanceof TagNode tag) {
+        for (Attribute attr : tag.getAttributes()) {
+          if (attr.getLine() > 0) {
+            attr.setLine(baseLine + attr.getLine() - 1);
+          }
+        }
+      }
+    }
+  }
+
+  private static int sourceCol(int[][] map, int localLine, int localCol, int baseCol) {
+    int lineIdx = localLine - 1;
+    if (lineIdx >= 0 && lineIdx < map.length) {
+      int[] lineCols = map[lineIdx];
+      if (localCol >= 0 && localCol < lineCols.length) {
+        return lineCols[localCol];
+      }
+      if (lineCols.length > 0) {
+        return lineCols[lineCols.length - 1] + 1;
+      }
+    }
+    return (localLine == 1) ? (baseCol + localCol) : localCol;
+  }
+
+  /**
+   * Appends a synthetic {@code </tag>} close for every tag that the re-lexed
+   * fragment leaves open, so that an open-only literal (e.g. {@code echo
+   * "<span>";}) does not turn every subsequent real-file tag into a child of
+   * the synthetic node when {@code createNodeHierarchy} runs.
+   *
+   * @param embedded nodes produced by re-lexing one literal; mutated in place
+   *                 by appending synthetic end tags for any element left open
+   */
+  private static void balanceUnclosedTags(List<Node> embedded) {
+    Deque<TagNode> openStack = new ArrayDeque<>();
+    for (Node node : embedded) {
+      // DirectiveNode extends TagNode but its nodeType is DIRECTIVE; only
+      // real element tags should contribute to the open-stack balancing.
+      if (node.getNodeType() == NodeType.TAG && node instanceof TagNode tag && !tag.hasEnd()) {
+        updateOpenStack(openStack, tag);
+      }
+    }
+    while (!openStack.isEmpty()) {
+      TagNode open = openStack.pop();
+      embedded.add(syntheticEndTag(open));
+    }
+  }
+
+  private static void updateOpenStack(Deque<TagNode> openStack, TagNode tag) {
+    if (tag.isEndElement()) {
+      if (!openStack.isEmpty() && openStack.peek().equalsElementName(tag.getNodeName())) {
+        openStack.pop();
+      }
+    } else if (!isVoidElement(tag)) {
+      // Void elements (br, img, input, ...) carry no content and cannot have
+      // a matching close tag, so they must not contribute to the open stack.
+      openStack.push(tag);
+    }
+  }
+
+  private static boolean isVoidElement(TagNode tag) {
+    return PageLexer.VOID_ELEMENTS.contains(tag.getNodeName().toLowerCase(Locale.ROOT));
+  }
+
+  private static TagNode syntheticEndTag(TagNode open) {
+    TagNode end = new TagNode();
+    end.setNodeName(open.getNodeName());
+    end.setCode("</" + open.getNodeName() + ">");
+    end.setStartLinePosition(open.getEndLinePosition());
+    end.setStartColumnPosition(open.getEndColumnPosition());
+    end.setEndLinePosition(open.getEndLinePosition());
+    end.setEndColumnPosition(open.getEndColumnPosition());
+    return end;
+  }
+
+  private static TextNode dynamicGapText(DirectiveNode directive) {
+    TextNode text = new TextNode();
+    text.setCode(DYNAMIC_PLACEHOLDER);
+    text.setStartLinePosition(directive.getStartLinePosition());
+    text.setStartColumnPosition(directive.getStartColumnPosition());
+    text.setEndLinePosition(directive.getEndLinePosition());
+    text.setEndColumnPosition(directive.getEndColumnPosition());
+    return text;
+  }
+
+  private static TextNode literalTextNode(StringLiteral literal) {
+    TextNode text = new TextNode();
+    String value = literal.value();
+    text.setCode(value);
+    text.setStartLinePosition(literal.lineOffset());
+    text.setStartColumnPosition(literal.columnOffset());
+    // Count real newlines so a multi-line literal lands on the right end line.
+    int extraLines = 0;
+    int lastLineStart = 0;
+    for (int i = 0; i < value.length(); i++) {
+      if (value.charAt(i) == '\n') {
+        extraLines++;
+        lastLineStart = i + 1;
+      }
+    }
+    text.setEndLinePosition(literal.lineOffset() + extraLines);
+    text.setEndColumnPosition((extraLines == 0)
+      ? (literal.columnOffset() + value.length())
+      : (value.length() - lastLineStart));
+    return text;
+  }
+
+  private static final class Cursor {
+    int pos;
+    int line;
+    int col;
+
+    Cursor(int pos, int line, int col) {
+      this.pos = pos;
+      this.line = line;
+      this.col = col;
+    }
+  }
+
+  /**
+   * Accumulates the decoded literal value while recording, for each appended
+   * character, the source column it originated from. The resulting {@code
+   * int[][]} maps local {@code (line, col)} pairs (line 1-based, col 0-based)
+   * back to source columns so escape sequences ({@code \"} → {@code "}) don't
+   * shift downstream token coordinates.
+   */
+  private static final class LiteralBuilder {
+    private final StringBuilder sb = new StringBuilder();
+    private final List<int[]> columnsPerLine = new ArrayList<>();
+    private int[] currentLine = new int[32];
+    private int currentLen;
+
+    void append(char c, int srcCol) {
+      if (currentLen >= currentLine.length) {
+        currentLine = Arrays.copyOf(currentLine, currentLine.length * 2);
+      }
+      currentLine[currentLen] = srcCol;
+      currentLen++;
+      sb.append(c);
+      if (c == '\n') {
+        columnsPerLine.add(Arrays.copyOf(currentLine, currentLen));
+        currentLen = 0;
+      }
+    }
+
+    String text() {
+      return sb.toString();
+    }
+
+    int[][] sourceColumns() {
+      List<int[]> all = new ArrayList<>(columnsPerLine);
+      all.add(Arrays.copyOf(currentLine, currentLen));
+      return all.toArray(new int[0][]);
+    }
+  }
+
+  record StringLiteral(String value, int lineOffset, int columnOffset, boolean interpolated, int[][] sourceColumns,
+                       int rawStart, int rawEnd) {
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof StringLiteral other)) {
+        return false;
+      }
+      return lineOffset == other.lineOffset
+        && columnOffset == other.columnOffset
+        && interpolated == other.interpolated
+        && rawStart == other.rawStart
+        && rawEnd == other.rawEnd
+        && java.util.Objects.equals(value, other.value)
+        && Arrays.deepEquals(sourceColumns, other.sourceColumns);
+    }
+
+    @Override
+    public int hashCode() {
+      return java.util.Objects.hash(value, lineOffset, columnOffset, interpolated, rawStart, rawEnd)
+        ^ Arrays.deepHashCode(sourceColumns);
+    }
+
+    @Override
+    public String toString() {
+      return "StringLiteral[value=" + value
+        + ", lineOffset=" + lineOffset
+        + ", columnOffset=" + columnOffset
+        + ", interpolated=" + interpolated
+        + ", sourceColumns=" + Arrays.deepToString(sourceColumns)
+        + ", rawStart=" + rawStart
+        + ", rawEnd=" + rawEnd + ']';
+    }
+  }
+}

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/Node.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/Node.java
@@ -29,6 +29,9 @@ public abstract class Node {
   private final NodeType nodeType;
   private int startColumnPosition;
   private int startLinePosition;
+  // Set on nodes produced by PhpEmbeddedHtmlExtractor; the scanner routes
+  // them only to visitors that opt in via EmbeddedHtmlCheck.
+  private boolean embedded;
 
   protected Node(NodeType nodeType) {
     this.nodeType = nodeType;
@@ -76,6 +79,14 @@ public abstract class Node {
 
   public void setStartLinePosition(int startLinePosition) {
     this.startLinePosition = startLinePosition;
+  }
+
+  public boolean isEmbedded() {
+    return embedded;
+  }
+
+  public void setEmbedded(boolean embedded) {
+    this.embedded = embedded;
   }
 
   @Override

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/HtmlAstScanner.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/HtmlAstScanner.java
@@ -18,6 +18,7 @@ package org.sonar.plugins.html.visitor;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.sonar.plugins.html.checks.EmbeddedHtmlCheck;
 import org.sonar.plugins.html.node.CommentNode;
 import org.sonar.plugins.html.node.DirectiveNode;
 import org.sonar.plugins.html.node.ExpressionNode;
@@ -69,6 +70,11 @@ public class HtmlAstScanner {
     // notify the visitors for start and end of element
     for (Node node : nodeList) {
       for (DefaultNodeVisitor visitor : visitors) {
+        if (node.isEmbedded() && !(visitor instanceof EmbeddedHtmlCheck)) {
+          // Skip visitor callbacks for embedded nodes on non-opted-in checks.
+          // The node is still visible to all checks via startDocument(nodeList) and getChildren().
+          continue;
+        }
         scanElement(visitor, node);
       }
     }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaProptypesCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaProptypesCheckTest.java
@@ -50,6 +50,16 @@ class AriaProptypesCheckTest {
   }
 
   @Test
+  void htmlEmbeddedInPhpStringLiteral() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/AriaProptypesCheck.php"),
+      new AriaProptypesCheck());
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(2).withMessage("The value of the attribute \"aria-hidden\" must be a boolean.")
+      .noMore();
+  }
+
+  @Test
   void cshtml() {
     HtmlSourceCode sourceCode = TestHelper.scan(
       new File("src/test/resources/checks/AriaProptypesCheck.cshtml"),

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaRoleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaRoleCheckTest.java
@@ -30,6 +30,17 @@ class AriaRoleCheckTest {
   public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
 
   @Test
+  void htmlEmbeddedInPhpStringLiteral() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+        new File("src/test/resources/checks/AriaRoleCheck.php"),
+        new AriaRoleCheck());
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+        .next().atLine(2).withMessage(
+            "Elements with ARIA roles must use a valid, non-abstract ARIA role. \"foobar\" is not a valid role.")
+        .noMore();
+  }
+
+  @Test
   void html() {
     HtmlSourceCode sourceCode = TestHelper.scan(
         new File("src/test/resources/checks/AriaRoleCheck.html"),
@@ -48,4 +59,5 @@ class AriaRoleCheckTest {
         .next().atLine(9)
         .noMore();
   }
+
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/TabIndexNoPositiveCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/TabIndexNoPositiveCheckTest.java
@@ -29,6 +29,16 @@ class TabIndexNoPositiveCheckTest {
   public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
 
   @Test
+  void htmlEmbeddedInPhpStringLiteral() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/TabIndexNoPositiveCheck.php"),
+      new TabIndexNoPositiveCheck());
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(2).withMessage("Avoid using positive values for the \"tabIndex\" attribute.")
+      .noMore();
+  }
+
+  @Test
   void html() {
     HtmlSourceCode sourceCode = TestHelper.scan(
       new File("src/test/resources/checks/TabIndexNoPositiveCheck.html"),

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/PageLexerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/PageLexerTest.java
@@ -700,6 +700,52 @@ class PageLexerTest {
       "<p>", "after", "</p>");
   }
 
+  // ---------------------------------------------------------------------------
+  // PHP embedded HTML extraction (pipeline integration)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void php_string_literal_produces_embedded_tag_node() {
+    List<Node> nodes = new PageLexer().parse(new StringReader("<?php echo \"<div role='toolbar'>\"; ?>"));
+    boolean hasDiv = nodes.stream()
+      .filter(n -> n.getNodeType() == NodeType.TAG)
+      .map(n -> (TagNode) n)
+      .anyMatch(t -> "div".equalsIgnoreCase(t.getNodeName()));
+    assertThat(hasDiv).isTrue();
+  }
+
+  @Test
+  void php_embedded_tag_has_file_absolute_line_position() {
+    // Directive on line 2; embedded <div> must also report line 2
+    List<Node> nodes = new PageLexer().parse(new StringReader("<p>\n<?php echo \"<div>\"; ?>"));
+    TagNode div = nodes.stream()
+      .filter(n -> n.getNodeType() == NodeType.TAG)
+      .map(n -> (TagNode) n)
+      .filter(t -> "div".equalsIgnoreCase(t.getNodeName()))
+      .findFirst().orElse(null);
+    assertThat(div).isNotNull();
+    assertThat(div.getStartLinePosition()).isEqualTo(2);
+  }
+
+  @Test
+  void php_embedded_open_and_close_tags_are_both_present() {
+    List<Node> nodes = new PageLexer().parse(new StringReader("<?php echo \"<div></div>\"; ?>"));
+    long divCount = nodes.stream()
+      .filter(n -> n.getNodeType() == NodeType.TAG)
+      .map(n -> (TagNode) n)
+      .filter(t -> "div".equalsIgnoreCase(t.getNodeName()))
+      .count();
+    assertThat(divCount).isEqualTo(2);
+  }
+
+  @Test
+  void php_non_html_string_does_not_produce_extra_nodes() {
+    List<Node> baseNodes = new PageLexer().parse(new StringReader("<?php $x = 1; ?>"));
+    List<Node> withString = new PageLexer().parse(new StringReader("<?php $s = 'no html here'; ?>"));
+    assertThat(withString.stream().filter(n -> n.getNodeType() == NodeType.TAG).count())
+      .isEqualTo(baseNodes.stream().filter(n -> n.getNodeType() == NodeType.TAG).count());
+  }
+
   private void assertSingleTag(String code) {
     StringReader reader = new StringReader(code);
     List<Node> nodeList = new PageLexer().parse(reader);

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/PhpEmbeddedHtmlExtractorTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/PhpEmbeddedHtmlExtractorTest.java
@@ -1,0 +1,760 @@
+/*
+ * SonarQube HTML
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.html.lex;
+
+import java.io.StringReader;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.sonar.plugins.html.lex.PhpEmbeddedHtmlExtractor.StringLiteral;
+import org.sonar.plugins.html.node.DirectiveNode;
+import org.sonar.plugins.html.node.Node;
+import org.sonar.plugins.html.node.NodeType;
+import org.sonar.plugins.html.node.TagNode;
+import org.sonar.plugins.html.node.TextNode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PhpEmbeddedHtmlExtractorTest {
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private static DirectiveNode directive(String nodeName, String code, int startLine, int startCol) {
+    DirectiveNode node = new DirectiveNode();
+    node.setNodeName(nodeName);
+    node.setCode(code);
+    node.setStartLinePosition(startLine);
+    node.setStartColumnPosition(startCol);
+    return node;
+  }
+
+  private static DirectiveNode phpDirective(String body) {
+    return directive("?php", "<?php " + body + " ?>", 1, 0);
+  }
+
+  // ---------------------------------------------------------------------------
+  // isPhpDirective
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void isPhpDirectiveAcceptsPhpNames() {
+    assertThat(PhpEmbeddedHtmlExtractor.isPhpDirective(directive("?php", "<?php ?>", 1, 0))).isTrue();
+    assertThat(PhpEmbeddedHtmlExtractor.isPhpDirective(directive("?PHP", "<?PHP ?>", 1, 0))).isTrue();
+    assertThat(PhpEmbeddedHtmlExtractor.isPhpDirective(directive("?=", "<?= 1 ?>", 1, 0))).isTrue();
+    // PHP 8 named args, attributes – any "?php..." variant
+    assertThat(PhpEmbeddedHtmlExtractor.isPhpDirective(directive("?phpecho", "<?phpecho ?>", 1, 0))).isTrue();
+  }
+
+  @Test
+  void isPhpDirectiveRejectsNonPhp() {
+    assertThat(PhpEmbeddedHtmlExtractor.isPhpDirective(directive("?xml", "<?xml ?>", 1, 0))).isFalse();
+    assertThat(PhpEmbeddedHtmlExtractor.isPhpDirective(directive(null, "<?xml ?>", 1, 0))).isFalse();
+    assertThat(PhpEmbeddedHtmlExtractor.isPhpDirective(directive("", "<??>", 1, 0))).isFalse();
+    assertThat(PhpEmbeddedHtmlExtractor.isPhpDirective(directive("%@", "<%@ page %>", 1, 0))).isFalse();
+  }
+
+  // ---------------------------------------------------------------------------
+  // extractLiterals – double-quoted strings
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void doubleQuotedLiteralDecodesEscapes() {
+    DirectiveNode node = phpDirective("echo \"<div role=\\\"toolbar\\\">\"");
+    List<StringLiteral> literals = PhpEmbeddedHtmlExtractor.extractLiterals(node);
+    assertThat(literals).hasSize(1);
+    assertThat(literals.get(0).value()).isEqualTo("<div role=\"toolbar\">");
+  }
+
+  @Test
+  void doubleQuotedLiteralDecodesEscapesAsNonNewlinePlaceholders() {
+    // \n / \r / \t in the source must NOT decode to real newlines/CRs in the
+    // sanitised buffer, otherwise the re-lex line counter advances past the
+    // literal's true source line and tokens land on the wrong file line.
+    DirectiveNode node = phpDirective("$x = \"line1\\nline2\\ttab\";");
+    List<StringLiteral> literals = PhpEmbeddedHtmlExtractor.extractLiterals(node);
+    assertThat(literals).hasSize(1);
+    assertThat(literals.get(0).value()).isEqualTo("line1 line2 tab");
+    assertThat(literals.get(0).value()).doesNotContain("\n");
+    assertThat(literals.get(0).value()).doesNotContain("\t");
+  }
+
+  // ---------------------------------------------------------------------------
+  // extractLiterals – single-quoted strings
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void singleQuotedLiteralOnlyUnescapesBackslashAndQuote() {
+    // In single-quoted strings only \\ and \' are escapes; \n is literal
+    DirectiveNode node = phpDirective("echo '<div role=\\'toolbar\\'>';");
+    List<StringLiteral> literals = PhpEmbeddedHtmlExtractor.extractLiterals(node);
+    assertThat(literals).hasSize(1);
+    assertThat(literals.get(0).value()).isEqualTo("<div role='toolbar'>");
+  }
+
+  @Test
+  void singleQuotedLiteralKeepsBackslashNLiteral() {
+    DirectiveNode node = phpDirective("'a\\nb'");
+    List<StringLiteral> literals = PhpEmbeddedHtmlExtractor.extractLiterals(node);
+    assertThat(literals).hasSize(1);
+    // \n inside single-quoted string is NOT a newline escape
+    assertThat(literals.get(0).value()).isEqualTo("a\\nb");
+  }
+
+  // ---------------------------------------------------------------------------
+  // extractLiterals – concatenation
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void concatenationEmitsTwoLiteralsAtDistinctColumns() {
+    // Two separate string literals joined with .
+    DirectiveNode node = phpDirective("\"<a \" . \"href='x'>\"");
+    List<StringLiteral> literals = PhpEmbeddedHtmlExtractor.extractLiterals(node);
+    assertThat(literals).hasSize(2);
+    assertThat(literals.get(0).value()).isEqualTo("<a ");
+    assertThat(literals.get(1).value()).isEqualTo("href='x'>");
+    assertThat(literals.get(1).columnOffset()).isGreaterThan(literals.get(0).columnOffset());
+  }
+
+  // ---------------------------------------------------------------------------
+  // extractLiterals – short-echo directive
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shortEchoDirectiveBodyIsScannedForLiterals() {
+    // <?= can contain string literals too
+    DirectiveNode node = directive("?=", "<?= \"<div role='toolbar'></div>\" ?>", 1, 0);
+    List<StringLiteral> literals = PhpEmbeddedHtmlExtractor.extractLiterals(node);
+    assertThat(literals).hasSize(1);
+    assertThat(literals.get(0).value()).isEqualTo("<div role='toolbar'></div>");
+  }
+
+  // ---------------------------------------------------------------------------
+  // extractLiterals – multiple literals in one directive
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void multipleLiteralsFromOneDirective() {
+    DirectiveNode node = phpDirective("echo \"<div></div>\"; print \"<span></span>\";");
+    List<StringLiteral> literals = PhpEmbeddedHtmlExtractor.extractLiterals(node);
+    assertThat(literals).hasSize(2);
+    assertThat(literals.get(0).value()).isEqualTo("<div></div>");
+    assertThat(literals.get(1).value()).isEqualTo("<span></span>");
+  }
+
+  // ---------------------------------------------------------------------------
+  // extractLiterals – interpolation sanitisation
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void phpVariablesAreSanitizedInDoubleQuotedStrings() {
+    DirectiveNode node = phpDirective("\"$var<div>\"");
+    List<StringLiteral> literals = PhpEmbeddedHtmlExtractor.extractLiterals(node);
+    assertThat(literals).hasSize(1);
+    String sanitized = PhpEmbeddedHtmlExtractor.sanitizeInterpolations(literals.get(0).value());
+    assertThat(sanitized)
+      .contains("${dynamic}")
+      .doesNotContain("$var");
+  }
+
+  @Test
+  void phpCurlyInterpolationIsSanitized() {
+    DirectiveNode node = phpDirective("\"<div>{$expr}</div>\"");
+    List<StringLiteral> literals = PhpEmbeddedHtmlExtractor.extractLiterals(node);
+    assertThat(literals).hasSize(1);
+    String sanitized = PhpEmbeddedHtmlExtractor.sanitizeInterpolations(literals.get(0).value());
+    assertThat(sanitized).isEqualTo("<div>${dynamic}</div>");
+  }
+
+  // ---------------------------------------------------------------------------
+  // extractLiterals – multi-line literal positions
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void multiLineLiteralPositionsAreAccurate() {
+    // Directive starts at line 5, column 0
+    // Code is: <?php echo "\n<div role='toolbar'>" ?>
+    // The literal content starts at line 5, after the opening "
+    DirectiveNode node = new DirectiveNode();
+    node.setNodeName("?php");
+    node.setCode("<?php echo \"\\n<div>\"; ?>");
+    node.setStartLinePosition(5);
+    node.setStartColumnPosition(0);
+
+    List<StringLiteral> literals = PhpEmbeddedHtmlExtractor.extractLiterals(node);
+    assertThat(literals).hasSize(1);
+    // The literal content itself starts on line 5 (same line as directive)
+    // because we record the position of the first content char after the opening quote
+    assertThat(literals.get(0).lineOffset()).isEqualTo(5);
+  }
+
+  // ---------------------------------------------------------------------------
+  // extractLiterals – heredoc
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void heredocBodyIsEmittedAtHeredocBodyLine() {
+    // Directive at line 3; heredoc body starts on line 4
+    String code = "<?php\n$x = <<<EOT\n<div role=\"toolbar\"></div>\nEOT;\n?>";
+    DirectiveNode node = new DirectiveNode();
+    node.setNodeName("?php");
+    node.setCode(code);
+    node.setStartLinePosition(3);
+    node.setStartColumnPosition(0);
+
+    List<StringLiteral> literals = PhpEmbeddedHtmlExtractor.extractLiterals(node);
+    assertThat(literals).hasSize(1);
+    assertThat(literals.get(0).value()).contains("<div role=\"toolbar\">");
+    // Body starts on line 5 (directive line 3 + 1 for the "<?php\n" preamble + 1 for the "<<<EOT\n" header)
+    assertThat(literals.get(0).lineOffset()).isEqualTo(5);
+  }
+
+  @Test
+  void nowdocDoesNotSanitizeInterpolations() {
+    String code = "<?php\n$x = <<<'EOT'\n<div>{$nope}</div>\nEOT;\n?>";
+    DirectiveNode node = new DirectiveNode();
+    node.setNodeName("?php");
+    node.setCode(code);
+    node.setStartLinePosition(1);
+    node.setStartColumnPosition(0);
+
+    List<StringLiteral> literals = PhpEmbeddedHtmlExtractor.extractLiterals(node);
+    assertThat(literals).hasSize(1);
+    // Nowdoc: no interpolation, {$nope} is literal text
+    assertThat(literals.get(0).value()).contains("{$nope}");
+    assertThat(literals.get(0).value()).doesNotContain("${dynamic}");
+  }
+
+  @Test
+  void indentedHeredocStripsClosingIndentFromAllLines() {
+    // PHP 7.3+ indented heredoc
+    String code = "<?php\n$x = <<<EOT\n    <div>\n    </div>\n    EOT;\n?>";
+    DirectiveNode node = new DirectiveNode();
+    node.setNodeName("?php");
+    node.setCode(code);
+    node.setStartLinePosition(1);
+    node.setStartColumnPosition(0);
+
+    List<StringLiteral> literals = PhpEmbeddedHtmlExtractor.extractLiterals(node);
+    assertThat(literals).hasSize(1);
+    String body = literals.get(0).value();
+    // Each body line should have the 4-char indent stripped
+    assertThat(body)
+      .contains("<div>")
+      .doesNotContain("    <div>");
+  }
+
+  // ---------------------------------------------------------------------------
+  // sanitizeInterpolations
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void sanitizeInterpolationsReplacesPatterns() {
+    assertThat(PhpEmbeddedHtmlExtractor.sanitizeInterpolations("$var")).isEqualTo("${dynamic}");
+    assertThat(PhpEmbeddedHtmlExtractor.sanitizeInterpolations("{$expr}")).isEqualTo("${dynamic}");
+    assertThat(PhpEmbeddedHtmlExtractor.sanitizeInterpolations("$obj->prop")).isEqualTo("${dynamic}->prop");
+    assertThat(PhpEmbeddedHtmlExtractor.sanitizeInterpolations("no-vars")).isEqualTo("no-vars");
+  }
+
+  // ---------------------------------------------------------------------------
+  // expand – end-to-end pipeline integration
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void expandSplicesTagNodesAfterDirective() {
+    List<Node> nodes = new PageLexer().parse(new StringReader("<?php echo \"<div role='toolbar'>\"; ?>"));
+    // The flat list should contain the <?php directive plus the embedded <div>
+    boolean hasDirective = nodes.stream().anyMatch(n -> n.getNodeType() == NodeType.DIRECTIVE);
+    boolean hasEmbeddedDiv = nodes.stream()
+      .filter(n -> n.getNodeType() == NodeType.TAG)
+      .map(n -> (TagNode) n)
+      .anyMatch(t -> "div".equalsIgnoreCase(t.getNodeName()));
+    assertThat(hasDirective).isTrue();
+    assertThat(hasEmbeddedDiv).isTrue();
+  }
+
+  @Test
+  void expandPreservesDirectiveNode() {
+    List<Node> nodes = new PageLexer().parse(new StringReader("<?php echo \"<span id='x'>\"; ?>"));
+    long directiveCount = nodes.stream().filter(n -> n.getNodeType() == NodeType.DIRECTIVE).count();
+    assertThat(directiveCount).isEqualTo(1);
+  }
+
+  @Test
+  void expandPositionsAreFileAbsolute() {
+    // Single-line file: directive at line 1, literal starts right after opening quote
+    // "<?php echo \"<div>\";"  — the <div> must appear at line 1
+    List<Node> nodes = new PageLexer().parse(new StringReader("<?php echo \"<div>\"; ?>"));
+    TagNode div = nodes.stream()
+      .filter(n -> n.getNodeType() == NodeType.TAG)
+      .map(n -> (TagNode) n)
+      .filter(t -> "div".equalsIgnoreCase(t.getNodeName()))
+      .findFirst().orElse(null);
+    assertThat(div).isNotNull();
+    assertThat(div.getStartLinePosition()).isEqualTo(1);
+  }
+
+  @Test
+  void expandPositionIsRebasedToDirectiveLine() {
+    // File: line 1 = <html>, line 2 = <?php directive with embedded <div>
+    // The embedded <div> must appear at line 2 in the merged node list
+    String source = "<html>\n<?php echo \"<div role='toolbar'>\"; ?>";
+    List<Node> nodes = new PageLexer().parse(new StringReader(source));
+    TagNode div = nodes.stream()
+      .filter(n -> n.getNodeType() == NodeType.TAG)
+      .map(n -> (TagNode) n)
+      .filter(t -> "div".equalsIgnoreCase(t.getNodeName()))
+      .findFirst().orElse(null);
+    assertThat(div).isNotNull();
+    assertThat(div.getStartLinePosition()).isEqualTo(2);
+  }
+
+  @Test
+  void expandNonPhpDirectiveNotExpanded() {
+    List<Node> nodes = new PageLexer().parse(new StringReader("<?xml version=\"1.0\" ?><root/>"));
+    long tagCount = nodes.stream()
+      .filter(n -> n.getNodeType() == NodeType.TAG)
+      .map(n -> (TagNode) n)
+      .filter(t -> "root".equalsIgnoreCase(t.getNodeName()))
+      .count();
+    // Only the <root/> tag, no phantom extraction from the XML declaration
+    assertThat(tagCount).isEqualTo(1);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Dynamic gap between concatenated literals
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void expandInsertsDynamicGapBetweenConcatenatedLiterals() {
+    // `echo "<a href='x'>" . $label . "</a>";` — the runtime text from the
+    // intervening PHP expression must be represented as a non-blank text node
+    // between the open and close tags so content-sensitive checks don't see
+    // an empty anchor.
+    List<Node> nodes = new PageLexer().parse(new StringReader(
+      "<?php echo \"<a href='x'>\" . $label . \"</a>\"; ?>"));
+    boolean hasDynamicGap = nodes.stream()
+      .filter(n -> n.getNodeType() == NodeType.TEXT)
+      .anyMatch(n -> n.getCode().contains("${dynamic}"));
+    assertThat(hasDynamicGap).isTrue();
+  }
+
+  @Test
+  void expandDoesNotCloseOpenTagBetweenConcatenatedLiterals() {
+    // The directive-level balance must NOT fabricate a `</a>` between the
+    // opening fragment and the gap text, otherwise the real `</a>` from the
+    // second literal becomes orphan and the first `<a>` is left empty.
+    List<Node> nodes = new PageLexer().parse(new StringReader(
+      "<?php echo \"<a href='x'>\" . $label . \"</a>\"; ?>"));
+
+    List<Node> tagsAndText = nodes.stream()
+      .filter(n -> n.getNodeType() == NodeType.TAG || n.getNodeType() == NodeType.TEXT)
+      .filter(n -> {
+        if (n.getNodeType() == NodeType.TEXT) {
+          return n.getCode().contains("${dynamic}");
+        }
+        TagNode t = (TagNode) n;
+        return "a".equalsIgnoreCase(t.getNodeName());
+      })
+      .toList();
+
+    assertThat(tagsAndText).hasSize(3);
+    assertThat(((TagNode) tagsAndText.get(0)).isEndElement()).isFalse();
+    assertThat(tagsAndText.get(1).getNodeType()).isEqualTo(NodeType.TEXT);
+    assertThat(((TagNode) tagsAndText.get(2)).isEndElement()).isTrue();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Void elements never get a synthetic close tag
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void voidElementInLiteralProducesNoSyntheticEndTag() {
+    // `<br>` is a void HTML element. The balance step must not push it onto
+    // the open stack and must therefore not append `</br>`.
+    List<Node> nodes = new PageLexer().parse(new StringReader("<?php echo \"<br>\"; ?>"));
+    List<TagNode> brTags = nodes.stream()
+      .filter(n -> n.getNodeType() == NodeType.TAG)
+      .map(n -> (TagNode) n)
+      .filter(t -> "br".equalsIgnoreCase(t.getNodeName()))
+      .toList();
+    assertThat(brTags).hasSize(1);
+    assertThat(brTags.get(0).isEndElement()).isFalse();
+  }
+
+  @Test
+  void voidElementsListIsRecognizedByBalancer() {
+    // A literal with several void elements must produce exactly those tags
+    // and nothing else — no synthetic closes for any of them.
+    List<Node> nodes = new PageLexer().parse(new StringReader(
+      "<?php echo \"<img><input><hr>\"; ?>"));
+    long syntheticCloses = nodes.stream()
+      .filter(n -> n.getNodeType() == NodeType.TAG)
+      .map(n -> (TagNode) n)
+      .filter(TagNode::isEndElement)
+      .count();
+    assertThat(syntheticCloses).isZero();
+  }
+
+  @Test
+  void expandDoesNotInsertGapForLoneLiteral() {
+    List<Node> nodes = new PageLexer().parse(new StringReader("<?php echo \"<div></div>\"; ?>"));
+    boolean hasDynamicGap = nodes.stream()
+      .filter(n -> n.getNodeType() == NodeType.TEXT)
+      .anyMatch(n -> n.getCode().contains("${dynamic}"));
+    assertThat(hasDynamicGap).isFalse();
+  }
+
+  @Test
+  void expandKeepsAnchorEmptyWhenConcatJoinsTwoTagLiteralsWithNothingBetween() {
+    // `echo "<a>" . "</a>";` — the two HTML literals are joined by a bare
+    // concatenation operator with no PHP expression between them, so the
+    // anchor must stay empty (no synthetic dynamic gap, no fabricated text).
+    List<Node> nodes = new PageLexer().parse(new StringReader(
+      "<?php echo \"<a>\" . \"</a>\"; ?>"));
+    boolean hasTextBetweenAnchors = nodes.stream()
+      .filter(n -> n.getNodeType() == NodeType.TEXT)
+      .anyMatch(n -> !n.getCode().isBlank());
+    assertThat(hasTextBetweenAnchors).isFalse();
+  }
+
+  @Test
+  void expandPreservesPlainLiteralBetweenConcatenatedTagLiterals() {
+    // `echo "<a>" . "Click" . "</a>";` — the middle literal carries no HTML
+    // but contributes real runtime text; it must be surfaced as a TextNode so
+    // that content-sensitive checks see the actual content rather than an
+    // opaque dynamic marker.
+    List<Node> nodes = new PageLexer().parse(new StringReader(
+      "<?php echo \"<a>\" . \"Click\" . \"</a>\"; ?>"));
+    boolean hasClickText = nodes.stream()
+      .filter(n -> n.getNodeType() == NodeType.TEXT)
+      .anyMatch(n -> "Click".equals(n.getCode()));
+    boolean hasDynamicGap = nodes.stream()
+      .filter(n -> n.getNodeType() == NodeType.TEXT)
+      .anyMatch(n -> n.getCode().contains("${dynamic}"));
+    assertThat(hasClickText).isTrue();
+    assertThat(hasDynamicGap).isFalse();
+  }
+
+  @Test
+  void expandKeepsDynamicGapWhenExpressionSitsBetweenTagLiterals() {
+    // Sanity check that the existing dynamic-gap behaviour still applies when
+    // a real PHP expression (not a literal) sits between the two HTML literals.
+    List<Node> nodes = new PageLexer().parse(new StringReader(
+      "<?php echo \"<a>\" . $label . \"</a>\"; ?>"));
+    boolean hasDynamicGap = nodes.stream()
+      .filter(n -> n.getNodeType() == NodeType.TEXT)
+      .anyMatch(n -> n.getCode().contains("${dynamic}"));
+    assertThat(hasDynamicGap).isTrue();
+  }
+
+  @Test
+  void expandSurfacesDoctypeDirectiveFromPhpLiteral() {
+    // The DOCTYPE literal must reach the merged AST as a DirectiveNode so that
+    // DoctypePresenceCheck (and similar) see it before the <html> tag from the
+    // following literal. Also, balancing must not synthesise a </DOCTYPE> close
+    // — DirectiveNode extends TagNode but its nodeType is DIRECTIVE.
+    String source = "<?php\n$retval  = \"<!DOCTYPE HTML>\";\n$retval .= \"<html>\";\n?>";
+    List<Node> nodes = new PageLexer().parse(new StringReader(source));
+    boolean hasDoctype = nodes.stream()
+      .filter(n -> n.getNodeType() == NodeType.DIRECTIVE)
+      .anyMatch(n -> "DOCTYPE".equalsIgnoreCase(((org.sonar.plugins.html.node.DirectiveNode) n).getNodeName()));
+    boolean hasSyntheticDoctypeClose = nodes.stream()
+      .filter(n -> n.getNodeType() == NodeType.TAG)
+      .map(n -> (TagNode) n)
+      .anyMatch(t -> "DOCTYPE".equalsIgnoreCase(t.getNodeName()));
+    assertThat(hasDoctype).isTrue();
+    assertThat(hasSyntheticDoctypeClose).isFalse();
+  }
+
+  @Test
+  void expandSurfacesHtmlCommentFromPhpLiteral() {
+    // An HTML comment hidden in a PHP literal must reach the merged AST so
+    // comment-sensitive checks have a chance to see it.
+    List<Node> nodes = new PageLexer().parse(new StringReader(
+      "<?php echo \"<!-- hello -->\"; ?>"));
+    boolean hasComment = nodes.stream().anyMatch(n -> n.getNodeType() == NodeType.COMMENT);
+    assertThat(hasComment).isTrue();
+  }
+
+  @Test
+  void expandSurfacesMultiLinePlainLiteralWithCorrectEndPosition() {
+    // Real LF byte in the middle literal — the surfaced text node must reflect
+    // that it spans onto a second source line, not collapse to the start line.
+    String source = "<?php echo \"<a>\" . \"Hello\nWorld\" . \"</a>\"; ?>";
+    List<Node> nodes = new PageLexer().parse(new StringReader(source));
+    TextNode helloWorld = nodes.stream()
+      .filter(n -> n.getNodeType() == NodeType.TEXT)
+      .map(n -> (TextNode) n)
+      .filter(n -> "Hello\nWorld".equals(n.getCode()))
+      .findFirst().orElse(null);
+    assertThat(helloWorld).isNotNull();
+    assertThat(helloWorld.getStartLinePosition()).isEqualTo(1);
+    assertThat(helloWorld.getEndLinePosition()).isEqualTo(2);
+    assertThat(helloWorld.getEndColumnPosition()).isEqualTo("World".length());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Line stability across escape sequences (H4)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void escapeNewlineDoesNotAdvanceTagSourceLine() {
+    // The \n escape must NOT shift the embedded <div> off the literal's line.
+    List<Node> nodes = new PageLexer().parse(new StringReader(
+      "<?php echo \"\\n<div></div>\"; ?>"));
+    TagNode div = nodes.stream()
+      .filter(n -> n.getNodeType() == NodeType.TAG)
+      .map(n -> (TagNode) n)
+      .filter(t -> "div".equalsIgnoreCase(t.getNodeName()))
+      .filter(t -> !t.isEndElement())
+      .findFirst().orElse(null);
+    assertThat(div).isNotNull();
+    assertThat(div.getStartLinePosition()).isEqualTo(1);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Single-quoted literals are not sanitized (M2)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void singleQuotedLiteralIsNotSanitized() {
+    DirectiveNode node = phpDirective("echo '<div id=\"$myId\"></div>';");
+    List<StringLiteral> literals = PhpEmbeddedHtmlExtractor.extractLiterals(node);
+    assertThat(literals).hasSize(1);
+    assertThat(literals.get(0).interpolated()).isFalse();
+    assertThat(literals.get(0).value()).contains("$myId");
+  }
+
+  @Test
+  void singleQuotedDollarSignSurvivesPipeline() {
+    // A literal dollar-sign attribute value inside a single-quoted PHP string
+    // must survive the pipeline without being rewritten to a dynamic marker,
+    // because PHP single-quoted strings do not interpolate variables.
+    List<Node> nodes = new PageLexer().parse(new StringReader(
+      "<?php echo '<div id=\"$myId\"></div>'; ?>"));
+    TagNode div = nodes.stream()
+      .filter(n -> n.getNodeType() == NodeType.TAG)
+      .map(n -> (TagNode) n)
+      .filter(t -> "div".equalsIgnoreCase(t.getNodeName()))
+      .filter(t -> !t.isEndElement())
+      .findFirst().orElse(null);
+    assertThat(div).isNotNull();
+    assertThat(div.getAttribute("id")).isEqualTo("$myId");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Column rebasing through source-column map (M3)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void columnsAfterEscapeAccountForExtraSourceChar() {
+    // `<?php echo "\"<div>"; ?>` — the leading \" escape spans 2 source chars
+    // but decodes to 1 in the sanitised buffer. The `<` of `<div>` lives at
+    // source col 14 (right after the 2-char `\"` whose `\` is at col 12); a
+    // naive {@code baseCol + localCol} would put it at col 13.
+    List<Node> nodes = new PageLexer().parse(new StringReader("<?php echo \"\\\"<div>\"; ?>"));
+    TagNode div = nodes.stream()
+      .filter(n -> n.getNodeType() == NodeType.TAG)
+      .map(n -> (TagNode) n)
+      .filter(t -> "div".equalsIgnoreCase(t.getNodeName()))
+      .filter(t -> !t.isEndElement())
+      .findFirst().orElse(null);
+    assertThat(div).isNotNull();
+    assertThat(div.getStartColumnPosition()).isEqualTo(14);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Orphan open tag is balanced (M4)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void openOnlyLiteralGetsBalancedByForeignEndTag() {
+    // `echo "<span>"` would otherwise splice an orphan <span> open into the
+    // flat list and turn every following real-file tag into its child.
+    String source = "<?php echo \"<span>\"; ?>\n<p>real-file</p>";
+    List<Node> nodes = new PageLexer().parse(new StringReader(source));
+    TagNode p = nodes.stream()
+      .filter(n -> n.getNodeType() == NodeType.TAG)
+      .map(n -> (TagNode) n)
+      .filter(t -> "p".equalsIgnoreCase(t.getNodeName()))
+      .filter(t -> !t.isEndElement())
+      .findFirst().orElse(null);
+    assertThat(p).isNotNull();
+    assertThat(p.getParent()).isNull();
+  }
+
+  @Test
+  void closeOnlyLiteralDoesNotAddSyntheticOpen() {
+    String source = "<?php echo \"</span>\"; ?>";
+    List<Node> nodes = new PageLexer().parse(new StringReader(source));
+    long spanOpenCount = nodes.stream()
+      .filter(n -> n.getNodeType() == NodeType.TAG)
+      .map(n -> (TagNode) n)
+      .filter(t -> "span".equalsIgnoreCase(t.getNodeName()))
+      .filter(t -> !t.isEndElement())
+      .count();
+    assertThat(spanOpenCount).isZero();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Heredoc EOF without terminator is rejected (L5)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void heredocWithoutTerminatorYieldsNoLiteral() {
+    // The terminator label is misspelled; the body must not be returned because
+    // the parser is now scanning to EOF and would otherwise swallow whatever
+    // follows as embedded HTML.
+    String code = "<?php\n$x = <<<EOT\n<div></div>\nEOX;\n?>";
+    DirectiveNode node = new DirectiveNode();
+    node.setNodeName("?php");
+    node.setCode(code);
+    node.setStartLinePosition(1);
+    node.setStartColumnPosition(0);
+
+    List<StringLiteral> literals = PhpEmbeddedHtmlExtractor.extractLiterals(node);
+    assertThat(literals).isEmpty();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Multi-line literals with deeply nested HTML
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void doubleQuotedMultiLineLiteralReportsNestedTagsOnRightLines() {
+    // Five levels of nesting on lines 2 to 6: opening `"` is line 1; the
+    // real newlines inside the literal push each tag onto its own file line.
+    String source = """
+      <?php echo "
+      <div>
+        <section>
+          <article>
+            <p>
+              <span>text</span>
+            </p>
+          </article>
+        </section>
+      </div>
+      "; ?>""";
+
+    List<Node> nodes = new PageLexer().parse(new StringReader(source));
+
+    assertThat(openTagLine(nodes, "div")).isEqualTo(2);
+    assertThat(openTagLine(nodes, "section")).isEqualTo(3);
+    assertThat(openTagLine(nodes, "article")).isEqualTo(4);
+    assertThat(openTagLine(nodes, "p")).isEqualTo(5);
+    assertThat(openTagLine(nodes, "span")).isEqualTo(6);
+  }
+
+  @Test
+  void doubleQuotedMultiLineLiteralPreservesParentChainAcrossNestedTags() {
+    String source = """
+      <?php echo "
+      <div>
+        <section>
+          <article>
+            <p>
+              <span>text</span>
+            </p>
+          </article>
+        </section>
+      </div>
+      "; ?>""";
+
+    List<Node> nodes = new PageLexer().parse(new StringReader(source));
+
+    TagNode span = openTag(nodes, "span");
+    assertThat(span).isNotNull();
+    assertThat(span.getParent()).isNotNull();
+    assertThat(span.getParent().getNodeName()).isEqualToIgnoringCase("p");
+    assertThat(span.getParent().getParent().getNodeName()).isEqualToIgnoringCase("article");
+    assertThat(span.getParent().getParent().getParent().getNodeName()).isEqualToIgnoringCase("section");
+    assertThat(span.getParent().getParent().getParent().getParent().getNodeName()).isEqualToIgnoringCase("div");
+    assertThat(span.getParent().getParent().getParent().getParent().getParent()).isNull();
+  }
+
+  @Test
+  void heredocMultiLineBodyReportsNestedTagsOnRightLines() {
+    // Directive opens line 1, `<<<EOT` ends line 2, body opens at line 3.
+    // Five levels of nesting beneath <div> span lines 3 to 7.
+    String code = """
+      <?php
+      $x = <<<EOT
+      <div>
+        <section>
+          <article>
+            <p>
+              <span>text</span>
+            </p>
+          </article>
+        </section>
+      </div>
+      EOT;
+      ?>""";
+
+    List<Node> nodes = new PageLexer().parse(new StringReader(code));
+
+    assertThat(openTagLine(nodes, "div")).isEqualTo(3);
+    assertThat(openTagLine(nodes, "section")).isEqualTo(4);
+    assertThat(openTagLine(nodes, "article")).isEqualTo(5);
+    assertThat(openTagLine(nodes, "p")).isEqualTo(6);
+    assertThat(openTagLine(nodes, "span")).isEqualTo(7);
+  }
+
+  @Test
+  void heredocMultiLineBodyPreservesParentChainAcrossNestedTags() {
+    String code = """
+      <?php
+      $x = <<<EOT
+      <div>
+        <section>
+          <article>
+            <p>
+              <span>text</span>
+            </p>
+          </article>
+        </section>
+      </div>
+      EOT;
+      ?>""";
+
+    List<Node> nodes = new PageLexer().parse(new StringReader(code));
+
+    TagNode span = openTag(nodes, "span");
+    assertThat(span).isNotNull();
+    assertThat(span.getParent().getNodeName()).isEqualToIgnoringCase("p");
+    assertThat(span.getParent().getParent().getNodeName()).isEqualToIgnoringCase("article");
+    assertThat(span.getParent().getParent().getParent().getNodeName()).isEqualToIgnoringCase("section");
+    assertThat(span.getParent().getParent().getParent().getParent().getNodeName()).isEqualToIgnoringCase("div");
+  }
+
+  private static TagNode openTag(List<Node> nodes, String name) {
+    return nodes.stream()
+      .filter(n -> n.getNodeType() == NodeType.TAG)
+      .map(n -> (TagNode) n)
+      .filter(t -> name.equalsIgnoreCase(t.getNodeName()))
+      .filter(t -> !t.isEndElement())
+      .findFirst().orElse(null);
+  }
+
+  private static int openTagLine(List<Node> nodes, String name) {
+    TagNode tag = openTag(nodes, name);
+    assertThat(tag).as("open <%s> tag", name).isNotNull();
+    return tag.getStartLinePosition();
+  }
+}

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/visitor/HtmlAstScannerEmbeddedGatingTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/visitor/HtmlAstScannerEmbeddedGatingTest.java
@@ -1,0 +1,98 @@
+/*
+ * SonarQube HTML
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.html.visitor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
+import org.sonar.plugins.html.checks.EmbeddedHtmlCheck;
+import org.sonar.plugins.html.node.Node;
+import org.sonar.plugins.html.node.TagNode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HtmlAstScannerEmbeddedGatingTest {
+
+  @Test
+  void embeddedNodesReachOnlyOptInVisitors() {
+    TagNode plain = newTag("plain", false);
+    TagNode embedded = newTag("embedded", true);
+
+    RecordingVisitor optedOut = new RecordingVisitor();
+    RecordingEmbeddedVisitor optedIn = new RecordingEmbeddedVisitor();
+
+    HtmlAstScanner scanner = new HtmlAstScanner(Collections.emptyList());
+    scanner.addVisitor(optedOut);
+    scanner.addVisitor(optedIn);
+    scanner.scan(List.of(plain, embedded), newSourceCode());
+
+    assertThat(optedOut.starts).containsExactly("plain");
+    assertThat(optedIn.starts).containsExactly("plain", "embedded");
+  }
+
+  @Test
+  void nonOptInCheckSeesEmbeddedNodesViaStartDocumentButNotViaCallbacks() {
+    TagNode plain = newTag("plain", false);
+    TagNode embedded = newTag("embedded", true);
+
+    List<Node> capturedByStartDocument = new ArrayList<>();
+    RecordingVisitor nonOptIn = new RecordingVisitor() {
+      @Override
+      public void startDocument(List<Node> nodes) {
+        capturedByStartDocument.addAll(nodes);
+      }
+    };
+
+    HtmlAstScanner scanner = new HtmlAstScanner(Collections.emptyList());
+    scanner.addVisitor(nonOptIn);
+    scanner.scan(List.of(plain, embedded), newSourceCode());
+
+    // Full node list — including embedded — reaches every check via startDocument.
+    assertThat(capturedByStartDocument).containsExactly(plain, embedded);
+    // Visitor callbacks (startElement) are gated: only the plain node fires.
+    assertThat(nonOptIn.starts).containsExactly("plain");
+  }
+
+  private static TagNode newTag(String name, boolean embedded) {
+    TagNode tag = new TagNode();
+    tag.setNodeName(name);
+    tag.setCode("<" + name + ">");
+    tag.setEmbedded(embedded);
+    return tag;
+  }
+
+  private static HtmlSourceCode newSourceCode() {
+    return new HtmlSourceCode(
+      new TestInputFileBuilder("fv", "probe.html")
+        .setLanguage("web")
+        .build());
+  }
+
+  private static class RecordingVisitor extends DefaultNodeVisitor {
+    final List<String> starts = new ArrayList<>();
+
+    @Override
+    public void startElement(TagNode element) {
+      starts.add(element.getNodeName());
+    }
+  }
+
+  private static class RecordingEmbeddedVisitor extends RecordingVisitor implements EmbeddedHtmlCheck {
+  }
+}

--- a/sonar-html-plugin/src/test/resources/checks/AriaProptypesCheck.php
+++ b/sonar-html-plugin/src/test/resources/checks/AriaProptypesCheck.php
@@ -1,0 +1,5 @@
+<?php
+$out  = "<div aria-hidden=\"not-a-bool\"></div>"; // Noncompliant: not-a-bool is not a valid boolean
+$out .= "<div aria-hidden=\"true\"></div>";         // Compliant
+$out .= "<div aria-hidden=\"$flag\"></div>";        // Compliant: dynamic value
+?>

--- a/sonar-html-plugin/src/test/resources/checks/AriaRoleCheck.php
+++ b/sonar-html-plugin/src/test/resources/checks/AriaRoleCheck.php
@@ -1,0 +1,6 @@
+<?php
+$out  = "<div role=\"foobar\"></div>";           // Noncompliant: foobar is an unknown role
+$out .= "<li id=\"fn:$note_id\" role=\"doc-endnote\">";  // Compliant: role is valid
+$out .= "<div role=\"$role\"></div>";              // Compliant: role is dynamic
+$out .= "<div role=\"toolbar\"></div>";            // Compliant: role is valid
+?>

--- a/sonar-html-plugin/src/test/resources/checks/TabIndexNoPositiveCheck.php
+++ b/sonar-html-plugin/src/test/resources/checks/TabIndexNoPositiveCheck.php
@@ -1,0 +1,5 @@
+<?php
+$out  = "<div tabindex=\"5\"></div>";   // Noncompliant: positive tabindex
+$out .= "<div tabindex=\"0\"></div>";   // Compliant
+$out .= "<div tabindex=\"$i\"></div>";  // Compliant: dynamic value
+?>


### PR DESCRIPTION
## Summary

HTML inside PHP string literals (`echo "<div role='toolbar'>"`) was invisible to all rules. `PhpEmbeddedHtmlExtractor` now re-lexes string-literal content from PHP directives and splices the resulting nodes (with file-accurate positions) into the main node list before hierarchy construction.

## Gating

Spliced nodes are stamped `embedded=true`. `HtmlAstScanner` routes them only to visitors that implement the new `EmbeddedHtmlCheck` marker interface, keeping context-heavy checks (label association, unclosed tags, doctype…) off the fragmented re-lex output. Six standalone single-element checks opt in: `AriaRoleCheck`, `AriaProptypesCheck`, `ElementWithRoleShouldHaveRequiredPropertiesCheck`, `FocusableInteractiveElementsCheck`, `NoRedundantRolesCheck`, `TabIndexNoPositiveCheck`.

## Changes

- **New** `PhpEmbeddedHtmlExtractor`: handles double-quoted, single-quoted, heredoc and nowdoc literals; replaces interpolations with a dynamic placeholder.
- **New** `EmbeddedHtmlCheck` marker interface + `Node.embedded` flag + one-line gate in `HtmlAstScanner`.
- Six opt-in checks switch from `isDynamicValue` (prefix match) to `containsDynamicValue` (substring match) for mid-value placeholders.
- Ruling baselines updated; non-opt-in baselines reverted to master.

## Functional Validation

See attached [SONARHTML-246-fv.zip](https://github.com/user-attachments/files/28513881/SONARHTML-246-fv.zip). Unzip and run `./run.sh` from inside `SONARHTML-246-fv/`. The script materialises `master` and the PR branch from an embedded bundle, builds each module's classpath, and scans `sample/embedded.php` with `AriaRoleCheck`. Expected delta:

- `master`: no issues — the literal's content never reaches the check.
- PR branch: `Web:S6821` on line 3, the bogus role's actual source line.
