### PR TITLE
Improve template-aware handling in S6827 and S7930

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -1,0 +1,510 @@
+/*
+ * SonarQube HTML
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.html.api;
+
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.sonar.plugins.html.node.DirectiveNode;
+import org.sonar.plugins.html.node.TagNode;
+import org.sonar.plugins.html.node.TextNode;
+
+/**
+ * Tracks mutually exclusive template branches across several templating syntaxes
+ * without requiring a dedicated parser for each of them.
+ */
+public final class TemplateConditionalScopeTracker {
+
+  private static final Set<String> JSTL_CONDITIONAL_TAGS = Set.of(
+    "c:if", "c:when", "c:otherwise", "c:choose"
+  );
+
+  private static final Set<String> VUE_CONDITIONAL_ATTRS = Set.of(
+    "v-if", "v-else-if", "v-else", "v-for"
+  );
+
+  private static final Set<String> ANGULAR_CONDITIONAL_ATTRS = Set.of(
+    "*ngIf", "*ngFor", "*ngSwitchCase", "*ngSwitchDefault"
+  );
+
+  private static final Pattern CONDITIONAL_START_PATTERN = Pattern.compile(
+    "@(if|switch)\\s*\\(|" +
+    "@(case|default)\\s*[({]|" +
+    "\\{%[-\\s]*(if|for)\\b|" +
+    "<\\?(?:php)?\\s*(if|foreach|for)\\b",
+    Pattern.CASE_INSENSITIVE
+  );
+
+  private static final Pattern CONDITIONAL_END_PATTERN = Pattern.compile(
+    "\\{%[-\\s]*(endif|endfor)\\b|" +
+    "<\\?(?:php)?\\s*(endif|endforeach|endfor)\\b",
+    Pattern.CASE_INSENSITIVE
+  );
+
+  private int textConditionalDepth;
+  private int tagConditionalDepth;
+
+  public void reset() {
+    textConditionalDepth = 0;
+    tagConditionalDepth = 0;
+  }
+
+  public void visitText(TextNode textNode) {
+    updateTextConditionalDepth(textNode.getCode(), textNode.getCode());
+  }
+
+  public void visitDirective(DirectiveNode directiveNode) {
+    String code = directiveNode.getCode();
+    updateTextConditionalDepth(code, unwrapDirective(code));
+  }
+
+  public void startElement(TagNode node) {
+    if (isJstlConditionalTag(node)) {
+      tagConditionalDepth++;
+    }
+  }
+
+  public void endElement(TagNode node) {
+    if (isJstlConditionalTag(node) && tagConditionalDepth > 0) {
+      tagConditionalDepth--;
+    }
+  }
+
+  public boolean isInConditional(TagNode node) {
+    return hasOpenConditionalScope() || hasConditionalAttribute(node);
+  }
+
+  private boolean hasOpenConditionalScope() {
+    return textConditionalDepth > 0 || tagConditionalDepth > 0;
+  }
+
+  private void updateTextConditionalDepth(String conditionalText, String braceText) {
+    int conditionalStarts = incrementTextConditionalDepthForStarts(conditionalText);
+    decrementTextConditionalDepthForExplicitEnds(conditionalText);
+    applyStructuralClosingBraces(conditionalText, braceText, conditionalStarts);
+  }
+
+  private int incrementTextConditionalDepthForStarts(String conditionalText) {
+    int starts = countMatches(CONDITIONAL_START_PATTERN, conditionalText);
+    textConditionalDepth += starts;
+    return starts;
+  }
+
+  private void decrementTextConditionalDepthForExplicitEnds(String conditionalText) {
+    applyTextConditionalClosings(countMatches(CONDITIONAL_END_PATTERN, conditionalText));
+  }
+
+  private void applyStructuralClosingBraces(String conditionalText, String braceText, int conditionalStarts) {
+    applyTextConditionalClosings(countStructuralClosings(conditionalText, braceText, conditionalStarts));
+  }
+
+  private int countStructuralClosings(String conditionalText, String braceText, int conditionalStarts) {
+    if (!hasOpenTextConditional() || !braceText.contains("}")) {
+      return 0;
+    }
+
+    String trimmed = braceText.trim();
+    boolean continuation = isConditionalContinuation(trimmed);
+    int structuralClosings = opensAndClosesInSameFragment(conditionalText, conditionalStarts)
+      ? StructuralClosingBraceCounter.count(trimmed)
+      : LeadingClosingBraceCounter.count(trimmed);
+
+    return continuation && structuralClosings > 0 ? structuralClosings - 1 : structuralClosings;
+  }
+
+  private boolean hasOpenTextConditional() {
+    return textConditionalDepth > 0;
+  }
+
+  private static boolean opensAndClosesInSameFragment(String conditionalText, int conditionalStarts) {
+    return conditionalStarts > 0 && !conditionalText.contains("{%");
+  }
+
+  private void applyTextConditionalClosings(int closingCount) {
+    if (closingCount > 0) {
+      textConditionalDepth = Math.max(0, textConditionalDepth - closingCount);
+    }
+  }
+
+  private static boolean isJstlConditionalTag(TagNode node) {
+    String nodeName = node.getNodeName();
+    return nodeName != null && JSTL_CONDITIONAL_TAGS.contains(nodeName.toLowerCase(Locale.ROOT));
+  }
+
+  private static boolean hasConditionalAttribute(TagNode node) {
+    return hasAnyAttribute(node, VUE_CONDITIONAL_ATTRS)
+      || hasAnyAttribute(node, ANGULAR_CONDITIONAL_ATTRS);
+  }
+
+  private static boolean hasAnyAttribute(TagNode node, Set<String> attributes) {
+    for (String attribute : attributes) {
+      if (node.hasAttribute(attribute)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static int countMatches(Pattern pattern, String text) {
+    Matcher matcher = pattern.matcher(text);
+    int matches = 0;
+    while (matcher.find()) {
+      matches++;
+    }
+    return matches;
+  }
+
+  private static String unwrapDirective(String code) {
+    String trimmed = code.trim();
+    if (!trimmed.startsWith("<?") || !trimmed.endsWith("?>")) {
+      return trimmed;
+    }
+
+    String unwrapped = trimmed.substring(2, trimmed.length() - 2).trim();
+    return unwrapped.toLowerCase(Locale.ROOT).startsWith("php")
+      ? unwrapped.substring(3).trim()
+      : unwrapped;
+  }
+
+  private static boolean isConditionalContinuation(String text) {
+    int index = skipLeadingTrivia(text, 0);
+    if (!startsWithSingleClosingBrace(text, index)) {
+      return false;
+    }
+
+    index = skipLeadingTrivia(text, index + 1);
+    if (index < text.length() && text.charAt(index) == '@') {
+      index++;
+    }
+
+    return startsWithKeyword(text, index, "elseif")
+      || startsWithElseIf(text, index)
+      || startsWithKeyword(text, index, "else");
+  }
+
+  private static boolean startsWithElseIf(String text, int index) {
+    if (!startsWithKeyword(text, index, "else")) {
+      return false;
+    }
+    int ifIndex = skipWhitespace(text, index + 4);
+    return startsWithKeyword(text, ifIndex, "if");
+  }
+
+  private static boolean startsWithKeyword(String text, int index, String keyword) {
+    return index >= 0
+      && index + keyword.length() <= text.length()
+      && text.regionMatches(true, index, keyword, 0, keyword.length())
+      && isWordBoundary(text, index + keyword.length());
+  }
+
+  private static boolean isWordBoundary(String text, int index) {
+    return index >= text.length()
+      || (!Character.isLetterOrDigit(text.charAt(index)) && text.charAt(index) != '_');
+  }
+
+  private static boolean startsWithSingleClosingBrace(String text, int index) {
+    return index < text.length()
+      && text.charAt(index) == '}'
+      && !(index + 1 < text.length() && text.charAt(index + 1) == '}');
+  }
+
+  private static int skipLeadingTrivia(String text, int index) {
+    int current = index;
+    boolean advanced = true;
+    while (advanced && current < text.length()) {
+      int afterWhitespace = skipWhitespace(text, current);
+      int afterComment = skipComment(text, afterWhitespace);
+      advanced = afterComment > current;
+      current = afterComment;
+    }
+    return current;
+  }
+
+  private static int skipWhitespace(String text, int index) {
+    int current = index;
+    while (current < text.length() && Character.isWhitespace(text.charAt(current))) {
+      current++;
+    }
+    return current;
+  }
+
+  private static int skipComment(String text, int index) {
+    if (index >= text.length()) {
+      return index;
+    }
+    if (text.charAt(index) == '#') {
+      return skipLineComment(text, index + 1);
+    }
+    if (startsWith(text, index, "//")) {
+      return skipLineComment(text, index + 2);
+    }
+    if (startsWith(text, index, "/*")) {
+      return skipBlockComment(text, index + 2);
+    }
+    return index;
+  }
+
+  private static int skipLineComment(String text, int index) {
+    int current = index;
+    while (current < text.length() && !isLineBreak(text.charAt(current))) {
+      current++;
+    }
+    return current;
+  }
+
+  private static int skipBlockComment(String text, int index) {
+    int current = index;
+    while (current + 1 < text.length() && !startsWith(text, current, "*/")) {
+      current++;
+    }
+    return current + 1 < text.length() ? current + 2 : text.length();
+  }
+
+  private static boolean startsWith(String text, int index, String token) {
+    return index + token.length() <= text.length()
+      && text.regionMatches(index, token, 0, token.length());
+  }
+
+  private static final class LeadingClosingBraceCounter {
+
+    private final String text;
+    private int index;
+
+    private LeadingClosingBraceCounter(String text) {
+      this.text = text;
+    }
+
+    private static int count(String text) {
+      return new LeadingClosingBraceCounter(text).count();
+    }
+
+    private int count() {
+      int closingBraces = 0;
+      while (hasMoreCharacters()) {
+        skipWhitespaceAndComments();
+        if (!hasMoreCharacters() || startsWithDoubleClosingBrace() || currentChar() != '}') {
+          return closingBraces;
+        }
+        closingBraces++;
+        index++;
+      }
+      return closingBraces;
+    }
+
+    private void skipWhitespaceAndComments() {
+      boolean advanced = true;
+      while (advanced && hasMoreCharacters()) {
+        advanced = skipWhitespace() || skipLineComment() || skipBlockComment();
+      }
+    }
+
+    private boolean skipWhitespace() {
+      int start = index;
+      while (hasMoreCharacters() && Character.isWhitespace(currentChar())) {
+        index++;
+      }
+      return index > start;
+    }
+
+    private boolean skipLineComment() {
+      if (!startsLineComment()) {
+        return false;
+      }
+      index += currentChar() == '#' ? 1 : 2;
+      while (hasMoreCharacters() && !isLineBreak(currentChar())) {
+        index++;
+      }
+      return true;
+    }
+
+    private boolean skipBlockComment() {
+      if (!startsBlockComment()) {
+        return false;
+      }
+      index += 2;
+      while (hasMoreCharacters() && !startsWith("*/")) {
+        index++;
+      }
+      if (startsWith("*/")) {
+        index += 2;
+      }
+      return true;
+    }
+
+    private boolean startsLineComment() {
+      return currentChar() == '#' || startsWith("//");
+    }
+
+    private boolean startsBlockComment() {
+      return startsWith("/*");
+    }
+
+    private boolean startsWithDoubleClosingBrace() {
+      return startsWith("}}");
+    }
+
+    private boolean startsWith(String token) {
+      return text.regionMatches(index, token, 0, token.length());
+    }
+
+    private boolean hasMoreCharacters() {
+      return index < text.length();
+    }
+
+    private char currentChar() {
+      return text.charAt(index);
+    }
+  }
+
+  private static final class StructuralClosingBraceCounter {
+
+    private final String text;
+    private int index;
+    private boolean inLineComment;
+    private boolean inBlockComment;
+    private boolean escaped;
+    private char quoteDelimiter;
+
+    private StructuralClosingBraceCounter(String text) {
+      this.text = text;
+    }
+
+    private static int count(String text) {
+      return new StructuralClosingBraceCounter(text).count();
+    }
+
+    private int count() {
+      int closingBraces = 0;
+      while (hasMoreCharacters()) {
+        closingBraces += scanCurrentCharacter();
+      }
+      return closingBraces;
+    }
+
+    private int scanCurrentCharacter() {
+      if (inLineComment) {
+        advanceLineComment();
+        return 0;
+      }
+      if (inBlockComment) {
+        advanceBlockComment();
+        return 0;
+      }
+      if (isInsideQuotedString()) {
+        advanceQuotedString();
+        return 0;
+      }
+      if (startsBlockComment()) {
+        inBlockComment = true;
+        index += 2;
+        return 0;
+      }
+      if (startsLineComment()) {
+        enterLineComment();
+        return 0;
+      }
+      if (startsQuotedString()) {
+        quoteDelimiter = currentChar();
+        escaped = false;
+        index++;
+        return 0;
+      }
+      if (startsWithDoubleClosingBrace()) {
+        index += 2;
+        return 0;
+      }
+      return consumeClosingBrace();
+    }
+
+    private void advanceLineComment() {
+      if (isLineBreak(currentChar())) {
+        inLineComment = false;
+      }
+      index++;
+    }
+
+    private void advanceBlockComment() {
+      if (startsWith("*/")) {
+        inBlockComment = false;
+        index += 2;
+      } else {
+        index++;
+      }
+    }
+
+    private void advanceQuotedString() {
+      char current = currentChar();
+      if (escaped) {
+        escaped = false;
+      } else if (current == '\\') {
+        escaped = true;
+      } else if (current == quoteDelimiter) {
+        quoteDelimiter = '\0';
+      }
+      index++;
+    }
+
+    private void enterLineComment() {
+      inLineComment = true;
+      index += currentChar() == '#' ? 1 : 2;
+    }
+
+    private boolean isInsideQuotedString() {
+      return quoteDelimiter != '\0';
+    }
+
+    private boolean startsBlockComment() {
+      return startsWith("/*");
+    }
+
+    private boolean startsLineComment() {
+      return currentChar() == '#' || startsWith("//");
+    }
+
+    private boolean startsQuotedString() {
+      char current = currentChar();
+      return current == '\'' || current == '"';
+    }
+
+    private boolean startsWithDoubleClosingBrace() {
+      return startsWith("}}");
+    }
+
+    private int consumeClosingBrace() {
+      int closingBraces = currentChar() == '}' ? 1 : 0;
+      index++;
+      return closingBraces;
+    }
+
+    private boolean startsWith(String token) {
+      return text.regionMatches(index, token, 0, token.length());
+    }
+
+    private boolean hasMoreCharacters() {
+      return index < text.length();
+    }
+
+    private char currentChar() {
+      return text.charAt(index);
+    }
+  }
+
+  private static boolean isLineBreak(char character) {
+    return character == '\n' || character == '\r';
+  }
+}

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -42,19 +42,13 @@ public final class TemplateConditionalScopeTracker {
     "*ngIf", "*ngFor", "*ngSwitchCase", "*ngSwitchDefault"
   );
 
-  private static final Pattern CONDITIONAL_START_PATTERN = Pattern.compile(
-    "@(if|switch)\\s*\\(|" +
-    "@(case|default)\\s*[({]|" +
-    "\\{%[-\\s]*(if|for)\\b|" +
-    "<\\?(?:php)?\\s*(if|foreach|for)\\b",
-    Pattern.CASE_INSENSITIVE
-  );
+  private static final Pattern RAZOR_BLOCK_START_PATTERN = Pattern.compile("@(if|switch)\\s*\\(", Pattern.CASE_INSENSITIVE);
+  private static final Pattern RAZOR_BRANCH_START_PATTERN = Pattern.compile("@(case|default)\\s*[({]", Pattern.CASE_INSENSITIVE);
+  private static final Pattern TWIG_CONDITIONAL_START_PATTERN = Pattern.compile("\\{%[-\\s]*(if|for)\\b", Pattern.CASE_INSENSITIVE);
+  private static final Pattern PHP_CONDITIONAL_START_PATTERN = Pattern.compile("<\\?(?:php)?\\s*(if|foreach|for)\\b", Pattern.CASE_INSENSITIVE);
 
-  private static final Pattern CONDITIONAL_END_PATTERN = Pattern.compile(
-    "\\{%[-\\s]*(endif|endfor)\\b|" +
-    "<\\?(?:php)?\\s*(endif|endforeach|endfor)\\b",
-    Pattern.CASE_INSENSITIVE
-  );
+  private static final Pattern TWIG_CONDITIONAL_END_PATTERN = Pattern.compile("\\{%[-\\s]*(endif|endfor)\\b", Pattern.CASE_INSENSITIVE);
+  private static final Pattern PHP_CONDITIONAL_END_PATTERN = Pattern.compile("<\\?(?:php)?\\s*(endif|endforeach|endfor)\\b", Pattern.CASE_INSENSITIVE);
 
   private int textConditionalDepth;
   private int tagConditionalDepth;
@@ -100,13 +94,13 @@ public final class TemplateConditionalScopeTracker {
   }
 
   private int incrementTextConditionalDepthForStarts(String conditionalText) {
-    int starts = countMatches(CONDITIONAL_START_PATTERN, conditionalText);
+    int starts = countConditionalStarts(conditionalText);
     textConditionalDepth += starts;
     return starts;
   }
 
   private void decrementTextConditionalDepthForExplicitEnds(String conditionalText) {
-    applyTextConditionalClosings(countMatches(CONDITIONAL_END_PATTERN, conditionalText));
+    applyTextConditionalClosings(countConditionalEnds(conditionalText));
   }
 
   private void applyStructuralClosingBraces(String conditionalText, String braceText, int conditionalStarts) {
@@ -124,7 +118,10 @@ public final class TemplateConditionalScopeTracker {
       ? StructuralClosingBraceCounter.count(trimmed)
       : LeadingClosingBraceCounter.count(trimmed);
 
-    return continuation && structuralClosings > 0 ? structuralClosings - 1 : structuralClosings;
+    if (continuation && structuralClosings > 0) {
+      return structuralClosings - 1;
+    }
+    return structuralClosings;
   }
 
   private boolean hasOpenTextConditional() {
@@ -167,6 +164,18 @@ public final class TemplateConditionalScopeTracker {
       matches++;
     }
     return matches;
+  }
+
+  private static int countConditionalStarts(String conditionalText) {
+    return countMatches(RAZOR_BLOCK_START_PATTERN, conditionalText)
+      + countMatches(RAZOR_BRANCH_START_PATTERN, conditionalText)
+      + countMatches(TWIG_CONDITIONAL_START_PATTERN, conditionalText)
+      + countMatches(PHP_CONDITIONAL_START_PATTERN, conditionalText);
+  }
+
+  private static int countConditionalEnds(String conditionalText) {
+    return countMatches(TWIG_CONDITIONAL_END_PATTERN, conditionalText)
+      + countMatches(PHP_CONDITIONAL_END_PATTERN, conditionalText);
   }
 
   private static String unwrapDirective(String code) {
@@ -272,7 +281,10 @@ public final class TemplateConditionalScopeTracker {
     while (current + 1 < text.length() && !startsWith(text, current, "*/")) {
       current++;
     }
-    return current + 1 < text.length() ? current + 2 : text.length();
+    if (current + 1 < text.length()) {
+      return current + 2;
+    }
+    return text.length();
   }
 
   private static boolean startsWith(String text, int index, String token) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheck.java
@@ -18,8 +18,8 @@ package org.sonar.plugins.html.checks.accessibility;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.Locale;
 import org.sonar.check.Rule;
+import org.sonar.plugins.html.api.Helpers;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
 import org.sonar.plugins.html.node.DirectiveNode;
 import org.sonar.plugins.html.node.ExpressionNode;
@@ -69,25 +69,23 @@ public class AnchorsHaveContentCheck extends AbstractPageCheck {
 
   @Override
   public void characters(TextNode node) {
-    if (!anchors.isEmpty()) {
-      var anchor = anchors.peek();
-      anchor.hasContent = anchor.hasContent || !node.isBlank();
-    }
+    updateCurrentAnchorContent(!node.isBlank() || hasDynamicContent(node.getCode()));
   }
 
   @Override
   public void directive(DirectiveNode node) {
-    if (!anchors.isEmpty()) {
-      var anchor = anchors.peek();
-      anchor.hasContent = anchor.hasContent || isPhpDirective(node);
-    }
+    updateCurrentAnchorContent(isDynamicDirective(node));
   }
 
   @Override
   public void expression(ExpressionNode node) {
+    updateCurrentAnchorContent(hasDynamicContent(node.getCode()));
+  }
+
+  private void updateCurrentAnchorContent(boolean hasContent) {
     if (!anchors.isEmpty()) {
       var anchor = anchors.peek();
-      anchor.hasContent = true;
+      anchor.hasContent = anchor.hasContent || hasContent;
     }
   }
 
@@ -95,13 +93,13 @@ public class AnchorsHaveContentCheck extends AbstractPageCheck {
     return "a".equalsIgnoreCase(element.getNodeName());
   }
 
-  private static boolean isPhpDirective(DirectiveNode node) {
-    var nodeName = node.getNodeName();
-    if (nodeName == null) {
-      return false;
-    }
-    nodeName = nodeName.toLowerCase(Locale.ROOT);
-    return nodeName.startsWith("?php") || "?=".equals(nodeName);
+  private boolean isDynamicDirective(DirectiveNode node) {
+    return node.getCode().startsWith("<?") && hasDynamicContent(node.getCode());
+  }
+
+  private boolean hasDynamicContent(String code) {
+    return Helpers.containsDynamicValue(code, getHtmlSourceCode())
+      || Helpers.containsRazorFragmentRendering(code);
   }
 
   private static boolean hasContent(TagNode element) {
@@ -112,6 +110,6 @@ public class AnchorsHaveContentCheck extends AbstractPageCheck {
       }
     }
     return element.hasProperty("title") || element.hasProperty("aria-label") || element.hasAttribute("th:text")
-       || element.hasAttribute("th:utext");
+       || element.hasAttribute("th:utext") || element.hasAttribute("v-text") || element.hasAttribute("v-html");
   }
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheck.java
@@ -18,6 +18,7 @@ package org.sonar.plugins.html.checks.accessibility;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.Locale;
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
 import org.sonar.plugins.html.node.DirectiveNode;
@@ -78,8 +79,8 @@ public class AnchorsHaveContentCheck extends AbstractPageCheck {
   public void directive(DirectiveNode node) {
     if (!anchors.isEmpty()) {
       var anchor = anchors.peek();
-      anchor.hasContent = anchor.hasContent || "?php".equals(node.getNodeName());
-     }
+      anchor.hasContent = anchor.hasContent || isPhpDirective(node);
+    }
   }
 
   @Override
@@ -92,6 +93,15 @@ public class AnchorsHaveContentCheck extends AbstractPageCheck {
 
   private static boolean isAnchor(TagNode element) {
     return "a".equalsIgnoreCase(element.getNodeName());
+  }
+
+  private static boolean isPhpDirective(DirectiveNode node) {
+    var nodeName = node.getNodeName();
+    if (nodeName == null) {
+      return false;
+    }
+    nodeName = nodeName.toLowerCase(Locale.ROOT);
+    return nodeName.startsWith("?php") || "?=".equals(nodeName);
   }
 
   private static boolean hasContent(TagNode element) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheck.java
@@ -69,17 +69,26 @@ public class AnchorsHaveContentCheck extends AbstractPageCheck {
 
   @Override
   public void characters(TextNode node) {
-    updateCurrentAnchorContent(!node.isBlank() || hasDynamicContent(node.getCode()));
+    if (anchors.isEmpty()) {
+      return;
+    }
+    updateCurrentAnchorContent(!node.isBlank());
   }
 
   @Override
   public void directive(DirectiveNode node) {
+    if (anchors.isEmpty()) {
+      return;
+    }
     updateCurrentAnchorContent(isDynamicDirective(node));
   }
 
   @Override
   public void expression(ExpressionNode node) {
-    updateCurrentAnchorContent(hasDynamicContent(node.getCode()));
+    if (anchors.isEmpty()) {
+      return;
+    }
+    updateCurrentAnchorContent(true);
   }
 
   private void updateCurrentAnchorContent(boolean hasContent) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheck.java
@@ -80,7 +80,7 @@ public class AnchorsHaveContentCheck extends AbstractPageCheck {
     if (anchors.isEmpty()) {
       return;
     }
-    updateCurrentAnchorContent(isDynamicDirective(node));
+    updateCurrentAnchorContent(isServerSideDirective(node));
   }
 
   @Override
@@ -102,13 +102,8 @@ public class AnchorsHaveContentCheck extends AbstractPageCheck {
     return "a".equalsIgnoreCase(element.getNodeName());
   }
 
-  private boolean isDynamicDirective(DirectiveNode node) {
-    return node.getCode().startsWith("<?") && hasDynamicContent(node.getCode());
-  }
-
-  private boolean hasDynamicContent(String code) {
-    return Helpers.containsDynamicValue(code, getHtmlSourceCode())
-      || Helpers.containsRazorFragmentRendering(code);
+  private static boolean isServerSideDirective(DirectiveNode node) {
+    return Helpers.containsServerSideMarker(node.getCode());
   }
 
   private static boolean hasContent(TagNode element) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheck.java
@@ -137,40 +137,169 @@ public class NoDuplicateIDCheck extends AbstractPageCheck {
 
     if (textConditionalDepth > 0 && braceText.contains("}")) {
       String trimmed = braceText.trim();
-      if (shouldTrackStructuralBraces(trimmed, conditionalText, conditionalStarts)) {
-        int closingBraces = countStandaloneClosingBraces(trimmed);
-        if (CONDITIONAL_CONTINUATION_PATTERN.matcher(trimmed).find() && closingBraces > 0) {
-          closingBraces--;
+      boolean isContinuation = CONDITIONAL_CONTINUATION_PATTERN.matcher(trimmed).find();
+      if (conditionalStarts > 0 && !conditionalText.contains("{%")) {
+        int structuralClosingBraces = countStructuralClosingBraces(trimmed);
+        if (isContinuation && structuralClosingBraces > 0) {
+          structuralClosingBraces--;
         }
-        if (closingBraces > 0) {
-          textConditionalDepth = Math.max(0, textConditionalDepth - closingBraces);
+        if (structuralClosingBraces > 0) {
+          textConditionalDepth = Math.max(0, textConditionalDepth - structuralClosingBraces);
+        }
+      } else {
+        int leadingStructuralClosingBraces = countLeadingStructuralClosingBraces(trimmed);
+        if (isContinuation && leadingStructuralClosingBraces > 0) {
+          leadingStructuralClosingBraces--;
+        }
+        if (leadingStructuralClosingBraces > 0) {
+          textConditionalDepth = Math.max(0, textConditionalDepth - leadingStructuralClosingBraces);
         }
       }
     }
   }
 
-  private static boolean shouldTrackStructuralBraces(String trimmed, String conditionalText, int conditionalStarts) {
-    return startsWithStandaloneClosingBrace(trimmed)
-      || (conditionalStarts > 0 && !conditionalText.contains("{%"));
-  }
-
-  private static boolean startsWithStandaloneClosingBrace(String text) {
-    return text.startsWith("}") && !text.startsWith("}}");
-  }
-
-  private static int countStandaloneClosingBraces(String text) {
+  private static int countStructuralClosingBraces(String text) {
     int count = 0;
+    boolean inSingleQuote = false;
+    boolean inDoubleQuote = false;
+    boolean inLineComment = false;
+    boolean inBlockComment = false;
+    boolean escaped = false;
+
     for (int i = 0; i < text.length(); i++) {
-      if (text.charAt(i) == '}' && !isDoubleBrace(text, i)) {
+      char current = text.charAt(i);
+      char next = i + 1 < text.length() ? text.charAt(i + 1) : '\0';
+
+      if (inLineComment) {
+        if (current == '\n' || current == '\r') {
+          inLineComment = false;
+        }
+        continue;
+      }
+
+      if (inBlockComment) {
+        if (current == '*' && next == '/') {
+          inBlockComment = false;
+          i++;
+        }
+        continue;
+      }
+
+      if (inSingleQuote) {
+        if (escaped) {
+          escaped = false;
+        } else if (current == '\\') {
+          escaped = true;
+        } else if (current == '\'') {
+          inSingleQuote = false;
+        }
+        continue;
+      }
+
+      if (inDoubleQuote) {
+        if (escaped) {
+          escaped = false;
+        } else if (current == '\\') {
+          escaped = true;
+        } else if (current == '"') {
+          inDoubleQuote = false;
+        }
+        continue;
+      }
+
+      if (current == '/' && next == '*') {
+        inBlockComment = true;
+        i++;
+        continue;
+      }
+
+      if (current == '/' && next == '/') {
+        inLineComment = true;
+        i++;
+        continue;
+      }
+
+      if (current == '#') {
+        inLineComment = true;
+        continue;
+      }
+
+      if (current == '\'') {
+        inSingleQuote = true;
+        continue;
+      }
+
+      if (current == '"') {
+        inDoubleQuote = true;
+        continue;
+      }
+
+      if (current == '}' && next == '}') {
+        i++;
+        continue;
+      }
+
+      if (current == '}') {
         count++;
       }
     }
     return count;
   }
 
-  private static boolean isDoubleBrace(String text, int index) {
-    return (index > 0 && text.charAt(index - 1) == '}')
-      || (index + 1 < text.length() && text.charAt(index + 1) == '}');
+  private static int countLeadingStructuralClosingBraces(String text) {
+    int count = 0;
+
+    for (int i = 0; i < text.length();) {
+      char current = text.charAt(i);
+      char next = i + 1 < text.length() ? text.charAt(i + 1) : '\0';
+
+      if (Character.isWhitespace(current)) {
+        i++;
+        continue;
+      }
+
+      if (current == '/' && next == '*') {
+        i += 2;
+        while (i + 1 < text.length() && !(text.charAt(i) == '*' && text.charAt(i + 1) == '/')) {
+          i++;
+        }
+        if (i + 1 >= text.length()) {
+          return count;
+        }
+        i += 2;
+        continue;
+      }
+
+      if (current == '/' && next == '/') {
+        i += 2;
+        while (i < text.length() && text.charAt(i) != '\n' && text.charAt(i) != '\r') {
+          i++;
+        }
+        continue;
+      }
+
+      if (current == '#') {
+        i++;
+        while (i < text.length() && text.charAt(i) != '\n' && text.charAt(i) != '\r') {
+          i++;
+        }
+        continue;
+      }
+
+      if (current == '}' && next == '}') {
+        return count;
+      }
+
+      if (current == '}') {
+        count++;
+        i++;
+        continue;
+      }
+
+      return count;
+    }
+
+    return count;
   }
 
   private static String unwrapDirective(String code) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheck.java
@@ -75,7 +75,7 @@ public class NoDuplicateIDCheck extends AbstractPageCheck {
    * Continuations such as "} else {" keep the element inside the same conditional block.
    */
   private static final Pattern CONDITIONAL_CONTINUATION_PATTERN = Pattern.compile(
-    "^}\\s*(else\\b|elseif\\b|else\\s+if\\b)",
+    "^}\\s*@?(else\\b|elseif\\b|else\\s+if\\b)",
     Pattern.CASE_INSENSITIVE | Pattern.DOTALL
   );
 
@@ -121,9 +121,11 @@ public class NoDuplicateIDCheck extends AbstractPageCheck {
   }
 
   private void updateTextConditionalDepth(String conditionalText, String braceText) {
+    int conditionalStarts = 0;
     var startMatcher = CONDITIONAL_START_PATTERN.matcher(conditionalText);
     while (startMatcher.find()) {
       textConditionalDepth++;
+      conditionalStarts++;
     }
 
     var endMatcher = CONDITIONAL_END_PATTERN.matcher(conditionalText);
@@ -135,11 +137,40 @@ public class NoDuplicateIDCheck extends AbstractPageCheck {
 
     if (textConditionalDepth > 0 && braceText.contains("}")) {
       String trimmed = braceText.trim();
-      if (trimmed.startsWith("}") && !trimmed.startsWith("}}")
-        && !CONDITIONAL_CONTINUATION_PATTERN.matcher(trimmed).find()) {
-        textConditionalDepth--;
+      if (shouldTrackStructuralBraces(trimmed, conditionalText, conditionalStarts)) {
+        int closingBraces = countStandaloneClosingBraces(trimmed);
+        if (CONDITIONAL_CONTINUATION_PATTERN.matcher(trimmed).find() && closingBraces > 0) {
+          closingBraces--;
+        }
+        if (closingBraces > 0) {
+          textConditionalDepth = Math.max(0, textConditionalDepth - closingBraces);
+        }
       }
     }
+  }
+
+  private static boolean shouldTrackStructuralBraces(String trimmed, String conditionalText, int conditionalStarts) {
+    return startsWithStandaloneClosingBrace(trimmed)
+      || (conditionalStarts > 0 && !conditionalText.contains("{%"));
+  }
+
+  private static boolean startsWithStandaloneClosingBrace(String text) {
+    return text.startsWith("}") && !text.startsWith("}}");
+  }
+
+  private static int countStandaloneClosingBraces(String text) {
+    int count = 0;
+    for (int i = 0; i < text.length(); i++) {
+      if (text.charAt(i) == '}' && !isDoubleBrace(text, i)) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private static boolean isDoubleBrace(String text, int index) {
+    return (index > 0 && text.charAt(index - 1) == '}')
+      || (index + 1 < text.length() && text.charAt(index + 1) == '}');
   }
 
   private static String unwrapDirective(String code) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheck.java
@@ -25,6 +25,7 @@ import java.util.regex.Pattern;
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.api.Helpers;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
+import org.sonar.plugins.html.node.DirectiveNode;
 import org.sonar.plugins.html.node.Node;
 import org.sonar.plugins.html.node.TagNode;
 import org.sonar.plugins.html.node.TextNode;
@@ -71,6 +72,14 @@ public class NoDuplicateIDCheck extends AbstractPageCheck {
   );
 
   /**
+   * Continuations such as "} else {" keep the element inside the same conditional block.
+   */
+  private static final Pattern CONDITIONAL_CONTINUATION_PATTERN = Pattern.compile(
+    "^}\\s*(else\\b|elseif\\b|else\\s+if\\b)",
+    Pattern.CASE_INSENSITIVE | Pattern.DOTALL
+  );
+
+  /**
    * Vue.js conditional directives.
    */
   private static final Set<String> VUE_CONDITIONAL_ATTRS = Set.of(
@@ -102,31 +111,48 @@ public class NoDuplicateIDCheck extends AbstractPageCheck {
 
   @Override
   public void characters(TextNode textNode) {
-    String text = textNode.getCode();
+    updateTextConditionalDepth(textNode.getCode(), textNode.getCode());
+  }
 
-    // Count conditional starts
-    var startMatcher = CONDITIONAL_START_PATTERN.matcher(text);
+  @Override
+  public void directive(DirectiveNode directiveNode) {
+    String code = directiveNode.getCode();
+    updateTextConditionalDepth(code, unwrapDirective(code));
+  }
+
+  private void updateTextConditionalDepth(String conditionalText, String braceText) {
+    var startMatcher = CONDITIONAL_START_PATTERN.matcher(conditionalText);
     while (startMatcher.find()) {
       textConditionalDepth++;
     }
 
-    // Count conditional ends
-    var endMatcher = CONDITIONAL_END_PATTERN.matcher(text);
+    var endMatcher = CONDITIONAL_END_PATTERN.matcher(conditionalText);
     while (endMatcher.find()) {
       if (textConditionalDepth > 0) {
         textConditionalDepth--;
       }
     }
 
-    // Handle closing braces for Angular/Razor blocks
-    // Count standalone closing braces that likely end conditional blocks
-    if (textConditionalDepth > 0 && text.contains("}")) {
-      // Simple heuristic: closing brace at start of text node often ends a block
-      String trimmed = text.trim();
-      if (trimmed.startsWith("}") && !trimmed.startsWith("}}")) {
+    if (textConditionalDepth > 0 && braceText.contains("}")) {
+      String trimmed = braceText.trim();
+      if (trimmed.startsWith("}") && !trimmed.startsWith("}}")
+        && !CONDITIONAL_CONTINUATION_PATTERN.matcher(trimmed).find()) {
         textConditionalDepth--;
       }
     }
+  }
+
+  private static String unwrapDirective(String code) {
+    String trimmed = code.trim();
+    if (!trimmed.startsWith("<?") || !trimmed.endsWith("?>")) {
+      return trimmed;
+    }
+
+    trimmed = trimmed.substring(2, trimmed.length() - 2).trim();
+    if (trimmed.toLowerCase(Locale.ROOT).startsWith("php")) {
+      trimmed = trimmed.substring(3).trim();
+    }
+    return trimmed;
   }
 
   @Override

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheck.java
@@ -18,12 +18,10 @@ package org.sonar.plugins.html.checks.coding;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
-import java.util.regex.Pattern;
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.api.Helpers;
+import org.sonar.plugins.html.api.TemplateConditionalScopeTracker;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
 import org.sonar.plugins.html.node.DirectiveNode;
 import org.sonar.plugins.html.node.Node;
@@ -42,357 +40,71 @@ import org.sonar.plugins.html.node.TextNode;
 @Rule(key = "S7930")
 public class NoDuplicateIDCheck extends AbstractPageCheck {
 
-  /**
-   * JSP JSTL conditional tags.
-   */
-  private static final Set<String> JSTL_CONDITIONAL_TAGS = Set.of(
-    "c:if", "c:when", "c:otherwise", "c:choose"
-  );
-
-  /**
-   * Pattern to detect start of conditional blocks in text (Angular, Razor, Twig/Jinja, PHP).
-   * Matches: @if(), @switch(), @case, @default, {% if %}, {% for %}, <?php if/foreach/for
-   */
-  private static final Pattern CONDITIONAL_START_PATTERN = Pattern.compile(
-    "@(if|switch)\\s*\\(|" +
-    "@(case|default)\\s*[({]|" +
-    "\\{%[-\\s]*(if|for)\\b|" +
-    "<\\?(?:php)?\\s*(if|foreach|for)\\b",
-    Pattern.CASE_INSENSITIVE
-  );
-
-  /**
-   * Pattern to detect end of conditional blocks in text.
-   * Matches: {% endif %}, {% endfor %}, <?php endif/endforeach/endfor
-   */
-  private static final Pattern CONDITIONAL_END_PATTERN = Pattern.compile(
-    "\\{%[-\\s]*(endif|endfor)\\b|" +
-    "<\\?(?:php)?\\s*(endif|endforeach|endfor)\\b",
-    Pattern.CASE_INSENSITIVE
-  );
-
-  /**
-   * Continuations such as "} else {" keep the element inside the same conditional block.
-   */
-  private static final Pattern CONDITIONAL_CONTINUATION_PATTERN = Pattern.compile(
-    "^}\\s*@?(else\\b|elseif\\b|else\\s+if\\b)",
-    Pattern.CASE_INSENSITIVE | Pattern.DOTALL
-  );
-
-  /**
-   * Vue.js conditional directives.
-   */
-  private static final Set<String> VUE_CONDITIONAL_ATTRS = Set.of(
-    "v-if", "v-else-if", "v-else", "v-for"
-  );
-
-  /**
-   * Angular structural directives for conditionals.
-   */
-  private static final Set<String> ANGULAR_CONDITIONAL_ATTRS = Set.of(
-    "*ngIf", "*ngFor", "*ngSwitchCase", "*ngSwitchDefault"
-  );
-
   // IDs seen outside any conditional - these are the "authoritative" IDs
   private final Map<String, Integer> unconditionalIds = new HashMap<>();
-
-  // Depth counter for nested conditionals (text-based: Razor, Twig, PHP, Angular new syntax)
-  private int textConditionalDepth = 0;
-
-  // Depth counter for tag-based conditionals (JSP JSTL)
-  private int tagConditionalDepth = 0;
+  private final TemplateConditionalScopeTracker conditionalScope = new TemplateConditionalScopeTracker();
 
   @Override
   public void startDocument(List<Node> nodes) {
     unconditionalIds.clear();
-    textConditionalDepth = 0;
-    tagConditionalDepth = 0;
+    conditionalScope.reset();
   }
 
   @Override
   public void characters(TextNode textNode) {
-    updateTextConditionalDepth(textNode.getCode(), textNode.getCode());
+    conditionalScope.visitText(textNode);
   }
 
   @Override
   public void directive(DirectiveNode directiveNode) {
-    String code = directiveNode.getCode();
-    updateTextConditionalDepth(code, unwrapDirective(code));
-  }
-
-  private void updateTextConditionalDepth(String conditionalText, String braceText) {
-    int conditionalStarts = 0;
-    var startMatcher = CONDITIONAL_START_PATTERN.matcher(conditionalText);
-    while (startMatcher.find()) {
-      textConditionalDepth++;
-      conditionalStarts++;
-    }
-
-    var endMatcher = CONDITIONAL_END_PATTERN.matcher(conditionalText);
-    while (endMatcher.find()) {
-      if (textConditionalDepth > 0) {
-        textConditionalDepth--;
-      }
-    }
-
-    if (textConditionalDepth > 0 && braceText.contains("}")) {
-      String trimmed = braceText.trim();
-      boolean isContinuation = CONDITIONAL_CONTINUATION_PATTERN.matcher(trimmed).find();
-      if (conditionalStarts > 0 && !conditionalText.contains("{%")) {
-        int structuralClosingBraces = countStructuralClosingBraces(trimmed);
-        if (isContinuation && structuralClosingBraces > 0) {
-          structuralClosingBraces--;
-        }
-        if (structuralClosingBraces > 0) {
-          textConditionalDepth = Math.max(0, textConditionalDepth - structuralClosingBraces);
-        }
-      } else {
-        int leadingStructuralClosingBraces = countLeadingStructuralClosingBraces(trimmed);
-        if (isContinuation && leadingStructuralClosingBraces > 0) {
-          leadingStructuralClosingBraces--;
-        }
-        if (leadingStructuralClosingBraces > 0) {
-          textConditionalDepth = Math.max(0, textConditionalDepth - leadingStructuralClosingBraces);
-        }
-      }
-    }
-  }
-
-  private static int countStructuralClosingBraces(String text) {
-    int count = 0;
-    boolean inSingleQuote = false;
-    boolean inDoubleQuote = false;
-    boolean inLineComment = false;
-    boolean inBlockComment = false;
-    boolean escaped = false;
-
-    for (int i = 0; i < text.length(); i++) {
-      char current = text.charAt(i);
-      char next = i + 1 < text.length() ? text.charAt(i + 1) : '\0';
-
-      if (inLineComment) {
-        if (current == '\n' || current == '\r') {
-          inLineComment = false;
-        }
-        continue;
-      }
-
-      if (inBlockComment) {
-        if (current == '*' && next == '/') {
-          inBlockComment = false;
-          i++;
-        }
-        continue;
-      }
-
-      if (inSingleQuote) {
-        if (escaped) {
-          escaped = false;
-        } else if (current == '\\') {
-          escaped = true;
-        } else if (current == '\'') {
-          inSingleQuote = false;
-        }
-        continue;
-      }
-
-      if (inDoubleQuote) {
-        if (escaped) {
-          escaped = false;
-        } else if (current == '\\') {
-          escaped = true;
-        } else if (current == '"') {
-          inDoubleQuote = false;
-        }
-        continue;
-      }
-
-      if (current == '/' && next == '*') {
-        inBlockComment = true;
-        i++;
-        continue;
-      }
-
-      if (current == '/' && next == '/') {
-        inLineComment = true;
-        i++;
-        continue;
-      }
-
-      if (current == '#') {
-        inLineComment = true;
-        continue;
-      }
-
-      if (current == '\'') {
-        inSingleQuote = true;
-        continue;
-      }
-
-      if (current == '"') {
-        inDoubleQuote = true;
-        continue;
-      }
-
-      if (current == '}' && next == '}') {
-        i++;
-        continue;
-      }
-
-      if (current == '}') {
-        count++;
-      }
-    }
-    return count;
-  }
-
-  private static int countLeadingStructuralClosingBraces(String text) {
-    int count = 0;
-
-    for (int i = 0; i < text.length();) {
-      char current = text.charAt(i);
-      char next = i + 1 < text.length() ? text.charAt(i + 1) : '\0';
-
-      if (Character.isWhitespace(current)) {
-        i++;
-        continue;
-      }
-
-      if (current == '/' && next == '*') {
-        i += 2;
-        while (i + 1 < text.length() && !(text.charAt(i) == '*' && text.charAt(i + 1) == '/')) {
-          i++;
-        }
-        if (i + 1 >= text.length()) {
-          return count;
-        }
-        i += 2;
-        continue;
-      }
-
-      if (current == '/' && next == '/') {
-        i += 2;
-        while (i < text.length() && text.charAt(i) != '\n' && text.charAt(i) != '\r') {
-          i++;
-        }
-        continue;
-      }
-
-      if (current == '#') {
-        i++;
-        while (i < text.length() && text.charAt(i) != '\n' && text.charAt(i) != '\r') {
-          i++;
-        }
-        continue;
-      }
-
-      if (current == '}' && next == '}') {
-        return count;
-      }
-
-      if (current == '}') {
-        count++;
-        i++;
-        continue;
-      }
-
-      return count;
-    }
-
-    return count;
-  }
-
-  private static String unwrapDirective(String code) {
-    String trimmed = code.trim();
-    if (!trimmed.startsWith("<?") || !trimmed.endsWith("?>")) {
-      return trimmed;
-    }
-
-    trimmed = trimmed.substring(2, trimmed.length() - 2).trim();
-    if (trimmed.toLowerCase(Locale.ROOT).startsWith("php")) {
-      trimmed = trimmed.substring(3).trim();
-    }
-    return trimmed;
+    conditionalScope.visitDirective(directiveNode);
   }
 
   @Override
   public void startElement(TagNode node) {
-    String nodeName = node.getNodeName().toLowerCase(Locale.ROOT);
-
-    // Track JSP JSTL conditional tag depth
-    if (JSTL_CONDITIONAL_TAGS.contains(nodeName)) {
-      tagConditionalDepth++;
-    }
-
-    // Check for ID attribute
-    var idValue = node.getAttribute("id");
-    if (idValue != null && !idValue.isEmpty()) {
-      // Skip dynamic IDs - they will be unique at runtime
-      if (Helpers.isDynamicValue(idValue, getHtmlSourceCode())) {
-        return;
-      }
-
-      boolean inConditional = isInConditional(node);
-
-      if (inConditional) {
-        // Inside a conditional: only check against unconditional IDs
-        if (unconditionalIds.containsKey(idValue)) {
-          createViolation(node,
-            String.format("Duplicate id \"%s\" found. First occurrence was on line %d.",
-              idValue, unconditionalIds.get(idValue)));
-        }
-        // Don't store - IDs in conditionals don't create new "authoritative" entries
-      } else {
-        // Outside conditionals: normal duplicate check and storage
-        if (unconditionalIds.containsKey(idValue)) {
-          createViolation(node,
-            String.format("Duplicate id \"%s\" found. First occurrence was on line %d.",
-              idValue, unconditionalIds.get(idValue)));
-        } else {
-          unconditionalIds.put(idValue, node.getStartLinePosition());
-        }
-      }
-    }
+    conditionalScope.startElement(node);
+    handleIdAttribute(node);
   }
 
   @Override
   public void endElement(TagNode node) {
-    String nodeName = node.getNodeName().toLowerCase(Locale.ROOT);
+    conditionalScope.endElement(node);
+  }
 
-    // Track JSP JSTL conditional tag depth
-    if (JSTL_CONDITIONAL_TAGS.contains(nodeName) && tagConditionalDepth > 0) {
-      tagConditionalDepth--;
+  private void handleIdAttribute(TagNode node) {
+    String idValue = node.getAttribute("id");
+    if (shouldIgnoreId(idValue)) {
+      return;
+    }
+    if (conditionalScope.isInConditional(node)) {
+      reportDuplicateAgainstUnconditionalId(node, idValue);
+    } else {
+      registerUnconditionalId(node, idValue);
     }
   }
 
-  /**
-   * Determines if an element is inside a conditional block.
-   */
-  private boolean isInConditional(TagNode node) {
-    // Check text-based conditional depth (Angular, Razor, Twig, PHP)
-    if (textConditionalDepth > 0) {
-      return true;
-    }
+  private boolean shouldIgnoreId(String idValue) {
+    return idValue == null
+      || idValue.isEmpty()
+      || Helpers.isDynamicValue(idValue, getHtmlSourceCode());
+  }
 
-    // Check tag-based conditional depth (JSP JSTL)
-    if (tagConditionalDepth > 0) {
-      return true;
+  private void reportDuplicateAgainstUnconditionalId(TagNode node, String idValue) {
+    Integer firstOccurrenceLine = unconditionalIds.get(idValue);
+    if (firstOccurrenceLine != null) {
+      createViolation(node, duplicateIdMessage(idValue, firstOccurrenceLine));
     }
+  }
 
-    // Check for Vue conditional attributes on the element itself
-    for (String attr : VUE_CONDITIONAL_ATTRS) {
-      if (node.hasAttribute(attr)) {
-        return true;
-      }
+  private void registerUnconditionalId(TagNode node, String idValue) {
+    Integer firstOccurrenceLine = unconditionalIds.putIfAbsent(idValue, node.getStartLinePosition());
+    if (firstOccurrenceLine != null) {
+      createViolation(node, duplicateIdMessage(idValue, firstOccurrenceLine));
     }
+  }
 
-    // Check for Angular structural directives on the element itself
-    for (String attr : ANGULAR_CONDITIONAL_ATTRS) {
-      if (node.hasAttribute(attr)) {
-        return true;
-      }
-    }
-
-    return false;
+  private static String duplicateIdMessage(String idValue, int firstOccurrenceLine) {
+    return String.format("Duplicate id \"%s\" found. First occurrence was on line %d.",
+      idValue, firstOccurrenceLine);
   }
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheck.java
@@ -19,6 +19,7 @@ package org.sonar.plugins.html.checks.coding;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.api.Helpers;
 import org.sonar.plugins.html.api.TemplateConditionalScopeTracker;
@@ -83,7 +84,7 @@ public class NoDuplicateIDCheck extends AbstractPageCheck {
     }
   }
 
-  private boolean shouldIgnoreId(String idValue) {
+  private boolean shouldIgnoreId(@Nullable String idValue) {
     return idValue == null
       || idValue.isEmpty()
       || Helpers.isDynamicValue(idValue, getHtmlSourceCode());

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/HelpersTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/HelpersTest.java
@@ -50,6 +50,14 @@ class HelpersTest {
   }
 
   @Test
+  void contains_server_side_marker_matches_supported_processing_instructions_only() {
+    assertThat(Helpers.containsServerSideMarker("<?php echo $u; ?>")).isTrue();
+    assertThat(Helpers.containsServerSideMarker("<?= $user ?>")).isTrue();
+    assertThat(Helpers.containsServerSideMarker("<?xml version=\"1.0\"?>")).isFalse();
+    assertThat(Helpers.containsServerSideMarker("<?foo \"bar\" ?>")).isFalse();
+  }
+
+  @Test
   void contains_dynamic_value_returns_false_when_no_marker_present() {
     HtmlSourceCode code = sourceCode("file.html");
     assertThat(Helpers.containsDynamicValue("just a static string", code)).isFalse();

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
@@ -1,0 +1,130 @@
+/*
+ * SonarQube HTML
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.html.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.StringReader;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.sonar.plugins.html.lex.PageLexer;
+import org.sonar.plugins.html.node.DirectiveNode;
+import org.sonar.plugins.html.node.Node;
+import org.sonar.plugins.html.node.TagNode;
+import org.sonar.plugins.html.node.TextNode;
+
+class TemplateConditionalScopeTrackerTest {
+
+  @Test
+  void tracks_php_conditionals_without_leaking_on_literal_braces() {
+    List<Node> nodes = parse("""
+      <?php if (random_int(0, 1)) { ?>
+        <div id="first">Shown</div>
+      <?php } /* } */ else { ?>
+        <div id="second">Fallback</div>
+      <?php } ?>
+      <?php if (random_int(0, 1)) { echo "}"; } ?>
+      <div id="footer">Footer</div>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 2)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 4)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 7)).isFalse();
+  }
+
+  @Test
+  void tracks_angular_brace_based_conditionals() {
+    List<Node> nodes = parse("""
+      @if (gridOptions) {
+        <div id="conditional">Table</div>
+      } @else {
+        <div id="conditional">Fallback</div>
+      }
+      <div id="footer">Footer</div>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 2)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 4)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 6)).isFalse();
+  }
+
+  @Test
+  void tracks_jstl_conditional_tags() {
+    List<Node> nodes = parse("""
+      <c:if test="${cond}">
+        <div id="conditional">Inside</div>
+      </c:if>
+      <div id="footer">Outside</div>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 2)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 4)).isFalse();
+  }
+
+  @Test
+  void treats_conditional_attributes_as_conditional_scopes() {
+    List<Node> nodes = parse("""
+      <div v-if="flag" id="vue">Inside</div>
+      <div *ngIf="flag" id="angular">Inside</div>
+      <div id="plain">Outside</div>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 1)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 2)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 3)).isFalse();
+  }
+
+  private static List<Node> parse(String content) {
+    return new PageLexer().parse(new StringReader(content));
+  }
+
+  private static boolean isConditionalAtLine(List<Node> nodes, String tagName, int startLine) {
+    return isConditional(nodes, findTag(nodes, tagName, startLine));
+  }
+
+  private static boolean isConditional(List<Node> nodes, TagNode target) {
+    TemplateConditionalScopeTracker tracker = new TemplateConditionalScopeTracker();
+    for (Node node : nodes) {
+      if (node instanceof TextNode textNode) {
+        tracker.visitText(textNode);
+      } else if (node instanceof DirectiveNode directiveNode) {
+        tracker.visitDirective(directiveNode);
+      } else if (node instanceof TagNode tagNode) {
+        if (tagNode.isEndElement()) {
+          tracker.endElement(tagNode);
+        } else {
+          tracker.startElement(tagNode);
+          if (tagNode == target) {
+            return tracker.isInConditional(tagNode);
+          }
+        }
+      }
+    }
+    throw new IllegalArgumentException("Target tag was not encountered during scan");
+  }
+
+  private static TagNode findTag(List<Node> nodes, String tagName, int startLine) {
+    return nodes.stream()
+      .filter(TagNode.class::isInstance)
+      .map(TagNode.class::cast)
+      .filter(tag -> !tag.isEndElement())
+      .filter(tag -> tagName.equalsIgnoreCase(tag.getNodeName()))
+      .filter(tag -> tag.getStartLinePosition() == startLine)
+      .findFirst()
+      .orElseThrow(() -> new IllegalArgumentException("No <" + tagName + "> tag at line " + startLine));
+  }
+}

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
@@ -60,10 +60,11 @@ class NoDuplicateIDCheckTest {
         new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocks.phtml"),
         new NoDuplicateIDCheck());
 
-    // IDs in mutually exclusive PHP if/else branches should NOT be flagged
+    // IDs in mutually exclusive PHP if/else branches should NOT be flagged,
+    // and self-contained PHP directives must not leak conditional depth
     // Only the actual duplicate outside conditionals should be flagged
     checkMessagesVerifier.verify(sourceCode.getIssues())
-        .next().atLine(21).withMessage("Duplicate id \"footer\" found. First occurrence was on line 20.")
+        .next().atLine(24).withMessage("Duplicate id \"footer\" found. First occurrence was on line 23.")
         .noMore();
   }
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
@@ -61,10 +61,10 @@ class NoDuplicateIDCheckTest {
         new NoDuplicateIDCheck());
 
     // IDs in mutually exclusive PHP if/else branches should NOT be flagged,
-    // and self-contained PHP directives must not leak conditional depth
+    // and PHP directives/comments with literal braces must not leak conditional depth
     // Only the actual duplicate outside conditionals should be flagged
     checkMessagesVerifier.verify(sourceCode.getIssues())
-        .next().atLine(24).withMessage("Duplicate id \"footer\" found. First occurrence was on line 23.")
+        .next().atLine(31).withMessage("Duplicate id \"footer\" found. First occurrence was on line 30.")
         .noMore();
   }
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
@@ -55,6 +55,19 @@ class NoDuplicateIDCheckTest {
   }
 
   @Test
+  void phpConditionalBlocks() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+        new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocks.phtml"),
+        new NoDuplicateIDCheck());
+
+    // IDs in mutually exclusive PHP if/else branches should NOT be flagged
+    // Only the actual duplicate outside conditionals should be flagged
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+        .next().atLine(21).withMessage("Duplicate id \"footer\" found. First occurrence was on line 20.")
+        .noMore();
+  }
+
+  @Test
   void vueConditionalBlocks() {
     HtmlSourceCode sourceCode = TestHelper.scan(
         new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocks.vue"),

--- a/sonar-html-plugin/src/test/resources/checks/AnchorsHaveContentCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/AnchorsHaveContentCheck.html
@@ -18,3 +18,5 @@
 </a> <!-- malformed on purpose -->
 <a th:href="${ price.provider.path }" th:text="${ price.provider.name }"></a>
 <a th:href="${ price.provider.path }" th:utext="${ price.provider.name }"></a>
+<a v-text="linkLabel"></a>
+<a v-html="linkLabel"></a>

--- a/sonar-html-plugin/src/test/resources/checks/AnchorsHaveContentCheck.php
+++ b/sonar-html-plugin/src/test/resources/checks/AnchorsHaveContentCheck.php
@@ -2,3 +2,4 @@
 <a><?foo "bar" ?></a>                           <!-- Noncompliant -->
 <a><?php echo "Click me"; ?></a>
 <a title="Click me"><?php echo "Click me"; ?></a>
+<?php $linkText = "Click me"; ?><a href="javascript:void(0)"><?= $linkText ?></a>

--- a/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocks.phtml
+++ b/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocks.phtml
@@ -16,6 +16,9 @@
     <div id="summary">Second</div>
 <?php endif; ?>
 
+<!-- Compliant: self-contained PHP conditionals must not leak conditional depth -->
+<?php if (random_int(0, 1)) { $noop = true; } ?>
+
 <!-- Non-compliant: Duplicate IDs outside conditionals -->
 <div id="footer">Footer 1</div>
 <div id="footer">Footer 2</div>

--- a/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocks.phtml
+++ b/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocks.phtml
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+<!-- Compliant: IDs in mutually exclusive PHP if/else branches -->
+<?php if (random_int(0, 1)) { ?>
+    <input type="text" id="test-id" name="customer_id" readonly />
+<?php } else { ?>
+    <input type="text" id="test-id" name="customer_id" readonly />
+<?php } ?>
+
+<!-- Compliant: IDs in alternative PHP syntax branches -->
+<?php if (random_int(0, 1)): ?>
+    <div id="summary">First</div>
+<?php else: ?>
+    <div id="summary">Second</div>
+<?php endif; ?>
+
+<!-- Non-compliant: Duplicate IDs outside conditionals -->
+<div id="footer">Footer 1</div>
+<div id="footer">Footer 2</div>
+
+</body>
+</html>

--- a/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocks.phtml
+++ b/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocks.phtml
@@ -16,8 +16,15 @@
     <div id="summary">Second</div>
 <?php endif; ?>
 
-<!-- Compliant: self-contained PHP conditionals must not leak conditional depth -->
-<?php if (random_int(0, 1)) { $noop = true; } ?>
+<!-- Compliant: self-contained PHP conditionals with literal braces in strings must not leak conditional depth -->
+<?php if (random_int(0, 1)) { echo "}"; } ?>
+
+<!-- Compliant: closing PHP fragments must not treat comment braces as structural -->
+<?php if (random_int(0, 1)) { ?>
+    <div id="message">Shown</div>
+<?php } /* } */ else { ?>
+    <div id="message">Fallback</div>
+<?php } ?>
 
 <!-- Non-compliant: Duplicate IDs outside conditionals -->
 <div id="footer">Footer 1</div>


### PR DESCRIPTION
## Summary

This PR improves template-aware handling for two accessibility/code-quality checks.

- S6827: recognize dynamic/rendered anchor content more generally, including PHP short echo and Vue `v-text` / `v-html` content attributes.
- S7930: treat PHP conditional directives as conditional blocks so duplicate `id` values in mutually exclusive `if` / `else` branches are not reported.

## Details

### S6827

The anchor-content check used a PHP-specific directive special case. This PR switches it to the existing dynamic-content helpers so server-side output markers are handled consistently instead of hard-coding PHP node names.

It also aligns anchor-level content attributes with the existing heading rule by accepting Vue `v-text` and `v-html` as content-producing attributes.

### S7930

The duplicate-id check already handled conditionals expressed in text nodes and template-specific attributes, but PHP `if` / `else` blocks are tokenized as `DirectiveNode`s.

This change extends the conditional-depth tracking to PHP directives, including brace-style `if (...) { } else { }` and alternative `if: ... else: ... endif;` syntax, while preserving the existing behavior for JSP, Vue, Angular, Razor, Twig, and Jinja test cases.

## Tests

- `mvn test "-Dtest=AnchorsHaveContentCheckTest,NoDuplicateIDCheckTest" -pl sonar-html-plugin`

## Community Reports

- https://community.sonarsource.com/t/web-s6827-false-positive-in-web-with-php-short-echo-syntax/183185
- https://community.sonarsource.com/t/web-s7930-flags-conditional-ids-as-duplicates/183176