### PR TITLE
SONARHTML-385 Restrict S5725 to statically versioned URLs

### DIFF
--- a/its/ruling/src/test/resources/expected/Web-S5725.json
+++ b/its/ruling/src/test/resources/expected/Web-S5725.json
@@ -2,67 +2,6 @@
 "project:Silverpeas-Core-master/src/site/resources/screenshots.html": [
 19
 ],
-"project:Silverpeas-Core-master/war-core/src/main/webapp/pdcPeas/jsp/webTab.jsp": [
-53
-],
-"project:Silverpeas-Core-master/war-core/src/main/webapp/socialNetwork/jsp/channelFB.html": [
-1
-],
-"project:Silverpeas-Core-master/war-core/src/main/webapp/wysiwyg/jsp/ckeditor/_samples/jqueryadapter.html": [
-10
-],
-"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/media-controls.html": [
-71
-],
-"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/media-default-playback-rate.html": [
-5,
-6
-],
-"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/media-muted.html": [
-3
-],
-"project:external_webkit-jb-mr1/Source/WebKit/chromium/tests/data/pageserialization/simple_page.html": [
-9
-],
-"project:external_webkit-jb-mr1/Tools/BuildSlaveSupport/build.webkit.org-config/public_html/LeaksViewer/index.html": [
-30,
-36,
-37,
-38,
-39,
-40,
-41,
-42,
-43,
-44,
-45,
-46,
-47,
-48
-],
-"project:external_webkit-jb-mr1/Tools/CSSTestSuiteHarness/harness/harness.html": [
-35
-],
-"project:external_webkit-jb-mr1/Tools/RebaselineQueueServer/templates/builder-picker.html": [
-5
-],
-"project:external_webkit-jb-mr1/Tools/RebaselineQueueServer/templates/builder-queue-edit.html": [
-5
-],
-"project:sonar-master/plugins/sonar-design-plugin/src/main/resources/org/sonar/plugins/design/ui/libraries/public/test.html": [
-10,
-11
-],
-"project:sonar-master/plugins/sonar-design-plugin/src/main/resources/org/sonar/plugins/design/ui/page/public/test.html": [
-10,
-11
-],
-"project:voten/resources/views/errors/403.blade.php": [
-6
-],
-"project:voten/resources/views/errors/503.blade.php": [
-6
-],
 "project:voten/resources/views/layouts/app.blade.php": [
 11,
 12
@@ -71,17 +10,12 @@
 16,
 17
 ],
-"project:voten/resources/views/layouts/bootstrap.blade.php": [
-15
-],
 "project:voten/resources/views/layouts/guest.blade.php": [
 14,
-15,
-54
+15
 ],
 "project:voten/resources/views/layouts/no-sidebar.blade.php": [
 14,
-15,
-40
+15
 ]
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/ResourceIntegrityCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/ResourceIntegrityCheck.java
@@ -16,8 +16,9 @@
  */
 package org.sonar.plugins.html.checks.security;
 
-import java.util.Set;
 import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Pattern;
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
 import org.sonar.plugins.html.node.Attribute;
@@ -26,20 +27,40 @@ import org.sonar.plugins.html.node.TagNode;
 @Rule(key = "S5725")
 public class ResourceIntegrityCheck extends AbstractPageCheck {
 
-  private static final String MESSAGE = "Make sure using artifacts without integrity checks is safe here.";
+  private static final String MSG_MISSING_BOTH = "Add integrity and crossorigin=\"anonymous\" attributes to this element to enforce integrity checks.";
+  private static final String MSG_MISSING_INTEGRITY = "Add an integrity attribute to this element to enforce integrity checks.";
+  private static final String MSG_MISSING_CROSSORIGIN = "Add a crossorigin=\"anonymous\" attribute to this element to enforce integrity checks.";
+
   private static final Set<String> LINK_REL_VALUES = Set.of("stylesheet", "preload", "modulepreload");
+
+  // Matches a semver path segment (/3.7.1/, /v5.3.0/) or a package@version alias (/jquery@3.7.1/)
+  private static final Pattern VERSION_PATTERN = Pattern.compile("/((v?\\d+\\.\\d+(\\.\\d+)?)|([^/@]*@[\\d.]+))/");
 
   @Override
   public void startElement(TagNode node) {
-    if ((node.equalsElementName("script") && hasExternalSource(node, "src")) ||
-      (node.equalsElementName("link") && hasIntegrityRelevantRel(node) && hasExternalSource(node, "href"))) {
-      createViolation(node, MESSAGE);
+    if (node.equalsElementName("script")) {
+      checkElement(node, "src");
+    } else if (node.equalsElementName("link") && hasIntegrityRelevantRel(node)) {
+      checkElement(node, "href");
     }
   }
 
-  private static boolean hasExternalSource(TagNode node, String sourceAttribute) {
+  private void checkElement(TagNode node, String sourceAttribute) {
     Attribute source = node.getProperty(sourceAttribute);
-    return source != null && isExternal(source.getValue()) && !node.hasProperty("integrity");
+    if (source == null || !isExternal(source.getValue()) || !hasVersionInUrl(source.getValue())) {
+      return;
+    }
+
+    boolean hasIntegrity = node.hasProperty("integrity");
+    boolean hasCrossorigin = hasCrossoriginAnonymous(node);
+
+    if (!hasIntegrity && !hasCrossorigin) {
+      createViolation(node, MSG_MISSING_BOTH);
+    } else if (!hasIntegrity) {
+      createViolation(node, MSG_MISSING_INTEGRITY);
+    } else if (!hasCrossorigin) {
+      createViolation(node, MSG_MISSING_CROSSORIGIN);
+    }
   }
 
   private static boolean hasIntegrityRelevantRel(TagNode node) {
@@ -47,8 +68,17 @@ public class ResourceIntegrityCheck extends AbstractPageCheck {
     return rel != null && LINK_REL_VALUES.contains(rel.getValue().toLowerCase(Locale.ROOT));
   }
 
-  private static boolean isExternal(String srcValue) {
-    return srcValue.startsWith("http") || srcValue.startsWith("//");
+  private static boolean isExternal(String url) {
+    return url.startsWith("http") || url.startsWith("//");
+  }
+
+  private static boolean hasVersionInUrl(String url) {
+    return VERSION_PATTERN.matcher(url).find();
+  }
+
+  private static boolean hasCrossoriginAnonymous(TagNode node) {
+    Attribute crossorigin = node.getProperty("crossorigin");
+    return crossorigin != null && "anonymous".equalsIgnoreCase(crossorigin.getValue());
   }
 
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/ResourceIntegrityCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/security/ResourceIntegrityCheck.java
@@ -33,8 +33,10 @@ public class ResourceIntegrityCheck extends AbstractPageCheck {
 
   private static final Set<String> LINK_REL_VALUES = Set.of("stylesheet", "preload", "modulepreload");
 
-  // Matches a semver path segment (/3.7.1/, /v5.3.0/) or a package@version alias (/jquery@3.7.1/)
-  private static final Pattern VERSION_PATTERN = Pattern.compile("/((v?\\d+\\.\\d+(\\.\\d+)?)|([^/@]*@[\\d.]+))/");
+  // Each pattern is kept separate to stay within the regex complexity limit (S5843)
+  // Trailing lookahead accepts a path separator, query/fragment boundary, or end-of-URL
+  private static final Pattern SEMVER_PATTERN = Pattern.compile("/v?\\d+\\.\\d+(?:\\.\\d+)?(?=[/?#]|$)");
+  private static final Pattern PKG_AT_VERSION_PATTERN = Pattern.compile("/[^/@]*@[\\d.]+(?=[/?#]|$)");
 
   @Override
   public void startElement(TagNode node) {
@@ -73,7 +75,7 @@ public class ResourceIntegrityCheck extends AbstractPageCheck {
   }
 
   private static boolean hasVersionInUrl(String url) {
-    return VERSION_PATTERN.matcher(url).find();
+    return SEMVER_PATTERN.matcher(url).find() || PKG_AT_VERSION_PATTERN.matcher(url).find();
   }
 
   private static boolean hasCrossoriginAnonymous(TagNode node) {

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/security/ResourceIntegrityCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/security/ResourceIntegrityCheckTest.java
@@ -25,7 +25,9 @@ import org.sonar.plugins.html.visitor.HtmlSourceCode;
 
 class ResourceIntegrityCheckTest {
 
-  private static final String MESSAGE = "Make sure using artifacts without integrity checks is safe here.";
+  private static final String MSG_MISSING_BOTH = "Add integrity and crossorigin=\"anonymous\" attributes to this element to enforce integrity checks.";
+  private static final String MSG_MISSING_INTEGRITY = "Add an integrity attribute to this element to enforce integrity checks.";
+  private static final String MSG_MISSING_CROSSORIGIN = "Add a crossorigin=\"anonymous\" attribute to this element to enforce integrity checks.";
 
   @RegisterExtension
   public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
@@ -35,20 +37,29 @@ class ResourceIntegrityCheckTest {
     HtmlSourceCode sourceCode = TestHelper.scan(new File("src/test/resources/checks/resourceIntegrityCheck.html"), new ResourceIntegrityCheck());
 
     checkMessagesVerifier.verify(sourceCode.getIssues())
-      .next().atLocation(1, 0, 1, 47).withMessage(MESSAGE)
-      .next().atLocation(2, 0, 2, 41).withMessage(MESSAGE)
-      .next().atLocation(3, 0, 3, 46).withMessage(MESSAGE)
-      .next().atLocation(4, 0, 4, 61).withMessage(MESSAGE)
-      .next().atLocation(18, 0, 18, 64).withMessage(MESSAGE)
-      .next().atLocation(19, 0, 19, 58).withMessage(MESSAGE)
-      .next().atLocation(20, 0, 20, 63).withMessage(MESSAGE)
-      .next().atLocation(21, 0, 21, 64).withMessage(MESSAGE)
-      .next().atLocation(24, 0, 24, 72).withMessage(MESSAGE)
-      .next().atLocation(25, 0, 25, 67).withMessage(MESSAGE)
-      .next().atLocation(26, 0, 26, 72).withMessage(MESSAGE)
-      .next().atLocation(29, 0, 29, 67).withMessage(MESSAGE)
-      .next().atLocation(30, 0, 30, 61).withMessage(MESSAGE)
-      .next().atLocation(31, 0, 31, 67).withMessage(MESSAGE);
+      // versioned URL, both missing
+      .next().atLine(2).withMessage(MSG_MISSING_BOTH)
+      .next().atLine(3).withMessage(MSG_MISSING_BOTH)
+      .next().atLine(4).withMessage(MSG_MISSING_BOTH)
+      .next().atLine(5).withMessage(MSG_MISSING_BOTH)
+      // package@version alias, both missing
+      .next().atLine(8).withMessage(MSG_MISSING_BOTH)
+      .next().atLine(9).withMessage(MSG_MISSING_BOTH)
+      // versioned URL, only integrity missing
+      .next().atLine(12).withMessage(MSG_MISSING_INTEGRITY)
+      // versioned URL, only crossorigin missing
+      .next().atLine(15).withMessage(MSG_MISSING_CROSSORIGIN)
+      // link rel=stylesheet, versioned URL, both missing
+      .next().atLine(46).withMessage(MSG_MISSING_BOTH)
+      // link rel=stylesheet, versioned URL, only integrity missing
+      .next().atLine(48).withMessage(MSG_MISSING_INTEGRITY)
+      // link rel=stylesheet, versioned URL, only crossorigin missing
+      .next().atLine(50).withMessage(MSG_MISSING_CROSSORIGIN)
+      // link rel=preload, versioned URL, both missing
+      .next().atLine(56).withMessage(MSG_MISSING_BOTH)
+      // link rel=modulepreload, versioned URL, both missing
+      .next().atLine(58).withMessage(MSG_MISSING_BOTH)
+      .noMore();
   }
 
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/security/ResourceIntegrityCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/security/ResourceIntegrityCheckTest.java
@@ -45,20 +45,24 @@ class ResourceIntegrityCheckTest {
       // package@version alias, both missing
       .next().atLine(8).withMessage(MSG_MISSING_BOTH)
       .next().atLine(9).withMessage(MSG_MISSING_BOTH)
+      // version as final path segment (no trailing slash)
+      .next().atLine(12).withMessage(MSG_MISSING_BOTH)
+      .next().atLine(13).withMessage(MSG_MISSING_BOTH)
+      .next().atLine(14).withMessage(MSG_MISSING_BOTH)
       // versioned URL, only integrity missing
-      .next().atLine(12).withMessage(MSG_MISSING_INTEGRITY)
+      .next().atLine(17).withMessage(MSG_MISSING_INTEGRITY)
       // versioned URL, only crossorigin missing
-      .next().atLine(15).withMessage(MSG_MISSING_CROSSORIGIN)
+      .next().atLine(20).withMessage(MSG_MISSING_CROSSORIGIN)
       // link rel=stylesheet, versioned URL, both missing
-      .next().atLine(46).withMessage(MSG_MISSING_BOTH)
+      .next().atLine(51).withMessage(MSG_MISSING_BOTH)
       // link rel=stylesheet, versioned URL, only integrity missing
-      .next().atLine(48).withMessage(MSG_MISSING_INTEGRITY)
+      .next().atLine(53).withMessage(MSG_MISSING_INTEGRITY)
       // link rel=stylesheet, versioned URL, only crossorigin missing
-      .next().atLine(50).withMessage(MSG_MISSING_CROSSORIGIN)
+      .next().atLine(55).withMessage(MSG_MISSING_CROSSORIGIN)
       // link rel=preload, versioned URL, both missing
-      .next().atLine(56).withMessage(MSG_MISSING_BOTH)
+      .next().atLine(61).withMessage(MSG_MISSING_BOTH)
       // link rel=modulepreload, versioned URL, both missing
-      .next().atLine(58).withMessage(MSG_MISSING_BOTH)
+      .next().atLine(63).withMessage(MSG_MISSING_BOTH)
       .noMore();
   }
 

--- a/sonar-html-plugin/src/test/resources/checks/resourceIntegrityCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/resourceIntegrityCheck.html
@@ -1,22 +1,22 @@
-<!-- Sensitive: versioned URL, both integrity and crossorigin missing -->
+<!-- Noncompliant:  versioned URL, both integrity and crossorigin missing -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
 <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
 <script type="module" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
 
-<!-- Sensitive: versioned URL using package@version alias, both missing -->
+<!-- Noncompliant:  versioned URL using package@version alias, both missing -->
 <script src="https://unpkg.com/jquery@3.7.1/dist/jquery.min.js"></script>
 <script src="https://unpkg.com/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 
-<!-- Sensitive: version is the final path segment (no trailing slash) -->
+<!-- Noncompliant:  version is the final path segment (no trailing slash) -->
 <script src="https://cdn.jsdelivr.net/npm/jquery@3.7.1"></script>
 <script src="https://unpkg.com/react@18.2.0"></script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.5.0">
 
-<!-- Sensitive: versioned URL, only integrity missing (has crossorigin) -->
+<!-- Noncompliant:  versioned URL, only integrity missing (has crossorigin) -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" crossorigin="anonymous"></script>
 
-<!-- Sensitive: versioned URL, only crossorigin missing (has integrity) -->
+<!-- Noncompliant:  versioned URL, only crossorigin missing (has integrity) -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC"></script>
 
 <!-- Compliant: both integrity and crossorigin present -->
@@ -47,19 +47,19 @@
   integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC"
   crossorigin="anonymous">
 
-<!-- Sensitive: link rel=stylesheet, versioned URL, both missing -->
+<!-- Noncompliant:  link rel=stylesheet, versioned URL, both missing -->
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.5.0/css/bulma.css">
-<!-- Sensitive: link rel=stylesheet, versioned URL, only integrity missing -->
+<!-- Noncompliant:  link rel=stylesheet, versioned URL, only integrity missing -->
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.5.0/css/bulma.css" crossorigin="anonymous">
-<!-- Sensitive: link rel=stylesheet, versioned URL, only crossorigin missing -->
+<!-- Noncompliant:  link rel=stylesheet, versioned URL, only crossorigin missing -->
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.5.0/css/bulma.css" integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC">
 
 <!-- Compliant: link rel=stylesheet, no version in URL -->
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Dosis:400">
 
-<!-- Sensitive: link rel=preload, versioned URL, both missing -->
+<!-- Noncompliant:  link rel=preload, versioned URL, both missing -->
 <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" as="script">
-<!-- Sensitive: link rel=modulepreload, versioned URL, both missing -->
+<!-- Noncompliant:  link rel=modulepreload, versioned URL, both missing -->
 <link rel="modulepreload" href="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js">
 
 <!-- Compliant: other rel values, versioned URL -->

--- a/sonar-html-plugin/src/test/resources/checks/resourceIntegrityCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/resourceIntegrityCheck.html
@@ -8,6 +8,11 @@
 <script src="https://unpkg.com/jquery@3.7.1/dist/jquery.min.js"></script>
 <script src="https://unpkg.com/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 
+<!-- Sensitive: version is the final path segment (no trailing slash) -->
+<script src="https://cdn.jsdelivr.net/npm/jquery@3.7.1"></script>
+<script src="https://unpkg.com/react@18.2.0"></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.5.0">
+
 <!-- Sensitive: versioned URL, only integrity missing (has crossorigin) -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" crossorigin="anonymous"></script>
 

--- a/sonar-html-plugin/src/test/resources/checks/resourceIntegrityCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/resourceIntegrityCheck.html
@@ -1,49 +1,65 @@
-<script src="https://cdnexample.com/script.js"></script> <!-- Sensitive -->
-<script src="//cdnexample.com/script.js"></script> <!-- Sensitive -->
-<script src="http://cdnexample.com/script.js"></script> <!-- Sensitive -->
-<script type="module" src="https://cdnexample.com/script.js"></script> <!-- Sensitive -->
+<!-- Sensitive: versioned URL, both integrity and crossorigin missing -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
+<script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
+<script type="module" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
 
-<!-- compliant, integrity correctly set -->
-<script src="https://cdnexample.com/script.js" integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC">
+<!-- Sensitive: versioned URL using package@version alias, both missing -->
+<script src="https://unpkg.com/jquery@3.7.1/dist/jquery.min.js"></script>
+<script src="https://unpkg.com/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+
+<!-- Sensitive: versioned URL, only integrity missing (has crossorigin) -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" crossorigin="anonymous"></script>
+
+<!-- Sensitive: versioned URL, only crossorigin missing (has integrity) -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC"></script>
+
+<!-- Compliant: both integrity and crossorigin present -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"
+  crossorigin="anonymous"
+  integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC">
 </script>
 
-<script src="text/javascript.js"></script> <!-- compliant , not external-->
+<!-- Compliant: local resource -->
+<script src="text/javascript.js"></script>
 
-<script></script> <!-- compliant , no source-->
+<!-- Compliant: no source -->
+<script></script>
 
-<img alt="foo" src="https://cdnexample.com/myImage.js" /> <!-- compliant , not a script-->
-<img src="https://cdnexample.com/myImage.png" /> <!-- compliant , not a script-->
+<!-- Compliant: not a script -->
+<img alt="foo" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" />
 
-<!-- link elements with rel="stylesheet" -->
-<link rel="stylesheet" href="https://cdn.example.com/style.css"> <!-- Sensitive -->
-<link rel="stylesheet" href="//cdn.example.com/style.css"> <!-- Sensitive -->
-<link rel="stylesheet" href="http://cdn.example.com/style.css"> <!-- Sensitive -->
-<link rel="STYLESHEET" href="https://cdn.example.com/style.css"> <!-- Sensitive, case insensitive -->
+<!-- Compliant: no version in URL (mutable URLs - SRI not applicable) -->
+<script src="https://www.googletagmanager.com/gtag/js?id=UA-XXX"></script>
+<script src="https://js.stripe.com/v3/"></script>
+<script src="https://cdn.example.com/latest/script.js"></script>
+<script src="https://cdn.example.com/script.js"></script>
+<script src="//connect.facebook.net/en_US/all.js"></script>
+<script src="https://www.google.com/recaptcha/api.js"></script>
 
-<!-- link elements with rel="preload" -->
-<link rel="preload" href="https://cdn.example.com/font.woff2" as="font"> <!-- Sensitive -->
-<link rel="preload" href="//cdn.example.com/script.js" as="script"> <!-- Sensitive -->
-<link rel="PRELOAD" href="https://cdn.example.com/style.css" as="style"> <!-- Sensitive, case insensitive -->
+<!-- Compliant: link rel=stylesheet, versioned URL, both attributes present -->
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.5.0/css/bulma.css"
+  integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC"
+  crossorigin="anonymous">
 
-<!-- link elements with rel="modulepreload" -->
-<link rel="modulepreload" href="https://cdn.example.com/module.js"> <!-- Sensitive -->
-<link rel="modulepreload" href="//cdn.example.com/module.js"> <!-- Sensitive -->
-<link rel="MODULEPRELOAD" href="https://cdn.example.com/module.js"> <!-- Sensitive, case insensitive -->
+<!-- Sensitive: link rel=stylesheet, versioned URL, both missing -->
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.5.0/css/bulma.css">
+<!-- Sensitive: link rel=stylesheet, versioned URL, only integrity missing -->
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.5.0/css/bulma.css" crossorigin="anonymous">
+<!-- Sensitive: link rel=stylesheet, versioned URL, only crossorigin missing -->
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.5.0/css/bulma.css" integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC">
 
-<!-- compliant, integrity correctly set -->
-<link rel="stylesheet" href="https://cdn.example.com/style.css" integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC">
-<link rel="preload" href="https://cdn.example.com/font.woff2" as="font" integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC">
-<link rel="modulepreload" href="https://cdn.example.com/module.js" integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC">
+<!-- Compliant: link rel=stylesheet, no version in URL -->
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Dosis:400">
 
-<!-- compliant, local resources -->
+<!-- Sensitive: link rel=preload, versioned URL, both missing -->
+<link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" as="script">
+<!-- Sensitive: link rel=modulepreload, versioned URL, both missing -->
+<link rel="modulepreload" href="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js">
+
+<!-- Compliant: other rel values, versioned URL -->
+<link rel="icon" href="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/favicon.ico">
+
+<!-- Compliant: local resources -->
 <link rel="stylesheet" href="styles/main.css">
 <link rel="preload" href="/fonts/font.woff2" as="font">
-<link rel="modulepreload" href="./modules/app.js">
-
-<!-- compliant, no href -->
-<link rel="stylesheet">
-
-<!-- compliant, other rel values -->
-<link rel="icon" href="https://cdn.example.com/favicon.ico">
-<link rel="canonical" href="https://cdn.example.com/page">
-<link rel="alternate" href="https://cdn.example.com/feed.xml">


### PR DESCRIPTION
Implements [SONARHTML-385](https://sonarsource.atlassian.net/browse/SONARHTML-385).

- Only raise on URLs with a recognizable version segment (`/3.7.1/`, `/v5.3.0/`, `/jquery@3.7.1/`)
- Check both `integrity` and `crossorigin="anonymous"`, with a distinct message for each missing attribute

[SONARHTML-385]: https://sonarsource.atlassian.net/browse/SONARHTML-385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ