### PR TITLE
SONARHTML-389 USER-2104 Fix S6853 false positive on empty asp-for labels

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheck.java
@@ -63,7 +63,7 @@ public class LabelHasAssociatedControlCheck extends AbstractPageCheck {
       foundAccessibleLabel = false;
       foundLabelBodyContent = false;
     } else {
-      if (label != null) {
+      if (label != null && !isRazorText(node)) {
         foundLabelBodyContent = true;
       }
       if (isControl(node)) {
@@ -103,6 +103,11 @@ public class LabelHasAssociatedControlCheck extends AbstractPageCheck {
 
   private static boolean isControl(TagNode node) {
     return CONTROL_TAGS.contains(node.getNodeName().toUpperCase(Locale.ROOT));
+  }
+
+  /** Razor's {@code <text>} pseudo-element renders only its children, not itself. */
+  private static boolean isRazorText(TagNode node) {
+    return "text".equalsIgnoreCase(node.getNodeName());
   }
 
   @Override

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheckTest.java
@@ -109,9 +109,10 @@ class LabelHasAssociatedControlCheckTest {
             new File("src/test/resources/checks/LabelHasAssociatedControlCheck/aspFor.cshtml"),
             new LabelHasAssociatedControlCheck());
     checkMessagesVerifier.verify(sourceCode.getIssues())
-            .next().atLine(11).withMessage("A form label must be associated with a control and have accessible text.")
-            .next().atLine(12)
-            .next().atLine(13)
+            .next().atLine(16).withMessage("A form label must be associated with a control and have accessible text.")
+            .next().atLine(17)
+            .next().atLine(18)
+            .next().atLine(19)
             .noMore();
   }
 

--- a/sonar-html-plugin/src/test/resources/checks/LabelHasAssociatedControlCheck/aspFor.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/LabelHasAssociatedControlCheck/aspFor.cshtml
@@ -7,7 +7,13 @@
 <label asp-for="GeneratedProperty">
 </label>
 
+<!-- Compliant: <text> is a Razor transition pseudo-element that renders no markup itself -->
+<label asp-for="GeneratedProperty"><text></text></label>
+<label asp-for="GeneratedProperty"><text>
+</text></label>
+
 <!-- Noncompliant: non-empty body suppresses the generated label text -->
 <label asp-for="ModelProperty"><input asp-for="ModelProperty" /></label>
+<label asp-for="ModelProperty"><input /></label>
 <label asp-for="ModelProperty"><span></span></label>
 <label asp-for="ModelProperty"><!-- comment --></label>


### PR DESCRIPTION
## Summary
`Web:S6853` was flagging `<label asp-for="..."></label>` elements in Razor files as noncompliant. The ASP.NET Core Razor `asp-for` tag helper generates both the `for` attribute and the label text at runtime when the body is empty, so these findings are false positives.

## Changes
- Track whether the label body has any non-blank content (`foundLabelBodyContent`)
- Treat empty-body `asp-for` labels as having an accessible name (Razor generates it)
- Noncompliant case: label with `asp-for` AND non-empty body still needs explicit accessible text (because the body suppresses Razor's generated text)
- Add test cases for compliant (empty body) and noncompliant (non-empty body) `asp-for` patterns

## Functional Validation
Artifact: `USER-2104-fv.zip`

Once the file is attached to the PR description, unzip and run:
    ./run.sh

Expected output is in `expected-output.txt`. The README shows the
before/after comparison so you can reproduce the difference directly.

:warning::warning: This is not ready for review :warning::warning:

----
## Summary by Gitar

- **Fixed false positives:**
  - Ignore `<text>` Razor pseudo-elements in `LabelHasAssociatedControlCheck` to prevent incorrect accessibility warnings.
- **Refined test coverage:**
  - Updated test cases in `aspFor.cshtml` to include additional scenarios for compliant `<text>` elements and noncompliant input patterns.

<sub>This will update automatically on new commits.</sub>