### PR TITLE
SONARHTML-380 Update rspec

### DIFF
--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S5247.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S5247.html
@@ -1,45 +1,58 @@
-<p>To reduce the risk of cross-site scripting attacks, templating systems, such as <code>Twig</code>, <code>Django</code>, <code>Smarty</code>,
-<code>Groovy's template engine</code>, allow configuration of automatic variable escaping before rendering templates. When escape occurs, characters
-that make sense to the browser (eg: &lt;a&gt;) will be transformed/replaced with escaped/sanitized values (eg: &amp; lt;a&amp; gt; ).</p>
-<p>Auto-escaping is not a magic feature to annihilate all cross-site scripting attacks, it depends on <a
-href="https://twig.symfony.com/doc/3.x/filters/escape.html">the strategy applied</a> and the context, for example a "html auto-escaping" strategy
-(which only transforms html characters into <a href="https://developer.mozilla.org/en-US/docs/Glossary/Entity">html entities</a>) will not be relevant
-when variables are used in a <a href="https://en.wikipedia.org/wiki/HTML_attribute">html attribute</a> because '<code>:</code>' character is not
-escaped and thus an attack as below is possible:</p>
-<pre>
-&lt;a href="{{ myLink }}"&gt;link&lt;/a&gt; // myLink = javascript:alert(document.cookie)
-&lt;a href="javascript:alert(document.cookie)"&gt;link&lt;/a&gt; // JS injection (XSS attack)
-</pre>
-<h2>Ask Yourself Whether</h2>
-<ul>
-  <li>Templates are used to render web content and
-    <ul>
-      <li>dynamic variables in templates come from untrusted locations or are user-controlled inputs</li>
-      <li>there is no local mechanism in place to sanitize or validate the inputs.</li>
-    </ul></li>
-</ul>
-<p>There is a risk if you answered yes to any of those questions.</p>
-<h2>Recommended Secure Coding Practices</h2>
-<p>Enable auto-escaping by default and continue to review the use of inputs in order to be sure that the chosen auto-escaping strategy is the right
-one.</p>
-<h2>Sensitive Code Example</h2>
-<pre>
+<p>Template engines, such as Twig, Django, and Jinja2, provide automatic escaping of template variables to prevent cross-site scripting (XSS) attacks,
+but this protection can be explicitly disabled.</p>
+<h2>Why is this an issue?</h2>
+<p>Template engines provide auto-escaping as a safety mechanism that transforms HTML special characters in variable output before rendering,
+preventing user-controlled input from being interpreted as HTML or JavaScript by the browser. Disabling this protection — through settings like
+<code>autoescape: false</code>, escape-bypass filters like <code>|safe</code>, or equivalent configuration — allows untrusted input to pass through
+unmodified and be executed by the browser as markup or script.</p>
+<h3>What is the potential impact?</h3>
+<p>When auto-escaping is disabled, an attacker who can control the content of template variables can inject malicious HTML or JavaScript into pages
+served to other users. An attacker could steal session tokens, redirect users to phishing pages, or perform unauthorized actions on behalf of the
+victim.</p>
+<h2>How to fix it in Django Templates</h2>
+<h3>Code examples</h3>
+<p>The following examples configure the template engine to disable its auto-escaping feature, allowing template variables to be rendered without HTML
+encoding.</p>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
 &lt;!-- Django templates --&gt;
-&lt;p&gt;{{ variable|safe }}&lt;/p&gt;&lt;!-- Sensitive --&gt;
-{% autoescape off %}&lt;!-- Sensitive --&gt;
-
-&lt;!-- Jinja2 templates --&gt;
-&lt;p&gt;{{ variable|safe }}&lt;/p&gt;&lt;!-- Sensitive --&gt;
-{% autoescape false %}&lt;!-- Sensitive --&gt;
+&lt;p&gt;{{ variable|safe }}&lt;/p&gt;&lt;!-- Noncompliant --&gt;
+{% autoescape off %}&lt;!-- Noncompliant --&gt;
 </pre>
-<h2>See</h2>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+&lt;!-- Django templates --&gt;
+&lt;p&gt;{{ variable }}&lt;/p&gt;
+{% autoescape on %}
+</pre>
+<h2>How to fix it in Jinja</h2>
+<h3>Code examples</h3>
+<p>The following examples configure the template engine to disable its auto-escaping feature, allowing template variables to be rendered without HTML
+encoding.</p>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="2" data-diff-type="noncompliant">
+&lt;!-- Jinja2 templates --&gt;
+&lt;p&gt;{{ variable|safe }}&lt;/p&gt;&lt;!-- Noncompliant --&gt;
+{% autoescape false %}&lt;!-- Noncompliant --&gt;
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="2" data-diff-type="compliant">
+&lt;!-- Jinja2 templates --&gt;
+&lt;p&gt;{{ variable }}&lt;/p&gt;
+{% autoescape true %}
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
 <ul>
-  <li>OWASP - <a href="https://owasp.org/Top10/A03_2021-Injection/">Top 10 2021 Category A3 - Injection</a></li>
   <li><a href="https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md">OWASP Cheat Sheet</a>
   - XSS Prevention Cheat Sheet</li>
-  <li>OWASP - <a href="https://owasp.org/www-project-top-ten/2017/A7_2017-Cross-Site_Scripting_(XSS)">Top 10 2017 Category A7 - Cross-Site Scripting
-  (XSS)</a></li>
+</ul>
+<h3>Standards</h3>
+<ul>
   <li>CWE - <a href="https://cwe.mitre.org/data/definitions/79">CWE-79 - Improper Neutralization of Input During Web Page Generation ('Cross-site
   Scripting')</a></li>
+  <li>OWASP - <a href="https://owasp.org/Top10/A03_2021-Injection/">Top 10 2021 Category A3 - Injection</a></li>
+  <li>OWASP - <a href="https://owasp.org/www-project-top-ten/2017/A7_2017-Cross-Site_Scripting_(XSS)">Top 10 2017 Category A7 - Cross-Site Scripting
+  (XSS)</a></li>
 </ul>
 

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S5247.json
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S5247.json
@@ -1,6 +1,6 @@
 {
-  "title": "Disabling auto-escaping in template engines is security-sensitive",
-  "type": "SECURITY_HOTSPOT",
+  "title": "Auto-escaping in HTML template engines should not be disabled",
+  "type": "VULNERABILITY",
   "code": {
     "impacts": {
       "SECURITY": "MEDIUM"
@@ -8,12 +8,14 @@
     "attribute": "COMPLETE"
   },
   "status": "ready",
+  "quickfix": "unknown",
   "remediation": {
     "func": "Constant\/Issue",
     "constantCost": "5min"
   },
   "tags": [
-    "cwe"
+    "cwe",
+    "former-hotspot"
   ],
   "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-5247",

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S5725.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S5725.html
@@ -1,11 +1,13 @@
-<p>This rule flags remote scripts and resources that are loaded without a cryptographic integrity check.</p>
+<p>This rule flags HTML elements that load statically versioned remote resources without a cryptographic integrity check.</p>
 <h2>Why is this an issue?</h2>
-<p>When a web application loads a script or resource from a remote host without verifying its integrity, it relies entirely on that remote host being
-trustworthy and uncompromised. This rule raises an issue when an HTML <code>&lt;script&gt;</code> tag uses a remote <code>src</code> attribute without
-a corresponding <code>integrity</code> attribute, or when JavaScript code dynamically creates a script element without setting its
-<code>.integrity</code> property.</p>
-<p>Note that downloading an artifact over HTTPS only protects it while in transit. It does not ensure the authenticity or security of the artifact
-itself.</p>
+<p>When a web application loads a script or stylesheet from a remote host without verifying its integrity, it relies entirely on that host being
+trustworthy and uncompromised. HTTPS only protects the resource in transit; it does not guarantee that the content served has not been tampered with
+at the source or by the CDN.</p>
+<p>This rule raises an issue when a <code>&lt;script&gt;</code> tag, a <code>&lt;link rel="stylesheet"&gt;</code> tag, or a dynamically created script
+element loads a resource from a URL whose path contains a recognizable version segment — indicating a static, pinned artifact — but omits the
+<code>integrity</code> attribute. Resources loaded from mutable URLs (such as analytics libraries, payment SDKs, or any endpoint that intentionally
+updates its content without changing its URL) are excluded because Subresource Integrity is structurally incompatible with content that can change at
+any time.</p>
 <h3>What is the potential impact?</h3>
 <p>If the remote source or its CDN is compromised, an attacker can silently replace the artifact with malicious code that executes in every visitor’s
 browser or on the server.</p>
@@ -17,13 +19,14 @@ mine cryptocurrency in the background.</p>
 use the compromised application as a pivot to attack the local network.</p>
 <h2>How to fix it</h2>
 <h3>Code examples</h3>
-<p>The following code does not include an integrity check, which means any change to the remote artifact — whether by its author or an attacker — will
-execute unverified in the application. It also loads the resource from a mutable URL, so an integrity hash alone is not enough: the URL must be pinned
-to a specific version.</p>
+<p>The following code loads a statically versioned resource without an integrity check, meaning any replacement of the artifact — whether by a
+supply-chain compromise or a tampered CDN — will execute unverified in the application.</p>
+<p><code>crossorigin="anonymous"</code> must also be set: without it the browser fetches the script in no-cors mode and cannot verify the response
+body, silently bypassing SRI.</p>
 <h4>Noncompliant code example</h4>
 <pre data-diff-id="1" data-diff-type="noncompliant">
 &lt;script
-    src="https://cdn.example.com/latest/script.js"
+    src="https://cdn.example.com/v5.3.6/script.js"
     crossorigin="anonymous"
 &gt;&lt;/script&gt; &lt;!-- Noncompliant --&gt;
 </pre>

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S7071.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S7071.html
@@ -22,10 +22,8 @@ potential financial and reputational losses.</p>
 <h2>How to fix it</h2>
 <h3>Code examples</h3>
 <h4>Noncompliant code example</h4>
-<p>Setting the <code>sandbox</code> property of <code>webPreferences</code> to false, adding the <code>nodeintegration</code> attribute, or enabling
-<code>nodeIntegration</code> in <code>webPreferences</code> will result in a webview that will not be sandboxed. For the <code>&lt;webview&gt;</code> tag,
-<code>nodeintegration</code> is a boolean attribute, so its presence enables Node.js integration even when written as
-<code>nodeintegration="false"</code>. Electron also treats a bare <code>nodeIntegration</code> entry in <code>webpreferences</code> as enabled.</p>
+<p>Setting the <code>sandbox</code> property of <code>webPreferences</code> to false or setting <code>nodeIntegration</code> to true will result in a
+webview that will not be sandboxed.</p>
 <pre data-diff-id="11" data-diff-type="noncompliant">
 &lt;webview
     src="https://example.com/index.html"
@@ -44,6 +42,7 @@ potential financial and reputational losses.</p>
 <pre data-diff-id="11" data-diff-type="compliant">
 &lt;webview
     src="https://example.com/index.html"
+    nodeintegration="false"
     &gt;
 &lt;/webview&gt;
 </pre>
@@ -55,9 +54,8 @@ potential financial and reputational losses.</p>
 &lt;/webview&gt;
 </pre>
 <h3>How does this work?</h3>
-<p>In the compliant examples <code>sandbox</code> is explicitly set to its secure value, the <code>nodeintegration</code> attribute is omitted, and
-<code>nodeIntegration</code> is not enabled in <code>webPreferences</code>. It is also sufficient to not set any of these properties since they will
-default to secure values.</p>
+<p>In the compliant examples <code>sandbox</code> or <code>nodeIntegration</code> are explicitly set to their secure value. It is also sufficient to
+not set any of these properties since they will default to secure values.</p>
 <h2>Resources</h2>
 <h3>Documentation</h3>
 <ul>
@@ -69,3 +67,4 @@ default to secure values.</p>
   process sandboxing</a></li>
   <li>Electron Documentation - <a href="https://www.electronjs.org/docs/latest/api/webview-tag#nodeintegration">Webview tag - nodeintegration</a></li>
 </ul>
+

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S8699.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S8699.html
@@ -1,12 +1,12 @@
 <h2>Why is this an issue?</h2>
-<p>When a <code>&lt;form&gt;</code> tag omits its <code>method</code> attribute, browsers submit it with <code>GET</code> by default.
-That behavior is well defined, but it makes the form's intent implicit.</p>
-<p>Empty or invalid <code>method</code> values are also problematic because HTML falls back to <code>GET</code> for them.
-This can make the markup misleading: the source code looks intentional, but the browser will not use the declared method.</p>
+<p>When a <code>&lt;form&gt;</code> tag omits its <code>method</code> attribute, browsers submit it with <code>GET</code> by default. That behavior is
+well defined, but it makes the form’s intent implicit.</p>
+<p>Empty or invalid <code>method</code> values are also problematic because HTML falls back to <code>GET</code> for them. This can make the markup
+misleading: the source code looks intentional, but the browser will not use the declared method.</p>
 <p>Using an explicit valid method makes form behavior easier to understand and avoids accidental fallback to <code>GET</code>.</p>
 <h2>How to fix it</h2>
-<p>Add a <code>method</code> attribute to each <code>&lt;form&gt;</code> tag and use one of the HTML-valid values:
-<code>get</code>, <code>post</code>, or <code>dialog</code>.</p>
+<p>Add a <code>method</code> attribute to each <code>&lt;form&gt;</code> tag and use one of the HTML-valid values: <code>get</code>,
+<code>post</code>, or <code>dialog</code>.</p>
 <h3>Code examples</h3>
 <h4>Noncompliant code example</h4>
 <pre data-diff-id="1" data-diff-type="noncompliant">
@@ -38,3 +38,4 @@ This can make the markup misleading: the source code looks intentional, but the 
   <li>MDN - <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#method">The <code>form</code> element:
   <code>method</code></a></li>
 </ul>
+

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S8699.json
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S8699.json
@@ -1,5 +1,5 @@
 {
-  "title": "\"<form>\" tags should have an explicit valid \"method\" attribute",
+  "title": "\"\u003cform\u003e\" tags should have an explicit valid \"method\" attribute",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {
@@ -13,7 +13,6 @@
   "ruleSpecification": "RSPEC-8699",
   "sqKey": "S8699",
   "scope": "Main",
-  "defaultQualityProfiles": [],
   "quickfix": "unknown",
   "code": {
     "impacts": {

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/HtmlRulesDefinitionTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/HtmlRulesDefinitionTest.java
@@ -50,7 +50,7 @@ class HtmlRulesDefinitionTest {
 
     RulesDefinition.Rule hotspotsRule = repository.rule("S5247");
     assertThat(hotspotsRule).isNotNull();
-    assertThat(hotspotsRule.type()).isEqualTo(RuleType.SECURITY_HOTSPOT);
+    assertThat(hotspotsRule.type()).isEqualTo(RuleType.VULNERABILITY);
 
     Set<String> templateRules = repository.rules().stream()
       .filter(RulesDefinition.Rule::template)

--- a/sonarpedia.json
+++ b/sonarpedia.json
@@ -3,7 +3,7 @@
   "languages": [
     "HTML"
   ],
-  "latest-update": "2026-04-27T09:03:43.307418Z",
+  "latest-update": "2026-06-09T15:12:04.282063400Z",
   "options": {
     "no-language-in-filenames": true,
     "preserve-filenames": true


### PR DESCRIPTION
----
## Summary by Gitar

- **Rule enhancements:**
  - Promoted `S5247` from `SECURITY_HOTSPOT` to `VULNERABILITY` and added `former-hotspot` tag.
  - Refined rule descriptions for `S5247`, `S5725`, `S7071`, and `S8699` for clarity.
- **Configuration updates:**
  - Removed `defaultQualityProfiles` from `S8699` metadata.
  - Updated `S8699` title formatting in JSON.
- **Testing:**
  - Updated `HtmlRulesDefinitionTest.java` to reflect the rule type promotion for `S5247`.

<sub>This will update automatically on new commits.</sub>