### PR TITLE
SONARHTML-289 Add rule S8720 for aria-role attribute usage

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaRoleAttributeCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AriaRoleAttributeCheck.java
@@ -1,0 +1,35 @@
+/*
+ * SonarQube HTML
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.html.checks.accessibility;
+
+import org.sonar.check.Rule;
+import org.sonar.plugins.html.checks.AbstractPageCheck;
+import org.sonar.plugins.html.node.TagNode;
+
+@Rule(key = "S8720")
+public class AriaRoleAttributeCheck extends AbstractPageCheck {
+
+  private static final String MESSAGE =
+    "Replace \"aria-role\" with \"role\"; \"role\" is the correct WAI-ARIA attribute name.";
+
+  @Override
+  public void startElement(TagNode element) {
+    if (element.hasProperty("aria-role")) {
+      createViolation(element, MESSAGE);
+    }
+  }
+}

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S8720.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S8720.html
@@ -1,0 +1,30 @@
+<h2>Why is this an issue?</h2>
+<p>The WAI-ARIA attribute used to assign a role to an element is named <code>role</code>, not <code>aria-role</code>. Unlike every other WAI-ARIA
+attribute, <code>role</code> does not start with the <code>aria-</code> prefix, which makes <code>aria-role</code> a common slip — especially since we
+routinely talk about adding "ARIA roles" to elements.</p>
+<p>Browsers and assistive technologies do not recognize <code>aria-role</code>. When the typo is present, the intended role is silently ignored:
+screen readers fall back to the element’s native role (or no role at all for generic elements such as <code>&lt;div&gt;</code> and
+<code>&lt;span&gt;</code>), so the role announced to users does not match what the author intended.</p>
+<h2>How to fix it</h2>
+<p>Rename the <code>aria-role</code> attribute to <code>role</code>.</p>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+&lt;span aria-role="button"&gt;Reset&lt;/span&gt;
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+&lt;span role="button"&gt;Reset&lt;/span&gt;
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li>W3C - <a href="https://www.w3.org/TR/wai-aria-1.2/">Accessible Rich Internet Applications (WAI-ARIA) 1.2</a></li>
+  <li>W3C - <a href="https://www.w3.org/TR/wai-aria-1.2/#host_general_role">The <code>role</code> attribute</a></li>
+  <li>MDN - <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles">ARIA roles (Reference)</a></li>
+</ul>
+<h3>Standards</h3>
+<ul>
+  <li>W3C - <a href="https://www.w3.org/WAI/WCAG22/Understanding/name-role-value">WCAG 2.2 - 4.1.2 Name, Role, Value</a></li>
+</ul>
+

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S8720.json
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S8720.json
@@ -1,0 +1,25 @@
+{
+  "title": "The \"role\" attribute should be used instead of \"aria-role\"",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "2min"
+  },
+  "tags": [
+    "accessibility",
+    "wcag2-a"
+  ],
+  "defaultSeverity": "Major",
+  "ruleSpecification": "RSPEC-8720",
+  "sqKey": "S8720",
+  "scope": "All",
+  "quickfix": "infeasible",
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "LOW",
+      "RELIABILITY": "MEDIUM"
+    },
+    "attribute": "LOGICAL"
+  }
+}

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S8720.json
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S8720.json
@@ -14,7 +14,7 @@
   "ruleSpecification": "RSPEC-8720",
   "sqKey": "S8720",
   "scope": "All",
-  "quickfix": "infeasible",
+  "quickfix": "targeted",
   "code": {
     "impacts": {
       "MAINTAINABILITY": "LOW",

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S8720.json
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S8720.json
@@ -1,6 +1,6 @@
 {
   "title": "The \"role\" attribute should be used instead of \"aria-role\"",
-  "type": "CODE_SMELL",
+  "type": "BUG",
   "status": "ready",
   "remediation": {
     "func": "Constant\/Issue",

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/Sonar_way_profile.json
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/Sonar_way_profile.json
@@ -54,6 +54,7 @@
     "S7929",
     "S7930",
     "S8697",
+    "S8720",
     "TableHeaderHasIdOrScopeCheck",
     "UnsupportedTagsInHtml5Check"
   ]

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaRoleAttributeCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AriaRoleAttributeCheckTest.java
@@ -1,0 +1,75 @@
+/*
+ * SonarQube HTML
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.html.checks.accessibility;
+
+import java.io.File;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.sonar.plugins.html.checks.CheckMessagesVerifierRule;
+import org.sonar.plugins.html.checks.TestHelper;
+import org.sonar.plugins.html.visitor.HtmlSourceCode;
+
+class AriaRoleAttributeCheckTest {
+
+  private static final String MESSAGE =
+    "Replace \"aria-role\" with \"role\"; \"role\" is the correct WAI-ARIA attribute name.";
+
+  @RegisterExtension
+  public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
+
+  @Test
+  void noncompliant() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/AriaRoleAttributeCheck/noncompliant.html"),
+      new AriaRoleAttributeCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(1).withMessage(MESSAGE)
+      .next().atLine(2).withMessage(MESSAGE)
+      .next().atLine(3).withMessage(MESSAGE)
+      .next().atLine(4).withMessage(MESSAGE)
+      .next().atLine(5).withMessage(MESSAGE)
+      .next().atLine(6).withMessage(MESSAGE)
+      .next().atLine(7).withMessage(MESSAGE)
+      .next().atLine(8).withMessage(MESSAGE)
+      .noMore();
+  }
+
+  @Test
+  void compliant() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/AriaRoleAttributeCheck/compliant.html"),
+      new AriaRoleAttributeCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .noMore();
+  }
+
+  @Test
+  void frameworks() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/AriaRoleAttributeCheck/frameworks.html"),
+      new AriaRoleAttributeCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(1).withMessage(MESSAGE)
+      .next().atLine(2).withMessage(MESSAGE)
+      .next().atLine(3).withMessage(MESSAGE)
+      .next().atLine(4).withMessage(MESSAGE)
+      .noMore();
+  }
+}

--- a/sonar-html-plugin/src/test/resources/checks/AriaRoleAttributeCheck/compliant.html
+++ b/sonar-html-plugin/src/test/resources/checks/AriaRoleAttributeCheck/compliant.html
@@ -1,0 +1,9 @@
+<span role="button">Reset</span>
+<div role="alert">Warning</div>
+<a role="link" href="#">Link</a>
+<span Role="button">Mixed case role</span>
+<span ROLE="button">Upper case role</span>
+<span>No role at all</span>
+<input type="text" aria-label="Name" />
+<span aria-rolex="button">Some other ARIA-prefixed attribute that is not aria-role</span>
+<custom-aria-role-element role="button">Element name contains aria-role but no attribute</custom-aria-role-element>

--- a/sonar-html-plugin/src/test/resources/checks/AriaRoleAttributeCheck/frameworks.html
+++ b/sonar-html-plugin/src/test/resources/checks/AriaRoleAttributeCheck/frameworks.html
@@ -1,0 +1,4 @@
+<span [aria-role]="myRole">Angular binding to wrong attribute</span>
+<span :aria-role="myRole">Vue shorthand binding to wrong attribute</span>
+<span v-bind:aria-role="myRole">Vue full binding to wrong attribute</span>
+<span [attr.aria-role]="myRole">Angular attribute binding to wrong attribute</span>

--- a/sonar-html-plugin/src/test/resources/checks/AriaRoleAttributeCheck/noncompliant.html
+++ b/sonar-html-plugin/src/test/resources/checks/AriaRoleAttributeCheck/noncompliant.html
@@ -1,0 +1,8 @@
+<span aria-role="button">Reset</span>
+<div aria-role="alert">Warning</div>
+<a aria-role="link" href="#">Link</a>
+<span Aria-Role="button">Mixed case</span>
+<span ARIA-ROLE="button">Upper case</span>
+<span aria-role="">Empty value still wrong attribute name</span>
+<span aria-role>Boolean-style aria-role</span>
+<input aria-role="checkbox" />


### PR DESCRIPTION
## Summary
Adds new HTML rule S8720 that flags use of the non-standard `aria-role` attribute. Browsers and assistive technologies do not recognize it, so the intended role is silently ignored — `role` is the correct WAI-ARIA attribute name.
RSPEC PR: https://github.com/SonarSource/rspec/pull/6955

## Changes
- New `AriaRoleAttributeCheck` raising an issue whenever an element carries an `aria-role` attribute (case-insensitive name match, also catches Angular/Vue property-binding variants such as `[aria-role]`, `:aria-role`).
- Generated rule description files (`S8720.html`/`S8720.json`) via `rule-api`; enabled in the Sonar way profile.
- Unit tests covering noncompliant cases (different elements, case variants, empty value, value-less attribute), compliant cases (`role`, unrelated `aria-` attributes), and framework binding variants.

## Functional Validation
Attached: [SONARHTML-289-fv.zip](https://github.com/user-attachments/files/28468678/SONARHTML-289-fv.zip)

Unzip and run:
    ./run.sh

Expected output is in `expected-output.txt`. The README shows the
before/after comparison so you can reproduce the difference directly.
