### PR TITLE
SONARHTML-329 Support Twig comments

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/whitespace/WhiteSpaceAroundCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/whitespace/WhiteSpaceAroundCheck.java
@@ -65,17 +65,12 @@ public class WhiteSpaceAroundCheck extends AbstractPageCheck {
 
   @Override
   public void comment(CommentNode node) {
-
-    if (node.isHtml()) {
-      if (node.isServerSideInclude()) {
-        return;
-      }
-      checkStartWhitespace(node, node.getCode(), "<!--");
-      checkEndWhitespace(node, node.getCode(), "-->");
-    } else {
-      checkStartWhitespace(node, node.getCode(), "<%--");
-      checkEndWhitespace(node, node.getCode(), "--%>");
+    if (node.isServerSideInclude()) {
+      return;
     }
+
+    checkStartWhitespace(node, node.getCode(), node.getStartDelimiter());
+    checkEndWhitespace(node, node.getCode(), node.getEndDelimiter());
   }
 
   @Override

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlLexer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlLexer.java
@@ -51,6 +51,8 @@ final class HtmlLexer {
       .withChannel(commentRegexp("<%--[\\w\\W]*?%>"))
       // HTML comment
       .withChannel(commentRegexp("<!--[\\w\\W]*?-->"))
+      // Twig comment
+      .withChannel(commentRegexp("\\{#[\\w\\W]*?#\\}"))
       // C comment
       .withChannel(commentRegexp("/\\*[\\w\\W]*?\\*/"))
       // CPP comment

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/CommentTokenizer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/CommentTokenizer.java
@@ -47,12 +47,16 @@ class CommentTokenizer<T extends List<Node>> extends AbstractTokenizer<T> {
   }
 
   private final Boolean html;
+  private final String startToken;
+  private final String endToken;
   private final char[] endChars;
 
   public CommentTokenizer(String startToken, String endToken, Boolean html) {
     super(startToken, endToken);
 
     this.html = html;
+    this.startToken = startToken;
+    this.endToken = endToken;
     this.endChars = endToken.toCharArray();
   }
 
@@ -66,6 +70,8 @@ class CommentTokenizer<T extends List<Node>> extends AbstractTokenizer<T> {
 
     CommentNode node = new CommentNode();
     node.setHtml(html);
+    node.setStartDelimiter(startToken);
+    node.setEndDelimiter(endToken);
     return node;
   }
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/PageLexer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/PageLexer.java
@@ -51,6 +51,8 @@ public class PageLexer {
     new CommentTokenizer("<!--", "-->", true),
     /* JSP Comments */
     new CommentTokenizer("<%--", "--%>", false),
+    /* Twig Comments */
+    new CommentTokenizer("{#", "#}", false),
     /* HTML Directive */
     new DoctypeTokenizer("<!DOCTYPE", ">"),
     /* XML/PHP Directives */

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/CommentNode.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/CommentNode.java
@@ -24,6 +24,8 @@ package org.sonar.plugins.html.node;
 public class CommentNode extends Node {
 
   private boolean html;
+  private String startDelimiter;
+  private String endDelimiter;
 
   public CommentNode() {
     super(NodeType.COMMENT);
@@ -35,6 +37,22 @@ public class CommentNode extends Node {
 
   public void setHtml(boolean html) {
     this.html = html;
+  }
+
+  public String getStartDelimiter() {
+    return startDelimiter;
+  }
+
+  public void setStartDelimiter(String startDelimiter) {
+    this.startDelimiter = startDelimiter;
+  }
+
+  public String getEndDelimiter() {
+    return endDelimiter;
+  }
+
+  public void setEndDelimiter(String endDelimiter) {
+    this.endDelimiter = endDelimiter;
   }
 
   public boolean isServerSideInclude() {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/SonarResolveScanner.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/SonarResolveScanner.java
@@ -89,12 +89,6 @@ public class SonarResolveScanner extends DefaultNodeVisitor {
 
   private static String stripCommentDelimiters(CommentNode node) {
     String code = node.getCode();
-    if (node.isHtml()) {
-      return code.substring("<!--".length(), code.length() - "-->".length());
-    }
-    if (code.startsWith("{#")) {
-      return code.substring("{#".length(), code.length() - "#}".length());
-    }
-    return code.substring("<%--".length(), code.length() - "--%>".length());
+    return code.substring(node.getStartDelimiter().length(), code.length() - node.getEndDelimiter().length());
   }
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/SonarResolveScanner.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/visitor/SonarResolveScanner.java
@@ -92,6 +92,9 @@ public class SonarResolveScanner extends DefaultNodeVisitor {
     if (node.isHtml()) {
       return code.substring("<!--".length(), code.length() - "-->".length());
     }
+    if (code.startsWith("{#")) {
+      return code.substring("{#".length(), code.length() - "#}".length());
+    }
     return code.substring("<%--".length(), code.length() - "--%>".length());
   }
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
@@ -107,6 +107,17 @@ class NoDuplicateIDCheckTest {
   }
 
   @Test
+  void twigCommentsDoNotCreateDuplicateIds() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+        new File("src/test/resources/checks/NoDuplicateIDCheck/twigComments.twig"),
+        new NoDuplicateIDCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+        .next().atLine(3).withMessage("Duplicate id \"username\" found. First occurrence was on line 2.")
+        .noMore();
+  }
+
+  @Test
   void jinjaConditionalBlocks() {
     HtmlSourceCode sourceCode = TestHelper.scan(
         new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksJinja.html"),

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/whitespace/WhiteSpaceAroundCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/whitespace/WhiteSpaceAroundCheckTest.java
@@ -45,4 +45,13 @@ class WhiteSpaceAroundCheckTest {
       .next().atLine(13).withMessage("Add a space at column 18.");
   }
 
+  @Test
+  void twig_comments() {
+    HtmlSourceCode sourceCode = TestHelper.scan(new File("src/test/resources/checks/whiteSpaceAroundCheck.twig"), new WhiteSpaceAroundCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(1).withMessage("A whitespace is missing after the starting tag at column 2.")
+      .next().atLine(1).withMessage("Add a space at column 16.");
+  }
+
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlLexerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlLexerTest.java
@@ -47,6 +47,7 @@ class HtmlLexerTest {
   void multiline_comment() {
     assertThat(lexer.lex("<!-- My Comment \n a -->"), hasComment("<!-- My Comment \n a -->"));
     assertThat(lexer.lex("<%-- My Comment \n a %>"), hasComment("<%-- My Comment \n a %>"));
+    assertThat(lexer.lex("{# My Comment \n a #}"), hasComment("{# My Comment \n a #}"));
     assertThat(lexer.lex("/* My Comment \n a */"), hasComment("/* My Comment \n a */"));
   }
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/PageLexerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/PageLexerTest.java
@@ -280,7 +280,10 @@ class PageLexerTest {
 
     assertThat(nodeList).hasSize(4);
     assertThat(nodeList.get(0)).isInstanceOf(CommentNode.class);
-    assertThat(((CommentNode) nodeList.get(0)).isHtml()).isFalse();
+    CommentNode commentNode = (CommentNode) nodeList.get(0);
+    assertThat(commentNode.isHtml()).isFalse();
+    assertThat(commentNode.getStartDelimiter()).isEqualTo("{#");
+    assertThat(commentNode.getEndDelimiter()).isEqualTo("#}");
     assertThat(nodeList.get(1)).isInstanceOf(TagNode.class);
     assertThat(nodeList.get(2)).isInstanceOf(TextNode.class);
     assertThat(nodeList.get(3)).isInstanceOf(TagNode.class);

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/PageLexerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/lex/PageLexerTest.java
@@ -271,6 +271,22 @@ class PageLexerTest {
   }
 
   @Test
+  void twig_comment_containing_markup_is_lexed_as_a_comment() {
+    String fragment = "{# <div id=\"username\"></div> #}<p>aaa</p>";
+
+    StringReader reader = new StringReader(fragment);
+    PageLexer lexer = new PageLexer();
+    List<Node> nodeList = lexer.parse(reader);
+
+    assertThat(nodeList).hasSize(4);
+    assertThat(nodeList.get(0)).isInstanceOf(CommentNode.class);
+    assertThat(((CommentNode) nodeList.get(0)).isHtml()).isFalse();
+    assertThat(nodeList.get(1)).isInstanceOf(TagNode.class);
+    assertThat(nodeList.get(2)).isInstanceOf(TextNode.class);
+    assertThat(nodeList.get(3)).isInstanceOf(TagNode.class);
+  }
+
+  @Test
   void testAttributeWithoutQuotes() {
     final StringReader reader = new StringReader("<img src=http://foo/sfds?sjg a=1\tb=2\r\nc=3 />");
     final PageLexer lexer = new PageLexer();

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/visitor/SonarResolveScannerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/visitor/SonarResolveScannerTest.java
@@ -157,6 +157,26 @@ class SonarResolveScannerTest {
   }
 
   @Test
+  void scan_multiline_twig_directive() throws IOException {
+    String content = String.join("\n",
+      "{#",
+      "sonar-resolve Web:S5256 \"first",
+      "second\"",
+      "#}");
+
+    SensorContextTester tester = newSensorContext();
+    InputFile inputFile = createInputFile("multiline.twig", content);
+    scan(tester, inputFile, content);
+
+    assertThat(issueResolutions(tester, inputFile)).singleElement().satisfies(issueResolution -> {
+      assertThat(issueResolution.status()).isEqualTo(IssueResolution.Status.DEFAULT);
+      assertThat(issueResolution.ruleKeys()).containsExactly(RuleKey.of(HtmlRulesDefinition.REPOSITORY_KEY, "S5256"));
+      assertThat(issueResolution.comment()).isEqualTo("first\nsecond");
+      assertThat(issueResolution.textRange().start().line()).isEqualTo(2);
+    });
+  }
+
+  @Test
   void scan_directives_with_multiple_justification_delimiters() throws IOException {
     String content = String.join("\n",
       "<table>",

--- a/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/twigComments.twig
+++ b/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/twigComments.twig
@@ -1,0 +1,3 @@
+{# <div id="username"></div> #}
+<div id="username"></div>
+<div id="username"></div>

--- a/sonar-html-plugin/src/test/resources/checks/whiteSpaceAroundCheck.twig
+++ b/sonar-html-plugin/src/test/resources/checks/whiteSpaceAroundCheck.twig
@@ -1,0 +1,3 @@
+{#two violations#}
+
+{# zero violations #}


### PR DESCRIPTION
## Summary
Twig comments are currently lexed as plain text, so markup inside `{# ... #}` can be analyzed as real HTML and trigger false positives such as duplicate IDs. This change recognizes Twig comments in both lexer paths and treats them like server-side comments during scanning.

## Changes
- Tokenize `{# ... #}` comments in both `PageLexer` and `HtmlLexer`.
- Strip Twig comment delimiters in `SonarResolveScanner` so comment directives still parse consistently.
- Add regression coverage for duplicate IDs, AST tokenization, token lexer behavior, and sonar-resolve parsing.

## Functional Validation
Attached: `SONARHTML-329-fv.zip`

Unzip and run:
    ./run.sh

Expected output is in `expected-output.txt`. The README shows the
before/after comparison so you can reproduce the difference directly.

