### PR TITLE
SONARHTML-388 USER-2104 Handle empty Razor asp-for labels

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheck.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
+import org.sonar.plugins.html.node.CommentNode;
 import org.sonar.plugins.html.node.DirectiveNode;
 import org.sonar.plugins.html.node.ExpressionNode;
 import org.sonar.plugins.html.node.Node;
@@ -43,10 +44,14 @@ public class LabelHasAssociatedControlCheck extends AbstractPageCheck {
     Pattern.CASE_INSENSITIVE);
   private boolean foundControl;
   private boolean foundAccessibleLabel;
+  private boolean foundLabelBodyContent;
   private TagNode label;
 
   @Override
   public void startDocument(List<Node> nodes) {
+    foundControl = false;
+    foundAccessibleLabel = false;
+    foundLabelBodyContent = false;
     label = null;
   }
 
@@ -54,13 +59,16 @@ public class LabelHasAssociatedControlCheck extends AbstractPageCheck {
   public void startElement(TagNode node) {
     if (isLabel(node)) {
       label = node;
-      if (hasForAttribute(label)) {
-        foundControl = true;
-      } else {
-        foundControl = false;
+      foundControl = hasForAttribute(label);
+      foundAccessibleLabel = false;
+      foundLabelBodyContent = false;
+    } else {
+      if (label != null) {
+        foundLabelBodyContent = true;
       }
-    } else if (isControl(node)) {
-      foundControl = true;
+      if (isControl(node)) {
+        foundControl = true;
+      }
     }
     if (hasAccessibleLabel(node)) {
       foundAccessibleLabel = true;
@@ -101,6 +109,7 @@ public class LabelHasAssociatedControlCheck extends AbstractPageCheck {
   public void characters(TextNode textNode) {
     if (label != null) {
       if (!textNode.isBlank()) {
+        foundLabelBodyContent = true;
         foundAccessibleLabel = true;
       }
       // Check for Razor HTML helpers that render form controls (e.g., @Html.RadioButtonFor)
@@ -111,8 +120,16 @@ public class LabelHasAssociatedControlCheck extends AbstractPageCheck {
   }
 
   @Override
+  public void comment(CommentNode node) {
+    if (label != null) {
+      foundLabelBodyContent = true;
+    }
+  }
+
+  @Override
   public void directive(DirectiveNode node) {
     if (label != null) {
+      foundLabelBodyContent = true;
       foundAccessibleLabel = true;
     }
   }
@@ -121,6 +138,7 @@ public class LabelHasAssociatedControlCheck extends AbstractPageCheck {
   public void expression(ExpressionNode node) {
     // for JSP
     if (label != null) {
+      foundLabelBodyContent = true;
       foundAccessibleLabel = true;
     }
   }
@@ -128,11 +146,15 @@ public class LabelHasAssociatedControlCheck extends AbstractPageCheck {
   @Override
   public void endElement(TagNode node) {
     if (isLabel(node)) {
+      if (label != null && label.hasProperty("asp-for") && !foundLabelBodyContent) {
+        foundAccessibleLabel = true;
+      }
       if ((!foundAccessibleLabel || !foundControl) && label != null) {
         createViolation(label, MESSAGE);
       }
       foundControl = false;
       foundAccessibleLabel = false;
+      foundLabelBodyContent = false;
       label = null;
     }
   }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheckTest.java
@@ -109,8 +109,9 @@ class LabelHasAssociatedControlCheckTest {
             new File("src/test/resources/checks/LabelHasAssociatedControlCheck/aspFor.cshtml"),
             new LabelHasAssociatedControlCheck());
     checkMessagesVerifier.verify(sourceCode.getIssues())
-            .next().atLine(6).withMessage("A form label must be associated with a control and have accessible text.")
-            .next().atLine(7)
+            .next().atLine(11).withMessage("A form label must be associated with a control and have accessible text.")
+            .next().atLine(12)
+            .next().atLine(13)
             .noMore();
   }
 

--- a/sonar-html-plugin/src/test/resources/checks/LabelHasAssociatedControlCheck/aspFor.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/LabelHasAssociatedControlCheck/aspFor.cshtml
@@ -1,7 +1,13 @@
-<!-- Compliant: asp-for on label acts as a "for" binding, with accessible text -->
+<!-- Compliant: asp-for on label acts as a "for" binding, with explicit accessible text -->
 <label asp-for="ModelProperty">Property</label>
 <div><label asp-for="ModelProperty">Property</label><input asp-for="ModelProperty" /></div>
 
-<!-- Noncompliant: asp-for provides the "for" binding, but still needs accessible label text -->
+<!-- Compliant: Razor generates fallback label text when the body is empty or whitespace -->
+<label asp-for="GeneratedProperty"></label>
+<label asp-for="GeneratedProperty">
+</label>
+
+<!-- Noncompliant: non-empty body suppresses the generated label text -->
 <label asp-for="ModelProperty"><input asp-for="ModelProperty" /></label>
-<label asp-for="ModelProperty"></label>
+<label asp-for="ModelProperty"><span></span></label>
+<label asp-for="ModelProperty"><!-- comment --></label>


### PR DESCRIPTION
## Summary
Handle Razor `label[asp-for]` in `S6853` the same way ASP.NET Core does: empty or whitespace-only label bodies get fallback text at render time, while non-empty bodies are still analyzed normally.

## Changes
- treat empty or whitespace-only `label[asp-for]` bodies as having generated accessible text
- keep reporting `label[asp-for]` when nested content suppresses the generated label text
- extend the `S6853` tests with empty, whitespace-only, nested tag, and comment-only Razor label cases

## Functional Validation
Artifact: [USER-2104-fv.zip](https://github.com/user-attachments/files/28637675/USER-2104-fv.zip)

Once the file is attached to the PR description, unzip and run:
    ./run.sh

Expected output is in `expected-output.txt`. The README shows the
before/after comparison so you can reproduce the difference directly.

