### PR TITLE
SONARHTML-178 Skip out-of-range issues instead of crashing

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlSensor.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlSensor.java
@@ -136,7 +136,7 @@ public final class HtmlSensor implements Sensor {
     }
   }
 
-  private static void saveMetrics(SensorContext context, HtmlSourceCode sourceCode) {
+  static void saveMetrics(SensorContext context, HtmlSourceCode sourceCode) {
     InputFile inputFile = sourceCode.inputFile();
 
     for (Map.Entry<Metric<Integer>, Integer> entry : sourceCode.getMeasures().entrySet()) {
@@ -152,6 +152,9 @@ public final class HtmlSensor implements Sensor {
         .forRule(issue.ruleKey())
         .gap(issue.cost());
       NewIssueLocation location = locationForIssue(inputFile, issue, newIssue);
+      if (location == null) {
+        continue;
+      }
       newIssue.at(location);
       newIssue.save();
     }
@@ -163,14 +166,28 @@ public final class HtmlSensor implements Sensor {
       .message(issue.message());
     Integer line = issue.line();
     if (issue instanceof PreciseHtmlIssue preciseHtmlIssue) {
-      location.at(inputFile.newRange(issue.line(),
+      if (!isValidLine(inputFile, line) || !isValidLine(inputFile, preciseHtmlIssue.endLine())) {
+        LOG.warn("Skipping issue from rule {} at lines [{}, {}] of {}: line is out of range (file has {} lines)",
+          issue.ruleKey(), line, preciseHtmlIssue.endLine(), inputFile, inputFile.lines());
+        return null;
+      }
+      location.at(inputFile.newRange(line,
         preciseHtmlIssue.startColumn(),
         preciseHtmlIssue.endLine(),
         preciseHtmlIssue.endColumn()));
     } else if (line != null) {
+      if (!isValidLine(inputFile, line)) {
+        LOG.warn("Skipping issue from rule {} at line {} of {}: line is out of range (file has {} lines)",
+          issue.ruleKey(), line, inputFile, inputFile.lines());
+        return null;
+      }
       location.at(inputFile.selectLine(line));
     }
     return location;
+  }
+
+  private static boolean isValidLine(InputFile inputFile, Integer line) {
+    return line != null && line >= 1 && line <= inputFile.lines();
   }
 
   private void saveLineLevelMeasures(InputFile inputFile, HtmlSourceCode htmlSourceCode) {

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlSensorTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlSensorTest.java
@@ -59,6 +59,11 @@ import org.sonar.plugins.html.api.HtmlConstants;
 import org.sonar.plugins.html.checks.sonar.AllowedLangAttributeCheck;
 import org.sonar.plugins.html.rules.HtmlRulesDefinition;
 
+import org.slf4j.event.Level;
+import org.sonar.plugins.html.checks.AbstractPageCheck;
+import org.sonar.plugins.html.checks.HtmlIssue;
+import org.sonar.plugins.html.visitor.HtmlSourceCode;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -207,7 +212,7 @@ class HtmlSensorTest {
   @Test
   void unreadable_file() {
     tester.setRuntime(SonarRuntimeImpl.forSonarLint(Version.create(6, 7)));
-    DefaultInputFile inputFile = new TestInputFileBuilder("key", "user-properties.jsp")
+    DefaultInputFile inputFile = new TestInputFileBuilder("key", "nonexistent-file.jsp")
       .setModuleBaseDir(TEST_DIR)
       .setLanguage(HtmlConstants.LANGUAGE_KEY)
       .setType(InputFile.Type.MAIN)
@@ -380,6 +385,45 @@ class HtmlSensorTest {
 
   private List<IssueResolution> issueResolutions(DefaultInputFile inputFile) {
     return tester.getIssueResolutions().getOrDefault(inputFile.key(), Collections.emptyList());
+  }
+
+  @Test
+  void out_of_range_line_issue_is_skipped_with_warning() {
+    RuleKey ruleKey = RuleKey.of(HtmlRulesDefinition.REPOSITORY_KEY, "S1195");
+    DefaultInputFile inputFile = createInputFile("test.html", "<html>\n<body>\n</body>\n</html>\n");
+    HtmlSourceCode sourceCode = new HtmlSourceCode(inputFile);
+    sourceCode.addIssue(new HtmlIssue(ruleKey, 2, "valid issue"));
+    sourceCode.addIssue(new HtmlIssue(ruleKey, 9999, "out-of-range issue"));
+
+    HtmlSensor.saveMetrics(tester, sourceCode);
+
+    assertThat(tester.allIssues()).hasSize(1);
+    assertThat(tester.allAnalysisErrors()).isEmpty();
+    assertThat(logTester.logs(Level.WARN)).anyMatch(msg -> msg.contains("9999") && msg.contains("out of range"));
+  }
+
+  @Test
+  void out_of_range_precise_issue_is_skipped_with_warning() {
+    DefaultInputFile inputFile = createInputFile("test.html", "<html>\n<body>\n</body>\n</html>\n");
+    HtmlSourceCode sourceCode = new HtmlSourceCode(inputFile);
+
+    RuleKey ruleKey = RuleKey.of(HtmlRulesDefinition.REPOSITORY_KEY, "S1195");
+    TestCheck check = new TestCheck();
+    check.setRuleKey(ruleKey);
+    check.setSourceCode(sourceCode);
+    check.createPreciseViolation(1, 0, 9999, 6, "end line out of range");
+
+    HtmlSensor.saveMetrics(tester, sourceCode);
+
+    assertThat(tester.allIssues()).isEmpty();
+    assertThat(tester.allAnalysisErrors()).isEmpty();
+    assertThat(logTester.logs(Level.WARN)).anyMatch(msg -> msg.contains("9999") && msg.contains("out of range"));
+  }
+
+  private static class TestCheck extends AbstractPageCheck {
+    void createPreciseViolation(int startLine, int startColumn, int endLine, int endColumn, String message) {
+      createViolation(startLine, startColumn, endLine, endColumn, message);
+    }
   }
 
   private static class RecordingAnalysisWarnings implements AnalysisWarnings {


### PR DESCRIPTION
## Summary
When the HTML lexer assigns an issue a line number beyond the file's actual line count, locationForIssue() now skips the issue with a WARN log instead of throwing IllegalArgumentException. Previously the exception propagated through saveMetrics() and was caught by the outer execute() try-catch, which dropped every issue and metric from the affected file and produced an AnalysisError in the SQ UI.

## Changes
- Add bounds-checking in locationForIssue() that returns null for out-of-range lines instead of crashing
- Add isValidLine() helper for the bounds check
- Fix unreadable_file test which accidentally relied on the crash to produce its AnalysisError

## Functional Validation
Artifact: SONARHTML-178-fv.zip

Once the file is attached to the PR description, unzip and run:
    ./run.sh

Expected output is in expected-output.txt. The README shows the before/after comparison so you can reproduce the difference directly.

:warning::warning: This is not ready for review :warning::warning: