### PR TITLE
SONARHTML-291 Allow S6819 ARIA role whitelist

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheck.java
@@ -19,12 +19,9 @@ package org.sonar.plugins.html.checks.accessibility;
 import static org.sonar.plugins.html.api.HtmlConstants.hasKnownHTMLTag;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashSet;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,6 +44,9 @@ public class PreferTagOverRoleCheck extends AbstractPageCheck {
   static final String UNKNOWN_ALLOWED_ROLE_WARNING =
     "Rule S6819 \"allowedRoles\" parameter contains unknown ARIA roles: %s. These entries will have no effect.";
 
+  private static final String UNKNOWN_ALLOWED_ROLE_LOG_MESSAGE =
+    "Rule S6819 \"allowedRoles\" parameter contains unknown ARIA roles: {}. These entries will have no effect.";
+
   @RuleProperty(
     key = "allowedRoles",
     description = "Comma-separated list of ARIA roles to allow on HTML elements even when an equivalent HTML tag exists. " +
@@ -55,7 +55,7 @@ public class PreferTagOverRoleCheck extends AbstractPageCheck {
   public String allowedRoles = DEFAULT_ALLOWED_ROLES;
 
   private String parsedAllowedRolesSource;
-  private Set<AriaRole> allowedRolesCache = Set.of();
+  private EnumSet<AriaRole> allowedRolesCache = EnumSet.noneOf(AriaRole.class);
   private List<String> unknownAllowedRoles = List.of();
 
   @Override
@@ -123,11 +123,11 @@ public class PreferTagOverRoleCheck extends AbstractPageCheck {
     }
     parsedAllowedRolesSource = current;
     if (current.isBlank()) {
-      allowedRolesCache = Set.of();
+      allowedRolesCache = EnumSet.noneOf(AriaRole.class);
       unknownAllowedRoles = List.of();
       return;
     }
-    Set<AriaRole> known = new LinkedHashSet<>();
+    EnumSet<AriaRole> known = EnumSet.noneOf(AriaRole.class);
     List<String> unknown = new ArrayList<>();
     for (String raw : trimSplitCommaSeparatedList(current)) {
       String normalized = raw.toLowerCase(Locale.ROOT);
@@ -138,10 +138,12 @@ public class PreferTagOverRoleCheck extends AbstractPageCheck {
         known.add(role);
       }
     }
-    allowedRolesCache = known.isEmpty() ? Set.of() : Collections.unmodifiableSet(known);
+    allowedRolesCache = known;
     if (!unknown.isEmpty()) {
-      unknownAllowedRoles = Collections.unmodifiableList(unknown);
-      LOG.warn(String.format(UNKNOWN_ALLOWED_ROLE_WARNING, String.join(", ", unknown)));
+      unknownAllowedRoles = List.copyOf(unknown);
+      if (LOG.isWarnEnabled()) {
+        LOG.warn(UNKNOWN_ALLOWED_ROLE_LOG_MESSAGE, String.join(", ", unknown));
+      }
     } else {
       unknownAllowedRoles = List.of();
     }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheck.java
@@ -16,19 +16,41 @@
  */
 package org.sonar.plugins.html.checks.accessibility;
 
+import static org.sonar.plugins.html.api.HtmlConstants.hasKnownHTMLTag;
+
+import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.sonar.check.Rule;
+import org.sonar.check.RuleProperty;
 import org.sonar.plugins.html.api.accessibility.Aria;
 import org.sonar.plugins.html.api.accessibility.AriaRole;
 import org.sonar.plugins.html.api.accessibility.Element;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
+import org.sonar.plugins.html.node.Node;
 import org.sonar.plugins.html.node.TagNode;
-
-import static org.sonar.plugins.html.api.HtmlConstants.hasKnownHTMLTag;
 
 @Rule(key = "S6819")
 public class PreferTagOverRoleCheck extends AbstractPageCheck {
+
+  private static final String DEFAULT_WHITELISTED_ROLES = "";
+
+  @RuleProperty(
+    key = "whitelistedRoles",
+    description = "Comma-separated list of ARIA roles to ignore when they could be replaced with equivalent HTML tags.",
+    defaultValue = DEFAULT_WHITELISTED_ROLES)
+  public String whitelistedRoles = DEFAULT_WHITELISTED_ROLES;
+
+  private Set<AriaRole> whitelistedRolesSet = Set.of();
+
+  @Override
+  public void startDocument(List<Node> nodes) {
+    whitelistedRolesSet = parseWhitelistedRoles(whitelistedRoles);
+  }
+
   @Override
   public void startElement(TagNode element) {
     var roleAttr = element.getPropertyValue("role");
@@ -42,6 +64,8 @@ public class PreferTagOverRoleCheck extends AbstractPageCheck {
     Aria.RoleDefinition roleDef = Aria.getRole(ariaRole);
     Element elementObj = Element.of(element.getNodeName().toLowerCase(Locale.ROOT));
     if (
+      ariaRole == null ||
+      whitelistedRolesSet.contains(ariaRole) ||
       roleDef == null ||
       roleDef.getElements().isEmpty() ||
       (elementObj != null && roleDef.getElements().contains(elementObj))
@@ -54,4 +78,19 @@ public class PreferTagOverRoleCheck extends AbstractPageCheck {
       ariaRole));
   }
 
+  /**
+   * Parses the configured ARIA role whitelist.
+   * @param whitelistedRoles comma-separated list of ARIA roles to ignore
+   * @return normalized ARIA roles configured to be ignored
+   */
+  private Set<AriaRole> parseWhitelistedRoles(String whitelistedRoles) {
+    if (whitelistedRoles == null || whitelistedRoles.isBlank()) {
+      return Set.of();
+    }
+    return Arrays.stream(trimSplitCommaSeparatedList(whitelistedRoles))
+      .map(role -> role.toLowerCase(Locale.ROOT))
+      .map(AriaRole::of)
+      .filter(Objects::nonNull)
+      .collect(Collectors.toSet());
+  }
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheck.java
@@ -16,6 +16,7 @@
  */
 package org.sonar.plugins.html.checks.accessibility;
 
+import static org.sonar.plugins.html.api.HtmlConstants.isAbstractRole;
 import static org.sonar.plugins.html.api.HtmlConstants.hasKnownHTMLTag;
 
 import java.util.ArrayList;
@@ -71,8 +72,8 @@ public class PreferTagOverRoleCheck extends AbstractPageCheck {
     }
 
     // The HTML "role" attribute is a fallback list: user agents pick the first
-    // non-abstract role they support. We replicate that by walking the tokens
-    // and using the first one mapped to a concrete RoleDefinition.
+    // valid, non-abstract role they support. S6819 only reports when that role
+    // has an equivalent HTML element to suggest.
     Aria.RoleDefinition roleDef = resolveFirstApplicableRole(roleAttr);
     if (roleDef == null || roleDef.getElements().isEmpty()) {
       return;
@@ -105,11 +106,11 @@ public class PreferTagOverRoleCheck extends AbstractPageCheck {
   private static Aria.RoleDefinition resolveFirstApplicableRole(String roleAttr) {
     for (String token : roleAttr.trim().split("\\s+")) {
       AriaRole role = AriaRole.of(token.toLowerCase(Locale.ROOT));
-      if (role == null) {
+      if (role == null || isAbstractRole(role)) {
         continue;
       }
       Aria.RoleDefinition def = Aria.getRole(role);
-      if (def != null && !def.getElements().isEmpty()) {
+      if (def != null) {
         return def;
       }
     }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheck.java
@@ -18,12 +18,16 @@ package org.sonar.plugins.html.checks.accessibility;
 
 import static org.sonar.plugins.html.api.HtmlConstants.hasKnownHTMLTag;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
 import org.sonar.plugins.html.api.accessibility.Aria;
@@ -36,40 +40,51 @@ import org.sonar.plugins.html.node.TagNode;
 @Rule(key = "S6819")
 public class PreferTagOverRoleCheck extends AbstractPageCheck {
 
-  private static final String DEFAULT_WHITELISTED_ROLES = "";
+  private static final Logger LOG = LoggerFactory.getLogger(PreferTagOverRoleCheck.class);
+
+  private static final String DEFAULT_ALLOWED_ROLES = "";
+
+  static final String UNKNOWN_ALLOWED_ROLE_WARNING =
+    "Rule S6819 \"allowedRoles\" parameter contains unknown ARIA roles: %s. These entries will have no effect.";
 
   @RuleProperty(
-    key = "whitelistedRoles",
-    description = "Comma-separated list of ARIA roles to ignore when they could be replaced with equivalent HTML tags.",
-    defaultValue = DEFAULT_WHITELISTED_ROLES)
-  public String whitelistedRoles = DEFAULT_WHITELISTED_ROLES;
+    key = "allowedRoles",
+    description = "Comma-separated list of ARIA roles to allow on HTML elements even when an equivalent HTML tag exists. " +
+      "Values are matched case-insensitively. Unknown role names are ignored.",
+    defaultValue = DEFAULT_ALLOWED_ROLES)
+  public String allowedRoles = DEFAULT_ALLOWED_ROLES;
 
-  private Set<AriaRole> whitelistedRolesSet = Set.of();
+  private String parsedAllowedRolesSource;
+  private Set<AriaRole> allowedRolesCache = Set.of();
+  private List<String> unknownAllowedRoles = List.of();
 
   @Override
   public void startDocument(List<Node> nodes) {
-    whitelistedRolesSet = parseWhitelistedRoles(whitelistedRoles);
+    refreshAllowedRolesCache();
   }
 
   @Override
   public void startElement(TagNode element) {
     var roleAttr = element.getPropertyValue("role");
-    if (roleAttr == null || !hasKnownHTMLTag(element)) {
+    if (roleAttr == null || roleAttr.isBlank() || !hasKnownHTMLTag(element)) {
       return;
     }
 
-    // If multiple roles, only use first role defined:
-    // https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/0d5321a5457c5f0da0ca216053cc5b4f571b53ae/src/rules/prefer-tag-over-role.js#L49
-    AriaRole ariaRole = AriaRole.of(roleAttr.split(" ")[0].toLowerCase(Locale.ROOT));
-    Aria.RoleDefinition roleDef = Aria.getRole(ariaRole);
+    // The HTML "role" attribute is a fallback list: user agents pick the first
+    // non-abstract role they support. We replicate that by walking the tokens
+    // and using the first one mapped to a concrete RoleDefinition.
+    Aria.RoleDefinition roleDef = resolveFirstApplicableRole(roleAttr);
+    if (roleDef == null || roleDef.getElements().isEmpty()) {
+      return;
+    }
+
+    AriaRole ariaRole = roleDef.getName();
+    if (allowedRolesCache.contains(ariaRole)) {
+      return;
+    }
+
     Element elementObj = Element.of(element.getNodeName().toLowerCase(Locale.ROOT));
-    if (
-      ariaRole == null ||
-      whitelistedRolesSet.contains(ariaRole) ||
-      roleDef == null ||
-      roleDef.getElements().isEmpty() ||
-      (elementObj != null && roleDef.getElements().contains(elementObj))
-    ) {
+    if (elementObj != null && roleDef.getElements().contains(elementObj)) {
       return;
     }
     createViolation(element, String.format(
@@ -78,19 +93,57 @@ public class PreferTagOverRoleCheck extends AbstractPageCheck {
       ariaRole));
   }
 
-  /**
-   * Parses the configured ARIA role whitelist.
-   * @param whitelistedRoles comma-separated list of ARIA roles to ignore
-   * @return normalized ARIA roles configured to be ignored
-   */
-  private Set<AriaRole> parseWhitelistedRoles(String whitelistedRoles) {
-    if (whitelistedRoles == null || whitelistedRoles.isBlank()) {
-      return Set.of();
+  @Override
+  public List<String> collectAnalysisWarnings() {
+    refreshAllowedRolesCache();
+    if (unknownAllowedRoles.isEmpty()) {
+      return List.of();
     }
-    return Arrays.stream(trimSplitCommaSeparatedList(whitelistedRoles))
-      .map(role -> role.toLowerCase(Locale.ROOT))
-      .map(AriaRole::of)
-      .filter(Objects::nonNull)
-      .collect(Collectors.toSet());
+    return List.of(String.format(UNKNOWN_ALLOWED_ROLE_WARNING, String.join(", ", unknownAllowedRoles)));
+  }
+
+  private static Aria.RoleDefinition resolveFirstApplicableRole(String roleAttr) {
+    for (String token : roleAttr.trim().split("\\s+")) {
+      AriaRole role = AriaRole.of(token.toLowerCase(Locale.ROOT));
+      if (role == null) {
+        continue;
+      }
+      Aria.RoleDefinition def = Aria.getRole(role);
+      if (def != null && !def.getElements().isEmpty()) {
+        return def;
+      }
+    }
+    return null;
+  }
+
+  private void refreshAllowedRolesCache() {
+    String current = allowedRoles == null ? "" : allowedRoles;
+    if (current.equals(parsedAllowedRolesSource)) {
+      return;
+    }
+    parsedAllowedRolesSource = current;
+    if (current.isBlank()) {
+      allowedRolesCache = Set.of();
+      unknownAllowedRoles = List.of();
+      return;
+    }
+    Set<AriaRole> known = new LinkedHashSet<>();
+    List<String> unknown = new ArrayList<>();
+    for (String raw : trimSplitCommaSeparatedList(current)) {
+      String normalized = raw.toLowerCase(Locale.ROOT);
+      AriaRole role = AriaRole.of(normalized);
+      if (role == null) {
+        unknown.add(raw);
+      } else {
+        known.add(role);
+      }
+    }
+    allowedRolesCache = known.isEmpty() ? Set.of() : Collections.unmodifiableSet(known);
+    if (!unknown.isEmpty()) {
+      unknownAllowedRoles = Collections.unmodifiableList(unknown);
+      LOG.warn(String.format(UNKNOWN_ALLOWED_ROLE_WARNING, String.join(", ", unknown)));
+    } else {
+      unknownAllowedRoles = List.of();
+    }
   }
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheckTest.java
@@ -40,6 +40,26 @@ class PreferTagOverRoleCheckTest {
       .next().atLine(5).withMessage("Use <tbody> or <tfoot> or <thead> instead of the rowgroup role to ensure accessibility across all devices.")
       .next().atLine(6).withMessage("Use <input> instead of the checkbox role to ensure accessibility across all devices.")
       .next().atLine(7).withMessage("Use <header> instead of the banner role to ensure accessibility across all devices.")
+      .next().atLine(8).withMessage("Use <output> instead of the status role to ensure accessibility across all devices.")
+      .next().atLine(9).withMessage("Use <output> instead of the status role to ensure accessibility across all devices.")
+      .consume();
+  }
+
+  @Test
+  void whitelistedRoles() {
+    var check = new PreferTagOverRoleCheck();
+    check.whitelistedRoles = " LINK , status ";
+
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/PreferTagOverRoleCheck.html"),
+      check);
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(1).withMessage("Use <input> instead of the checkbox role to ensure accessibility across all devices.")
+      .next().atLine(2).withMessage("Use <button> or <input> instead of the button role to ensure accessibility across all devices.")
+      .next().atLine(3).withMessage("Use <h1> or <h2> or <h3> or <h4> or <h5> or <h6> instead of the heading role to ensure accessibility across all devices.")
+      .next().atLine(5).withMessage("Use <tbody> or <tfoot> or <thead> instead of the rowgroup role to ensure accessibility across all devices.")
+      .next().atLine(6).withMessage("Use <input> instead of the checkbox role to ensure accessibility across all devices.")
+      .next().atLine(7).withMessage("Use <header> instead of the banner role to ensure accessibility across all devices.")
       .consume();
   }
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheckTest.java
@@ -81,6 +81,18 @@ class PreferTagOverRoleCheckTest {
   }
 
   @Test
+  void firstApplicableRoleWithoutEquivalentHtmlTagIsIgnored() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/PreferTagOverRoleCheckFirstApplicableToken.html"),
+      new PreferTagOverRoleCheck());
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(1).withMessage("Use <input> instead of the checkbox role to ensure accessibility across all devices.")
+      .next().atLine(2).withMessage("Use <output> instead of the status role to ensure accessibility across all devices.")
+      .next().atLine(3).withMessage("Use <a> or <area> instead of the link role to ensure accessibility across all devices.")
+      .consume();
+  }
+
+  @Test
   void unknownAllowedRolesAreReportedAsAnalysisWarning() {
     var check = new PreferTagOverRoleCheck();
     check.allowedRoles = "checkbocx, status, totallyMadeUp";

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheckTest.java
@@ -16,6 +16,8 @@
  */
 package org.sonar.plugins.html.checks.accessibility;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -42,13 +44,14 @@ class PreferTagOverRoleCheckTest {
       .next().atLine(7).withMessage("Use <header> instead of the banner role to ensure accessibility across all devices.")
       .next().atLine(8).withMessage("Use <output> instead of the status role to ensure accessibility across all devices.")
       .next().atLine(9).withMessage("Use <output> instead of the status role to ensure accessibility across all devices.")
+      .next().atLine(10).withMessage("Use <a> or <area> instead of the link role to ensure accessibility across all devices.")
       .consume();
   }
 
   @Test
-  void whitelistedRoles() {
+  void allowedRoles() {
     var check = new PreferTagOverRoleCheck();
-    check.whitelistedRoles = " LINK , status ";
+    check.allowedRoles = " LINK , status ";
 
     HtmlSourceCode sourceCode = TestHelper.scan(
       new File("src/test/resources/checks/PreferTagOverRoleCheck.html"),
@@ -61,5 +64,47 @@ class PreferTagOverRoleCheckTest {
       .next().atLine(6).withMessage("Use <input> instead of the checkbox role to ensure accessibility across all devices.")
       .next().atLine(7).withMessage("Use <header> instead of the banner role to ensure accessibility across all devices.")
       .consume();
+  }
+
+  @Test
+  void allowedRolesOnlyMatchesFirstApplicableToken() {
+    var check = new PreferTagOverRoleCheck();
+    check.allowedRoles = "status";
+
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/PreferTagOverRoleCheckFirstApplicableToken.html"),
+      check);
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(1).withMessage("Use <input> instead of the checkbox role to ensure accessibility across all devices.")
+      .next().atLine(3).withMessage("Use <a> or <area> instead of the link role to ensure accessibility across all devices.")
+      .consume();
+  }
+
+  @Test
+  void unknownAllowedRolesAreReportedAsAnalysisWarning() {
+    var check = new PreferTagOverRoleCheck();
+    check.allowedRoles = "checkbocx, status, totallyMadeUp";
+
+    TestHelper.scan(
+      new File("src/test/resources/checks/PreferTagOverRoleCheck.html"),
+      check);
+
+    assertThat(check.collectAnalysisWarnings())
+      .singleElement()
+      .asString()
+      .contains("checkbocx", "totallyMadeUp")
+      .doesNotContain("status");
+  }
+
+  @Test
+  void blankAllowedRolesProducesNoWarning() {
+    var check = new PreferTagOverRoleCheck();
+    check.allowedRoles = "";
+
+    TestHelper.scan(
+      new File("src/test/resources/checks/PreferTagOverRoleCheck.html"),
+      check);
+
+    assertThat(check.collectAnalysisWarnings()).isEmpty();
   }
 }

--- a/sonar-html-plugin/src/test/resources/checks/PreferTagOverRoleCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/PreferTagOverRoleCheck.html
@@ -7,6 +7,7 @@
 <div role="banner" />             <!-- Noncompliant -->
 <div role="status" />             <!-- Noncompliant -->
 <div role="status checkbox" />    <!-- Noncompliant -->
+<div role="foo	link" />           <!-- Noncompliant -->
 
 <div />
 <div role="unknown" />

--- a/sonar-html-plugin/src/test/resources/checks/PreferTagOverRoleCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/PreferTagOverRoleCheck.html
@@ -5,6 +5,8 @@
 <div role="rowgroup" />           <!-- Noncompliant -->
 <span role="checkbox" />          <!-- Noncompliant -->
 <div role="banner" />             <!-- Noncompliant -->
+<div role="status" />             <!-- Noncompliant -->
+<div role="status checkbox" />    <!-- Noncompliant -->
 
 <div />
 <div role="unknown" />

--- a/sonar-html-plugin/src/test/resources/checks/PreferTagOverRoleCheckFirstApplicableToken.html
+++ b/sonar-html-plugin/src/test/resources/checks/PreferTagOverRoleCheckFirstApplicableToken.html
@@ -2,3 +2,4 @@
 <div role="status checkbox" />    <!-- resolves to status; status is allowed -->
 <div role="unknown link" />       <!-- resolves to link (first applicable, "unknown" skipped) -->
 <div role="unknown alsoUnknown" /><!-- no applicable role; not flagged -->
+<div role="alert status" />       <!-- resolves to alert; no equivalent HTML tag, so no issue -->

--- a/sonar-html-plugin/src/test/resources/checks/PreferTagOverRoleCheckFirstApplicableToken.html
+++ b/sonar-html-plugin/src/test/resources/checks/PreferTagOverRoleCheckFirstApplicableToken.html
@@ -1,0 +1,4 @@
+<div role="checkbox status" />    <!-- resolves to checkbox; status allowlist does not help -->
+<div role="status checkbox" />    <!-- resolves to status; status is allowed -->
+<div role="unknown link" />       <!-- resolves to link (first applicable, "unknown" skipped) -->
+<div role="unknown alsoUnknown" /><!-- no applicable role; not flagged -->


### PR DESCRIPTION
## Summary
S6819 can now skip a configured set of ARIA roles when teams intentionally keep those roles instead of switching to the suggested semantic tag.

## Changes
- added a `whitelistedRoles` rule property to `PreferTagOverRoleCheck`
- parse the configured roles once per document and ignore matching roles case-insensitively
- added tests covering the default behavior and configured suppression for `link` and `status`

## Functional Validation
Attached: `SONARHTML-291-fv.zip`

Unzip and run:
    ./run.sh

Expected output is in `expected-output.txt`. The README shows the
before/after comparison so you can reproduce the difference directly.


----
## Summary by Gitar

- **Rule Property:**
  - Added `allowedRoles` rule property to `PreferTagOverRoleCheck` to suppress violations for specific ARIA roles.
- **Role Resolution:**
  - Improved `resolveFirstApplicableRole` to correctly identify the first non-abstract, applicable role from the `role` attribute string.
- **Analysis Warnings:**
  - Implemented `collectAnalysisWarnings` to report invalid role names passed to the `allowedRoles` property.
- **Testing:**
  - Added comprehensive tests for `allowedRoles` configuration, validation of unknown roles, and verifying that only the first applicable role is evaluated.

<sub>This will update automatically on new commits.</sub>