### PR TITLE
SONARHTML-386 USER-2103 Fix S6840 false positives on input without type and numeric control groups

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/ControlGroup.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/ControlGroup.java
@@ -16,15 +16,27 @@
  */
 package org.sonar.plugins.html.api.accessibility;
 
+import java.util.Locale;
+import java.util.Set;
+import javax.annotation.CheckForNull;
 import org.sonar.plugins.html.node.TagNode;
 
 public class ControlGroup {
+  private static final String INPUT_TAG = "input";
+  // All valid HTML input type values per WHATWG; anything not in this set has an
+  // invalid-value default of the Text state.
+  private static final Set<String> VALID_INPUT_TYPES = Set.of(
+    "hidden", "text", "search", "tel", "url", "email", "password",
+    "date", "month", "week", "time", "datetime-local", "number", "range", "color",
+    "checkbox", "radio", "file", "submit", "image", "reset", "button"
+  );
+
   public static boolean belongsToAutofillExpectationMantleControlGroup(TagNode node) {
-    if (!node.getNodeName().equalsIgnoreCase("input")) {
+    if (!node.getNodeName().equalsIgnoreCase(INPUT_TAG)) {
       return true;
     }
 
-    var type = node.getAttribute("type");
+    var type = resolveType(node);
 
     return type == null || !type.equalsIgnoreCase("hidden");
   }
@@ -34,13 +46,13 @@ public class ControlGroup {
       return true;
     }
 
-    var type = node.getAttribute("type");
+    var type = resolveType(node);
 
     return type != null && type.equalsIgnoreCase("date");
   }
 
   public static boolean belongsToMonthControlGroup(TagNode node) {
-    var type = node.getAttribute("type");
+    var type = resolveType(node);
 
     if (type != null && type.equalsIgnoreCase("month")) {
       return true;
@@ -56,17 +68,17 @@ public class ControlGroup {
       return true;
     }
 
-    if (!nodeName.equalsIgnoreCase("input")) {
+    if (!nodeName.equalsIgnoreCase(INPUT_TAG)) {
       return false;
     }
 
-    var type = node.getAttribute("type");
+    var type = resolveType(node);
 
     return type != null && type.equalsIgnoreCase("hidden");
   }
 
   public static boolean belongsToNumericControlGroup(TagNode node) {
-    var type = node.getAttribute("type");
+    var type = resolveType(node);
 
     if (type != null && type.equalsIgnoreCase("number")) {
       return true;
@@ -76,7 +88,7 @@ public class ControlGroup {
   }
 
   public static boolean belongsToPasswordControlGroup(TagNode node) {
-    var type = node.getAttribute("type");
+    var type = resolveType(node);
 
     if (type != null && type.equalsIgnoreCase("password")) {
       return true;
@@ -86,7 +98,7 @@ public class ControlGroup {
   }
 
   public static boolean belongsToTelControlGroup(TagNode node) {
-    var type = node.getAttribute("type");
+    var type = resolveType(node);
 
     if (type != null && type.equalsIgnoreCase("tel")) {
       return true;
@@ -102,17 +114,28 @@ public class ControlGroup {
       return true;
     }
 
-    var type = node.getAttribute("type");
+    if (!nodeName.equalsIgnoreCase(INPUT_TAG)) {
+      return false;
+    }
+
+    var type = resolveType(node);
 
     if (type == null) {
-      return false;
+      // No type attribute, or a dynamic binding whose value cannot be statically
+      // resolved: treat conservatively as Text to avoid false positives.
+      return true;
+    }
+
+    // WHATWG invalid-value default is also Text state.
+    if (!VALID_INPUT_TYPES.contains(type.toLowerCase(Locale.ROOT))) {
+      return true;
     }
 
     return type.equalsIgnoreCase("hidden") || type.equalsIgnoreCase("text") || type.equalsIgnoreCase("search");
   }
 
   public static boolean belongsToUrlControlGroup(TagNode node) {
-    var type = node.getAttribute("type");
+    var type = resolveType(node);
 
     if (type != null && type.equalsIgnoreCase("url")) {
       return true;
@@ -122,13 +145,57 @@ public class ControlGroup {
   }
 
   public static boolean belongsToUsernameControlGroup(TagNode node) {
-    var type = node.getAttribute("type");
+    var type = resolveType(node);
 
     if (type != null && type.equalsIgnoreCase("email")) {
       return true;
     }
 
     return belongsToTextControlGroup(node);
+  }
+
+  // Returns true when the node has a bound type attribute (e.g. [type], :type) whose
+  // value is a dynamic expression that cannot be statically resolved. String literals
+  // like [type]="'checkbox'" are resolvable and therefore not dynamic.
+  public static boolean hasDynamicTypeBinding(TagNode node) {
+    var typeAttr = node.getProperty("type");
+    if (typeAttr == null || typeAttr.getName().equalsIgnoreCase("type")) {
+      return false;
+    }
+    return !isStaticStringLiteral(typeAttr.getValue());
+  }
+
+  // Returns the resolved type value via getProperty, which covers static attributes
+  // and all Angular/Vue binding forms ([type], :type, v-bind:type).
+  // For bound attributes, JS string literals (e.g. "'checkbox'") are unwrapped to
+  // their inner value; dynamic expressions that cannot be statically resolved return null.
+  @CheckForNull
+  private static String resolveType(TagNode node) {
+    var typeAttr = node.getProperty("type");
+    if (typeAttr == null) {
+      return null;
+    }
+    var value = typeAttr.getValue();
+    // Plain static attribute
+    if (typeAttr.getName().equalsIgnoreCase("type")) {
+      return value;
+    }
+    // Bound attribute: unwrap JS string literal (e.g. "'checkbox'" → "checkbox")
+    if (isStaticStringLiteral(value)) {
+      String inner = value.substring(1, value.length() - 1).trim();
+      return inner.isEmpty() ? null : inner;
+    }
+    // Dynamic expression → unknown
+    return null;
+  }
+
+  private static boolean isStaticStringLiteral(@CheckForNull String value) {
+    if (value == null || value.length() < 2) {
+      return false;
+    }
+    char first = value.charAt(0);
+    char last = value.charAt(value.length() - 1);
+    return (first == '\'' && last == '\'') || (first == '"' && last == '"');
   }
 
   private ControlGroup() {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ValidAutocompleteCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ValidAutocompleteCheck.java
@@ -299,16 +299,16 @@ public class ValidAutocompleteCheck extends AbstractPageCheck {
       new Token("cc-number", ControlGroup::belongsToTextControlGroup),
       new Token("cc-exp", ControlGroup::belongsToMonthControlGroup),
       new Token("cc-exp-month", ControlGroup::belongsToNumericControlGroup),
-      new Token("cc-exp-year", ControlGroup::belongsToMultilineControlGroup),
+      new Token("cc-exp-year", ControlGroup::belongsToNumericControlGroup),
       new Token("cc-csc", ControlGroup::belongsToTextControlGroup),
       new Token("cc-type", ControlGroup::belongsToTextControlGroup),
       new Token("transaction-currency", ControlGroup::belongsToTextControlGroup),
-      new Token("transaction-amount", ControlGroup::belongsToMultilineControlGroup),
+      new Token("transaction-amount", ControlGroup::belongsToNumericControlGroup),
       new Token("language", ControlGroup::belongsToTextControlGroup),
       new Token("bday", ControlGroup::belongsToDateControlGroup),
-      new Token("bday-day", ControlGroup::belongsToMultilineControlGroup),
-      new Token("bday-month", ControlGroup::belongsToMultilineControlGroup),
-      new Token("bday-year", ControlGroup::belongsToMultilineControlGroup),
+      new Token("bday-day", ControlGroup::belongsToNumericControlGroup),
+      new Token("bday-month", ControlGroup::belongsToNumericControlGroup),
+      new Token("bday-year", ControlGroup::belongsToNumericControlGroup),
       new Token("sex", ControlGroup::belongsToTextControlGroup),
       new Token("url", ControlGroup::belongsToUrlControlGroup),
       new Token("photo", ControlGroup::belongsToUrlControlGroup)
@@ -324,6 +324,10 @@ public class ValidAutocompleteCheck extends AbstractPageCheck {
   @Override
   public void startElement(TagNode node) {
     if (isCustomComponent(node)) {
+      return;
+    }
+
+    if (ControlGroup.hasDynamicTypeBinding(node)) {
       return;
     }
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ValidAutocompleteCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ValidAutocompleteCheckTest.java
@@ -33,15 +33,53 @@ class ValidAutocompleteCheckTest {
 
   @ParameterizedTest
   @ValueSource(strings = {
+    "bday-day",
+    "bday-month",
+    "bday-year",
     "cc-exp",
     "cc-exp-month",
+    "cc-exp-year",
+    "current-password",
     "new-password",
-    "street-address",
+    "one-time-code",
+    "transaction-amount",
     "url",
     "username"
   })
   void html(String file) {
     HtmlSourceCode sourceCode = TestHelper.scan(new File(String.format("src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/%s.html", file)), new ValidAutocompleteCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(1).withMessage("DOM elements should use the \"autocomplete\" attribute correctly.")
+      .next().atLine(3)
+      .noMore();
+  }
+
+  @Test
+  void boundType() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/bound-type.html"),
+      new ValidAutocompleteCheck());
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(2).withMessage("DOM elements should use the \"autocomplete\" attribute correctly.")
+      .next().atLine(3)
+      .next().atLine(4)
+      .noMore();
+  }
+
+  @Test
+  void invalidType() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/invalid-type.html"),
+      new ValidAutocompleteCheck());
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(3).withMessage("DOM elements should use the \"autocomplete\" attribute correctly.")
+      .noMore();
+  }
+
+  @Test
+  void streetAddress() {
+    HtmlSourceCode sourceCode = TestHelper.scan(new File("src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/street-address.html"), new ValidAutocompleteCheck());
 
     checkMessagesVerifier.verify(sourceCode.getIssues())
       .next().atLine(1).withMessage("DOM elements should use the \"autocomplete\" attribute correctly.")
@@ -56,7 +94,6 @@ class ValidAutocompleteCheckTest {
 
     checkMessagesVerifier.verify(htmlSourceCode.getIssues())
       .next().atLine(1).withMessage("DOM elements should use the \"autocomplete\" attribute correctly.")
-      .next().atLine(2)
       .next().atLine(3);
 
     HtmlSourceCode jspSourceCode = TestHelper.scan(new File("src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/bday/file.jsp"), check);
@@ -71,7 +108,6 @@ class ValidAutocompleteCheckTest {
 
     checkMessagesVerifier.verify(vueSourceCode.getIssues())
       .next().atLine(2).withMessage("DOM elements should use the \"autocomplete\" attribute correctly.")
-      .next().atLine(3)
       .next().atLine(4);
   }
 
@@ -89,7 +125,6 @@ class ValidAutocompleteCheckTest {
 
     checkMessagesVerifier.verify(sourceCode.getIssues())
       .next().atLine(1).withMessage("DOM elements should use the \"autocomplete\" attribute correctly.")
-      .next().atLine(2)
       .next().atLine(3)
       .next().atLine(4);
   }

--- a/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/bday-day.html
+++ b/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/bday-day.html
@@ -1,0 +1,9 @@
+<div autocomplete="bday-day"></div> <!-- Noncompliant -->
+<input autocomplete="bday-day"/>
+<input type="url" autocomplete="bday-day"/> <!-- Noncompliant -->
+<input type="number" autocomplete="bday-day"/>
+<input type="text" autocomplete="bday-day"/>
+<select autocomplete="bday-day"></select>
+<textarea autocomplete="bday-day"></textarea>
+<input type="hidden" autocomplete="bday-day"/>
+<INPUT TYPE="NUMBER" AUTOCOMPLETE="BDAY-DAY"/>

--- a/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/bday-month.html
+++ b/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/bday-month.html
@@ -1,0 +1,9 @@
+<div autocomplete="bday-month"></div> <!-- Noncompliant -->
+<input autocomplete="bday-month"/>
+<input type="url" autocomplete="bday-month"/> <!-- Noncompliant -->
+<input type="number" autocomplete="bday-month"/>
+<input type="text" autocomplete="bday-month"/>
+<select autocomplete="bday-month"></select>
+<textarea autocomplete="bday-month"></textarea>
+<input type="hidden" autocomplete="bday-month"/>
+<INPUT TYPE="NUMBER" AUTOCOMPLETE="BDAY-MONTH"/>

--- a/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/bday-year.html
+++ b/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/bday-year.html
@@ -1,0 +1,9 @@
+<div autocomplete="bday-year"></div> <!-- Noncompliant -->
+<input autocomplete="bday-year"/>
+<input type="url" autocomplete="bday-year"/> <!-- Noncompliant -->
+<input type="number" autocomplete="bday-year"/>
+<input type="text" autocomplete="bday-year"/>
+<select autocomplete="bday-year"></select>
+<textarea autocomplete="bday-year"></textarea>
+<input type="hidden" autocomplete="bday-year"/>
+<INPUT TYPE="NUMBER" AUTOCOMPLETE="BDAY-YEAR"/>

--- a/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/bday/file.html
+++ b/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/bday/file.html
@@ -1,5 +1,5 @@
 <div autocomplete="bday"></div> <!-- Noncompliant -->
-<input autocomplete="bday"/> <!-- Noncompliant -->
+<input autocomplete="bday"/>
 <input type="url" autocomplete="bday"/> <!-- Noncompliant -->
 <input type="date" autocomplete="bday"/>
 <input type="text" autocomplete="bday"/>

--- a/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/bday/file.vue
+++ b/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/bday/file.vue
@@ -1,6 +1,6 @@
 <template>
   <div autocomplete="bday"></div> <!-- Noncompliant -->
-  <input autocomplete="bday"/> <!-- Noncompliant -->
+  <input autocomplete="bday"/>
   <input type="url" autocomplete="bday"/> <!-- Noncompliant -->
   <input type="date" autocomplete="bday"/>
   <input type="text" autocomplete="bday"/>

--- a/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/bound-type.html
+++ b/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/bound-type.html
@@ -1,0 +1,24 @@
+<!-- Bound to non-text type: Noncompliant -->
+<input [type]="'checkbox'" autocomplete="organization"/> <!-- Noncompliant -->
+<input :type="'radio'" autocomplete="organization"/> <!-- Noncompliant -->
+<input v-bind:type="'file'" autocomplete="organization"/> <!-- Noncompliant -->
+
+<!-- Bound to text type: Compliant -->
+<input [type]="'text'" autocomplete="organization"/>
+<input [type]="'search'" autocomplete="organization"/>
+<input [type]="'hidden'" autocomplete="organization"/>
+
+<!-- Bound to invalid type: fallback to Text → Compliant -->
+<input [type]="'foobar'" autocomplete="organization"/>
+
+<!-- No type attribute: Compliant (missing-value default = Text state) -->
+<input autocomplete="organization"/>
+
+<!-- Dynamic (unresolvable) binding: Compliant (rule skipped, type unknown) -->
+<input [type]="dynamicType" autocomplete="organization"/>
+<input :type="computedType" autocomplete="organization"/>
+<input [type]="dynamicType" autocomplete="street-address"/>
+
+<!-- Bound to correct type for group: Compliant -->
+<input [type]="'password'" autocomplete="new-password"/>
+<input [type]="'number'" autocomplete="cc-exp-year"/>

--- a/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/cc-exp-month.html
+++ b/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/cc-exp-month.html
@@ -1,5 +1,5 @@
 <div autocomplete="cc-exp-month"></div> <!-- Noncompliant -->
-<input autocomplete="cc-exp-month"/> <!-- Noncompliant -->
+<input autocomplete="cc-exp-month"/>
 <input type="url" autocomplete="cc-exp-month"/> <!-- Noncompliant -->
 <input type="number" autocomplete="cc-exp-month"/>
 <input type="text" autocomplete="cc-exp-month"/>

--- a/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/cc-exp-year.html
+++ b/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/cc-exp-year.html
@@ -1,0 +1,9 @@
+<div autocomplete="cc-exp-year"></div> <!-- Noncompliant -->
+<input autocomplete="cc-exp-year"/>
+<input type="url" autocomplete="cc-exp-year"/> <!-- Noncompliant -->
+<input type="number" autocomplete="cc-exp-year"/>
+<input type="text" autocomplete="cc-exp-year"/>
+<select autocomplete="cc-exp-year"></select>
+<textarea autocomplete="cc-exp-year"></textarea>
+<input type="hidden" autocomplete="cc-exp-year"/>
+<INPUT TYPE="NUMBER" AUTOCOMPLETE="CC-EXP-YEAR"/>

--- a/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/cc-exp.html
+++ b/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/cc-exp.html
@@ -1,5 +1,5 @@
 <div autocomplete="cc-exp"></div> <!-- Noncompliant -->
-<input autocomplete="cc-exp"/> <!-- Noncompliant -->
+<input autocomplete="cc-exp"/>
 <input type="url" autocomplete="cc-exp"/> <!-- Noncompliant -->
 <input type="month" autocomplete="cc-exp"/>
 <input type="text" autocomplete="cc-exp"/>

--- a/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/current-password.html
+++ b/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/current-password.html
@@ -1,0 +1,10 @@
+<input type="email" autocomplete="current-password"/> <!-- Noncompliant -->
+<input autocomplete="current-password"/>
+<div autocomplete="current-password"></div>  <!-- Noncompliant -->
+<input type="text" autocomplete="current-password"/>
+<input type="search" autocomplete="current-password"/>
+<input type="hidden" autocomplete="current-password"/>
+<input type="password" autocomplete="current-password"/>
+<textarea autocomplete="current-password"></textarea>
+<select autocomplete="current-password"></select>
+<INPUT TYPE="PASSWORD" AUTOCOMPLETE="CURRENT-PASSWORD"/>

--- a/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/invalid-type.html
+++ b/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/invalid-type.html
@@ -1,0 +1,3 @@
+<input type="foobar" autocomplete="organization"/>
+<input type="FOOBAR" autocomplete="organization"/>
+<input type="checkbox" autocomplete="organization"/> <!-- Noncompliant -->

--- a/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/new-password.html
+++ b/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/new-password.html
@@ -1,5 +1,5 @@
 <input type="email" autocomplete="new-password"/> <!-- Noncompliant -->
-<input autocomplete="new-password"/> <!-- Noncompliant -->
+<input autocomplete="new-password"/>
 <div autocomplete="new-password"></div>  <!-- Noncompliant -->
 <input type="text" autocomplete="new-password"/>
 <input type="search" autocomplete="new-password"/>

--- a/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/one-time-code.html
+++ b/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/one-time-code.html
@@ -1,0 +1,10 @@
+<input type="email" autocomplete="one-time-code"/> <!-- Noncompliant -->
+<input autocomplete="one-time-code"/>
+<div autocomplete="one-time-code"></div>  <!-- Noncompliant -->
+<input type="text" autocomplete="one-time-code"/>
+<input type="search" autocomplete="one-time-code"/>
+<input type="hidden" autocomplete="one-time-code"/>
+<input type="password" autocomplete="one-time-code"/>
+<textarea autocomplete="one-time-code"></textarea>
+<select autocomplete="one-time-code"></select>
+<INPUT TYPE="PASSWORD" AUTOCOMPLETE="ONE-TIME-CODE"/>

--- a/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/tel.html
+++ b/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/tel.html
@@ -1,5 +1,5 @@
 <div autocomplete="tel"></div> <!-- Noncompliant -->
-<input autocomplete="tel"/> <!-- Noncompliant -->
+<input autocomplete="tel"/>
 <input type="url" autocomplete="tel"/> <!-- Noncompliant -->
 <input type="tel" autocomplete="foo tel"/>
 <input type="tel" autocomplete="tel"/>

--- a/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/transaction-amount.html
+++ b/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/transaction-amount.html
@@ -1,0 +1,9 @@
+<div autocomplete="transaction-amount"></div> <!-- Noncompliant -->
+<input autocomplete="transaction-amount"/>
+<input type="url" autocomplete="transaction-amount"/> <!-- Noncompliant -->
+<input type="number" autocomplete="transaction-amount"/>
+<input type="text" autocomplete="transaction-amount"/>
+<select autocomplete="transaction-amount"></select>
+<textarea autocomplete="transaction-amount"></textarea>
+<input type="hidden" autocomplete="transaction-amount"/>
+<INPUT TYPE="NUMBER" AUTOCOMPLETE="TRANSACTION-AMOUNT"/>

--- a/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/url.html
+++ b/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/url.html
@@ -1,5 +1,5 @@
 <div autocomplete="url"></div> <!-- Noncompliant -->
-<input autocomplete="url"/> <!-- Noncompliant -->
+<input autocomplete="url"/>
 <input type="number" autocomplete="url"/> <!-- Noncompliant -->
 <input type="text" autocomplete="url"/>
 <input type="url" autocomplete="url"/>

--- a/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/username.html
+++ b/sonar-html-plugin/src/test/resources/checks/DomElementsShouldUseAutocompleteAttributeCorrectlyCheck/username.html
@@ -1,5 +1,5 @@
 <div autocomplete="username"></div> <!-- Noncompliant -->
-<input autocomplete="username"/> <!-- Noncompliant -->
+<input autocomplete="username"/>
 <input type="url" autocomplete="username"/> <!-- Noncompliant -->
 <input type="email" autocomplete="username"/>
 <input type="text" autocomplete="username"/>


### PR DESCRIPTION
## Summary
Rule S6840 raised false positives on `<input>` elements without an explicit `type` attribute (including those using Razor's `asp-for` tag helper), and on `<input type="number">` for five autocomplete values that were incorrectly mapped to the Multiline control group instead of Numeric.

## Changes
- `ControlGroup.belongsToTextControlGroup`: treat `<input>` with no `type` as Text state (HTML spec default), so it belongs to the text control group
- `ValidAutocompleteCheck`: correct control group for `cc-exp-year`, `transaction-amount`, `bday-day`, `bday-month`, `bday-year` from Multiline to Numeric per WHATWG HTML spec
- Update existing test files to remove false-noncompliant annotations on type-less inputs; split parameterised test to reflect that `street-address` (Multiline) behaves differently; add five new test files for the corrected field names

## Functional Validation
Attached: [USER-2103-fv.zip](https://github.com/user-attachments/files/28549698/USER-2103-fv.zip)

Unzip and run:
    ./run.sh

Expected output is in `expected-output.txt`. The README shows the before/after comparison so you can reproduce the difference directly.
