### PR TITLE
SONARHTML-264 Add rule S8732: legend must be direct child of fieldset

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
@@ -138,7 +138,15 @@ public class Helpers {
     return hasAncestorMatching(node, Helpers::isTemplateLikeTag);
   }
 
-  private static boolean isTemplateLikeTag(TagNode node) {
+  /**
+   * Returns true if {@code node} is a template-like wrapper: HTML {@code <template>},
+   * Angular {@code <ng-template>}, or an ASP.NET WebForms server control ({@code asp:*}).
+   * These elements do not contribute to the rendered DOM and can be treated as transparent.
+   *
+   * @param node the tag node to test
+   * @return true if the node is a template-like wrapper
+   */
+  public static boolean isTemplateLikeTag(TagNode node) {
     String name = node.getNodeName();
     if (name == null || name.isEmpty()) {
       return false;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/RazorSectionScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/RazorSectionScopeTracker.java
@@ -1,0 +1,129 @@
+/*
+ * SonarQube HTML
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.html.api;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.sonar.plugins.html.node.Node;
+import org.sonar.plugins.html.node.TagNode;
+import org.sonar.plugins.html.node.TextNode;
+import org.sonar.plugins.html.visitor.HtmlSourceCode;
+
+/**
+ * Tracks top-level Razor {@code @section ... { ... }} scopes so checks can suppress
+ * false positives on markup whose rendered container lives outside the current file fragment.
+ */
+public final class RazorSectionScopeTracker {
+
+  private static final Pattern RAZOR_SECTION_OPEN = Pattern.compile("@section\\s+\\w+\\s*\\{");
+  private static final RazorSectionScopeTracker EMPTY = new RazorSectionScopeTracker(List.of());
+
+  private final List<int[]> sectionRanges;
+
+  private RazorSectionScopeTracker(List<int[]> sectionRanges) {
+    this.sectionRanges = sectionRanges;
+  }
+
+  public static RazorSectionScopeTracker empty() {
+    return EMPTY;
+  }
+
+  public static RazorSectionScopeTracker create(List<Node> nodes, HtmlSourceCode code) {
+    if (!Helpers.isRazorFile(code)) {
+      return EMPTY;
+    }
+    List<int[]> sectionRanges = new ArrayList<>();
+    ScanState state = new ScanState();
+    for (Node node : nodes) {
+      if (node instanceof TextNode textNode) {
+        scanForSections(textNode, state, sectionRanges);
+      }
+    }
+    return sectionRanges.isEmpty() ? EMPTY : new RazorSectionScopeTracker(sectionRanges);
+  }
+
+  public boolean contains(TagNode node) {
+    int line = node.getStartLinePosition();
+    for (int[] range : sectionRanges) {
+      if (line >= range[0] && line <= range[1]) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static void scanForSections(TextNode textNode, ScanState state, List<int[]> sectionRanges) {
+    // TextNodes inside an HTML element are body content. Any { or } there is
+    // literal text (e.g. `<p>}</p>`) and must not affect Razor section depth.
+    if (textNode.getParent() != null) {
+      return;
+    }
+    String code = textNode.getCode();
+    int baseLine = textNode.getStartLinePosition();
+    int pos = 0;
+    while (pos < code.length()) {
+      pos = (state.depth == 0)
+        ? enterSectionIfFound(code, pos, baseLine, state)
+        : advanceBraceDepth(code, pos, baseLine, state, sectionRanges);
+      if (pos < 0) {
+        return;
+      }
+    }
+  }
+
+  private static int enterSectionIfFound(String code, int pos, int baseLine, ScanState state) {
+    Matcher matcher = RAZOR_SECTION_OPEN.matcher(code);
+    if (!matcher.find(pos)) {
+      return -1;
+    }
+    state.sectionStartLine = baseLine + countNewlines(code, 0, matcher.start());
+    state.depth = 1;
+    return matcher.end();
+  }
+
+  private static int advanceBraceDepth(String code, int pos, int baseLine, ScanState state, List<int[]> sectionRanges) {
+    char c = code.charAt(pos);
+    if (c == '{') {
+      state.depth++;
+    } else if (c == '}') {
+      state.depth--;
+      if (state.depth == 0) {
+        sectionRanges.add(new int[] {state.sectionStartLine, baseLine + countNewlines(code, 0, pos)});
+        state.sectionStartLine = -1;
+      }
+    }
+    return pos + 1;
+  }
+
+  private static int countNewlines(String s, int from, int to) {
+    int n = 0;
+    int limit = Math.min(to, s.length());
+    for (int i = from; i < limit; i++) {
+      if (s.charAt(i) == '\n') {
+        n++;
+      }
+    }
+    return n;
+  }
+
+  private static final class ScanState {
+    int depth;
+    int sectionStartLine = -1;
+  }
+}

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/MisplacedLegendCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/MisplacedLegendCheck.java
@@ -1,0 +1,76 @@
+/*
+ * SonarQube HTML
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.html.checks.accessibility;
+
+import static org.sonar.plugins.html.api.HtmlConstants.hasKnownHTMLTag;
+
+import java.util.List;
+import org.sonar.check.Rule;
+import org.sonar.plugins.html.api.Helpers;
+import org.sonar.plugins.html.api.RazorSectionScopeTracker;
+import org.sonar.plugins.html.checks.AbstractPageCheck;
+import org.sonar.plugins.html.node.Node;
+import org.sonar.plugins.html.node.TagNode;
+
+@Rule(key = "S8732")
+public class MisplacedLegendCheck extends AbstractPageCheck {
+
+  private static final String MESSAGE = "Move this <legend> element to be a direct child of a <fieldset> or <optgroup> element.";
+  private RazorSectionScopeTracker razorSectionScope = RazorSectionScopeTracker.empty();
+
+  @Override
+  public void startDocument(List<Node> nodes) {
+    razorSectionScope = RazorSectionScopeTracker.create(nodes, getHtmlSourceCode());
+  }
+
+  @Override
+  public void startElement(TagNode node) {
+    // Filter legend elements
+    if (!isLegend(node)) {
+      return;
+    }
+    TagNode parent = node.getParent();
+    // Orphan legend: no parent at all, unless the surrounding <fieldset> is provided by a Razor section host.
+    if (parent == null) {
+      if (razorSectionScope.contains(node)) {
+        return;
+      }
+      createViolation(node, MESSAGE);
+      return;
+    }
+    // Template-like direct parent (<template>, <ng-template>, asp:*): rendered structure is
+    // unknowable (Vue/Angular slots, ASP.NET server-rendered HTML), skip
+    if (Helpers.isTemplateLikeTag(parent)) {
+      return;
+    }
+    // Allowed parent: compliant
+    String parentName = parent.getNodeName();
+    if ("FIELDSET".equalsIgnoreCase(parentName) || "OPTGROUP".equalsIgnoreCase(parentName)) {
+      return;
+    }
+    // Framework/custom element: skip to avoid false positives on framework-rendered markup
+    if (!hasKnownHTMLTag(parent)) {
+      return;
+    }
+    createViolation(node, MESSAGE);
+  }
+
+  private static boolean isLegend(TagNode node) {
+    return "LEGEND".equalsIgnoreCase(node.getNodeName());
+  }
+
+}

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheck.java
@@ -16,90 +16,27 @@
  */
 package org.sonar.plugins.html.checks.sonar;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.api.Helpers;
+import org.sonar.plugins.html.api.RazorSectionScopeTracker;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
 import org.sonar.plugins.html.node.Node;
 import org.sonar.plugins.html.node.TagNode;
-import org.sonar.plugins.html.node.TextNode;
 
 @Rule(key = "ItemTagNotWithinContainerTagCheck")
 public class ItemTagNotWithinContainerTagCheck extends AbstractPageCheck {
 
-  private static final Pattern RAZOR_SECTION_OPEN = Pattern.compile("@section\\s+\\w+\\s*\\{");
-
-  private final List<int[]> razorSectionRanges = new ArrayList<>();
+  private RazorSectionScopeTracker razorSectionScope = RazorSectionScopeTracker.empty();
 
   @Override
   public void startDocument(List<Node> nodes) {
-    razorSectionRanges.clear();
-    if (!isRazorFile()) {
-      return;
-    }
-    ScanState state = new ScanState();
-    for (Node node : nodes) {
-      if (node instanceof TextNode textNode) {
-        scanForSections(textNode, state);
-      }
-    }
-  }
-
-  private void scanForSections(TextNode textNode, ScanState state) {
-    // TextNodes inside an HTML element are body content. Any { or } there is
-    // literal text (e.g. `<p>}</p>`) and must not affect Razor section depth.
-    if (textNode.getParent() != null) {
-      return;
-    }
-    String code = textNode.getCode();
-    int baseLine = textNode.getStartLinePosition();
-    int pos = 0;
-    while (pos < code.length()) {
-      pos = (state.depth == 0)
-        ? enterSectionIfFound(code, pos, baseLine, state)
-        : advanceBraceDepth(code, pos, baseLine, state);
-      if (pos < 0) {
-        return;
-      }
-    }
-  }
-
-  private static int enterSectionIfFound(String code, int pos, int baseLine, ScanState state) {
-    Matcher m = RAZOR_SECTION_OPEN.matcher(code);
-    if (!m.find(pos)) {
-      return -1;
-    }
-    state.sectionStartLine = baseLine + countNewlines(code, 0, m.start());
-    state.depth = 1;
-    return m.end();
-  }
-
-  private int advanceBraceDepth(String code, int pos, int baseLine, ScanState state) {
-    char c = code.charAt(pos);
-    if (c == '{') {
-      state.depth++;
-    } else if (c == '}') {
-      state.depth--;
-      if (state.depth == 0) {
-        razorSectionRanges.add(new int[] { state.sectionStartLine, baseLine + countNewlines(code, 0, pos) });
-        state.sectionStartLine = -1;
-      }
-    }
-    return pos + 1;
-  }
-
-  private static final class ScanState {
-    int depth;
-    int sectionStartLine = -1;
+    razorSectionScope = RazorSectionScopeTracker.create(nodes, getHtmlSourceCode());
   }
 
   @Override
   public void startElement(TagNode node) {
-    if (Helpers.hasTemplateAncestor(node) || isInsideRazorSection(node)) {
+    if (Helpers.hasTemplateAncestor(node) || razorSectionScope.contains(node)) {
       return;
     }
     if (isLi(node) && !hasLiOrUlOrOlAncestor(node)) {
@@ -107,38 +44,6 @@ public class ItemTagNotWithinContainerTagCheck extends AbstractPageCheck {
     } else if (isDt(node) && !hasDtOrDlAncestor(node)) {
       createViolation(node, "Surround this <" + node.getNodeName() + "> item tag by a <dl> container one.");
     }
-  }
-
-  /**
-   * Returns true if {@code node} sits inside a Razor {@code @section ... { ... }} block.
-   *
-   * @param node the tag node whose location is inspected
-   * @return true if any pre-computed section range contains the node's start line
-   */
-  private boolean isInsideRazorSection(TagNode node) {
-    int line = node.getStartLinePosition();
-    for (int[] range : razorSectionRanges) {
-      if (line >= range[0] && line <= range[1]) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private boolean isRazorFile() {
-    String filename = getHtmlSourceCode().inputFile().filename();
-    return filename.endsWith(".cshtml") || filename.endsWith(".vbhtml");
-  }
-
-  private static int countNewlines(String s, int from, int to) {
-    int n = 0;
-    int limit = Math.min(to, s.length());
-    for (int i = from; i < limit; i++) {
-      if (s.charAt(i) == '\n') {
-        n++;
-      }
-    }
-    return n;
   }
 
   private static boolean hasLiOrUlOrOlAncestor(TagNode node) {

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S8732.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S8732.html
@@ -1,0 +1,42 @@
+<h2>Why is this an issue?</h2>
+<p>The HTML specification requires the <code>&lt;legend&gt;</code> element to be a <strong>direct child</strong> of a <code>&lt;fieldset&gt;</code> or
+<code>&lt;optgroup&gt;</code> element. Wrapping <code>&lt;legend&gt;</code> inside an intermediate container such as <code>&lt;div&gt;</code> or
+<code>&lt;span&gt;</code> violates this requirement.</p>
+<p>Screen readers and assistive technologies rely on this structure to associate the <code>&lt;legend&gt;</code> caption with the form controls
+grouped by the <code>&lt;fieldset&gt;</code>. When <code>&lt;legend&gt;</code> is wrapped in another element, most assistive technologies cannot read
+the legend to users, making the form group inaccessible.</p>
+<h2>How to fix it</h2>
+<p>Move the <code>&lt;legend&gt;</code> element so that it is a direct child of its enclosing <code>&lt;fieldset&gt;</code> or
+<code>&lt;optgroup&gt;</code> element.</p>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+&lt;fieldset&gt;
+  &lt;div&gt;
+    &lt;legend&gt;Personal information&lt;/legend&gt; &lt;!-- Noncompliant: legend is wrapped in a div --&gt;
+  &lt;/div&gt;
+  &lt;label for="name"&gt;Name:&lt;/label&gt;
+  &lt;input id="name" type="text" /&gt;
+&lt;/fieldset&gt;
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+&lt;fieldset&gt;
+  &lt;legend&gt;Personal information&lt;/legend&gt;
+  &lt;label for="name"&gt;Name:&lt;/label&gt;
+  &lt;input id="name" type="text" /&gt;
+&lt;/fieldset&gt;
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li>MDN - <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/legend"><code>&lt;legend&gt;</code>: The Field Set Legend
+  element</a></li>
+  <li>W3C WAI - <a href="https://www.w3.org/WAI/tutorials/forms/grouping/">Grouping Controls</a></li>
+</ul>
+<h3>Standards</h3>
+<ul>
+  <li>W3C - <a href="https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships">WCAG 2.2 - 1.3.1 Info and Relationships</a></li>
+  <li>W3C - <a href="https://www.w3.org/WAI/WCAG22/Understanding/name-role-value">WCAG 2.2 - 4.1.2 Name, Role, Value</a></li>
+</ul>
+

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S8732.json
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S8732.json
@@ -1,0 +1,24 @@
+{
+  "title": "\"\u003clegend\u003e\" tags should be direct children of \"\u003cfieldset\u003e\" or \"\u003coptgroup\u003e\" elements",
+  "type": "BUG",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5min"
+  },
+  "tags": [
+    "accessibility",
+    "wcag2-a"
+  ],
+  "defaultSeverity": "Major",
+  "ruleSpecification": "RSPEC-8732",
+  "sqKey": "S8732",
+  "scope": "All",
+  "quickfix": "unknown",
+  "code": {
+    "impacts": {
+      "RELIABILITY": "MEDIUM"
+    },
+    "attribute": "LOGICAL"
+  }
+}

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/Sonar_way_profile.json
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/Sonar_way_profile.json
@@ -59,6 +59,7 @@
     "S7930",
     "S8697",
     "S8720",
+    "S8732",
     "TableHeaderHasIdOrScopeCheck",
     "UnsupportedTagsInHtml5Check"
   ]

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/RazorSectionScopeTrackerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/RazorSectionScopeTrackerTest.java
@@ -1,0 +1,110 @@
+/*
+ * SonarQube HTML
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.html.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
+import org.sonar.plugins.html.lex.PageLexer;
+import org.sonar.plugins.html.node.Node;
+import org.sonar.plugins.html.node.TagNode;
+import org.sonar.plugins.html.visitor.HtmlSourceCode;
+
+class RazorSectionScopeTrackerTest {
+
+  @Test
+  void tracks_tags_inside_razor_sections() {
+    ParsedDocument document = parse("file.cshtml", """
+      @section LegendSection {
+        <legend>In section</legend>
+      }
+
+      <legend>At root</legend>
+
+      @section TermsSection {
+        <li>Also in section</li>
+      }
+      """);
+
+    RazorSectionScopeTracker tracker = RazorSectionScopeTracker.create(document.nodes(), document.sourceCode());
+
+    assertThat(tracker.contains(findTag(document.nodes(), "legend", 2))).isTrue();
+    assertThat(tracker.contains(findTag(document.nodes(), "legend", 5))).isFalse();
+    assertThat(tracker.contains(findTag(document.nodes(), "li", 8))).isTrue();
+  }
+
+  @Test
+  void ignores_literal_braces_inside_html_body_when_tracking_sections() {
+    ParsedDocument document = parse("file.cshtml", """
+      @section LegendSection {
+        <p>literal close: }</p>
+        <legend>Still in section</legend>
+      }
+
+      <legend>Outside section</legend>
+      """);
+
+    RazorSectionScopeTracker tracker = RazorSectionScopeTracker.create(document.nodes(), document.sourceCode());
+
+    assertThat(tracker.contains(findTag(document.nodes(), "legend", 3))).isTrue();
+    assertThat(tracker.contains(findTag(document.nodes(), "legend", 6))).isFalse();
+  }
+
+  @Test
+  void returns_empty_tracker_for_non_razor_files() {
+    ParsedDocument document = parse("file.html", """
+      @section LegendSection {
+        <legend>Not Razor</legend>
+      }
+      """);
+
+    RazorSectionScopeTracker tracker = RazorSectionScopeTracker.create(document.nodes(), document.sourceCode());
+
+    assertThat(tracker.contains(findTag(document.nodes(), "legend", 2))).isFalse();
+  }
+
+  private static ParsedDocument parse(String filename, String content) {
+    List<Node> nodes = new PageLexer().parse(new StringReader(content));
+    HtmlSourceCode sourceCode = new HtmlSourceCode(
+      new TestInputFileBuilder("key", filename)
+        .setLanguage(HtmlConstants.LANGUAGE_KEY)
+        .setType(InputFile.Type.MAIN)
+        .setCharset(StandardCharsets.UTF_8)
+        .build()
+    );
+    return new ParsedDocument(nodes, sourceCode);
+  }
+
+  private static TagNode findTag(List<Node> nodes, String tagName, int startLine) {
+    return nodes.stream()
+      .filter(TagNode.class::isInstance)
+      .map(TagNode.class::cast)
+      .filter(tag -> !tag.isEndElement())
+      .filter(tag -> tagName.equalsIgnoreCase(tag.getNodeName()))
+      .filter(tag -> tag.getStartLinePosition() == startLine)
+      .findFirst()
+      .orElseThrow(() -> new IllegalArgumentException("No <" + tagName + "> tag at line " + startLine));
+  }
+
+  private record ParsedDocument(List<Node> nodes, HtmlSourceCode sourceCode) {
+  }
+}

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/MisplacedLegendCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/MisplacedLegendCheckTest.java
@@ -1,0 +1,69 @@
+/*
+ * SonarQube HTML
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.html.checks.accessibility;
+
+import java.io.File;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.sonar.plugins.html.checks.CheckMessagesVerifierRule;
+import org.sonar.plugins.html.checks.TestHelper;
+import org.sonar.plugins.html.visitor.HtmlSourceCode;
+
+class MisplacedLegendCheckTest {
+  @RegisterExtension
+  public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
+
+  private static final String MESSAGE = "Move this <legend> element to be a direct child of a <fieldset> or <optgroup> element.";
+
+  @Test
+  void html() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/MisplacedLegendCheck/test.html"),
+      new MisplacedLegendCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(15).withMessage(MESSAGE)
+      .next().atLine(22)
+      .next().atLine(30)
+      .next().atLine(37)
+      .next().atLine(41)
+      .noMore();
+  }
+
+  @Test
+  void vue() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/MisplacedLegendCheck/test.vue"),
+      new MisplacedLegendCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(18).withMessage(MESSAGE)
+      .noMore();
+  }
+
+  @Test
+  void razorSection() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/MisplacedLegendCheck/test.cshtml"),
+      new MisplacedLegendCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(5).withMessage(MESSAGE)
+      .next().atLine(8).withMessage(MESSAGE)
+      .noMore();
+  }
+}

--- a/sonar-html-plugin/src/test/resources/checks/MisplacedLegendCheck/test.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/MisplacedLegendCheck/test.cshtml
@@ -1,0 +1,9 @@
+@section LegendSection {
+  <legend>Group title</legend>
+}
+
+<legend>Orphan legend</legend> <!-- Noncompliant -->
+
+<div>
+  <legend>Wrapped legend</legend> <!-- Noncompliant -->
+</div>

--- a/sonar-html-plugin/src/test/resources/checks/MisplacedLegendCheck/test.html
+++ b/sonar-html-plugin/src/test/resources/checks/MisplacedLegendCheck/test.html
@@ -1,0 +1,92 @@
+<!-- Compliant: legend is a direct child of fieldset -->
+<fieldset>
+  <legend>Group title</legend>
+  <input type="text" />
+</fieldset>
+
+<!-- Compliant: uppercase tags (case-insensitivity) -->
+<FIELDSET>
+  <LEGEND>Group title</LEGEND>
+</FIELDSET>
+
+<!-- Noncompliant: legend wrapped in div inside fieldset -->
+<fieldset>
+  <div>
+    <legend>Group title</legend> <!-- Noncompliant -->
+  </div>
+</fieldset>
+
+<!-- Noncompliant: legend wrapped in span inside fieldset -->
+<fieldset>
+  <span>
+    <legend>Group title</legend> <!-- Noncompliant -->
+  </span>
+</fieldset>
+
+<!-- Noncompliant: legend wrapped in two levels of divs -->
+<fieldset>
+  <div>
+    <div>
+      <legend>Group title</legend> <!-- Noncompliant -->
+    </div>
+  </div>
+</fieldset>
+
+<!-- Noncompliant: legend outside fieldset entirely -->
+<div>
+  <legend>Group title</legend> <!-- Noncompliant -->
+</div>
+
+<!-- Noncompliant: legend at document root with no parent -->
+<legend>Orphan legend</legend> <!-- Noncompliant -->
+
+<!-- Compliant: multiple fieldsets, each with a direct legend -->
+<fieldset>
+  <legend>Section A</legend>
+</fieldset>
+<fieldset>
+  <legend>Section B</legend>
+</fieldset>
+
+<!-- Compliant: legend as non-first direct child of fieldset -->
+<fieldset>
+  <input type="text" />
+  <legend>Group title</legend>
+</fieldset>
+
+<!-- Compliant: legend as direct child of optgroup -->
+<select>
+  <optgroup>
+    <legend>Group label</legend>
+    <option>Option 1</option>
+  </optgroup>
+</select>
+
+<!-- Compliant: legend inside a custom framework component (PascalCase, unknown HTML tag) -->
+<MyFieldset>
+  <legend>Group title</legend>
+</MyFieldset>
+
+<!-- Compliant: legend inside a custom web component (kebab-case, unknown HTML tag) -->
+<my-fieldset>
+  <legend>Group title</legend>
+</my-fieldset>
+
+<!-- Compliant: legend inside an ASP.NET WebForms server control (transparent wrapper) -->
+<asp:Panel>
+  <legend>Group title</legend>
+</asp:Panel>
+
+<!-- Compliant: ASP.NET WebForms server control nested inside another element -->
+<div>
+  <asp:Panel>
+    <legend>Group title</legend>
+  </asp:Panel>
+</div>
+
+<!-- Compliant: custom wrapper postprocessed into a valid fieldset structure -->
+<fieldset>
+  <my-wrapper>
+    <legend>Group title</legend>
+  </my-wrapper>
+</fieldset>

--- a/sonar-html-plugin/src/test/resources/checks/MisplacedLegendCheck/test.vue
+++ b/sonar-html-plugin/src/test/resources/checks/MisplacedLegendCheck/test.vue
@@ -1,0 +1,21 @@
+<template>
+  <!-- Compliant: legend is a direct child of fieldset -->
+  <fieldset>
+    <legend>Section</legend>
+    <input type="text" />
+  </fieldset>
+
+  <!-- Compliant: legend inside a transparent template wrapper directly under fieldset -->
+  <fieldset>
+    <template v-if="show">
+      <legend>Section</legend>
+    </template>
+  </fieldset>
+
+  <!-- Noncompliant: legend wrapped in div -->
+  <fieldset>
+    <div>
+      <legend>Section</legend> <!-- Noncompliant -->
+    </div>
+  </fieldset>
+</template>


### PR DESCRIPTION
## Summary
Add rule S8732 to flag `<legend>` elements that are not a direct child of `<fieldset>`. Screen readers cannot associate a legend with its fieldset group when the legend is wrapped in an intermediate `<div>` or other element.
RSPEC PR: https://github.com/SonarSource/rspec/pull/7005

## Changes
- Add `LegendMustBeDirectChildOfFieldsetCheck` (rule S8732): reports any `<legend>` whose direct parent is not `<fieldset>`
- Add generated rule resources `S8732.html` / `S8732.json` from rspec branch
- Update `Sonar_way_profile.json` to include S8732
- Add test fixtures `test.html` and `test.vue` covering compliant and noncompliant cases

## Functional Validation
Artifact: [Uploading SONARHTML-264-fv.zip…]()

Once the file is attached to the PR description, unzip and run:
    ./run.sh

Expected output is in `expected-output.txt`. The README shows the before/after comparison so you can reproduce the difference directly.

----
## Summary by Gitar

- **New Feature:**
  - Added `MisplacedLegendCheck` (S8732) to enforce `<legend>` is a direct child of `<fieldset>` or `<optgroup>`.
  - Added `RazorSectionScopeTracker` to prevent false positives by tracking Razor `@section` blocks.
- **Refactored Logic:**
  - Integrated `RazorSectionScopeTracker` into `ItemTagNotWithinContainerTagCheck` to suppress warnings in scoped fragments.
  - Enhanced `Helpers.isTemplateLikeTag` to identify `asp:*` and `ng-template` as transparent wrappers.
- **Documentation & Tests:**
  - Added rule metadata, `Sonar_way_profile.json` updates, and comprehensive `html`/`vue`/`cshtml` test fixtures.

<sub>This will update automatically on new commits.</sub>