### PR TITLE
SONARHTML-391 Fix build number reuse across downstream CI jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ permissions:
 jobs:
   build:
     runs-on: github-ubuntu-latest-m
+    outputs:
+      build_number: ${{ steps.build_maven.outputs.BUILD_NUMBER }}
     steps:
       - &checkout
         name: Checkout source code
@@ -29,7 +31,8 @@ jobs:
           version: 2025.7.12
       - &maven_cache
         uses: ./.github/actions/maven-cache
-      - uses: SonarSource/ci-github-actions/build-maven@v1
+      - id: build_maven
+        uses: SonarSource/ci-github-actions/build-maven@v1
         with:
           deploy-pull-request: true
           artifactory-reader-role: private-reader
@@ -40,6 +43,8 @@ jobs:
   build-windows:
     needs: [build]
     runs-on: windows-latest
+    env:
+      BUILD_NUMBER: ${{ needs.build.outputs.build_number }}
     steps:
       - *checkout
       - *mise
@@ -57,6 +62,8 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     needs: [build]
     runs-on: github-ubuntu-latest-m
+    env:
+      BUILD_NUMBER: ${{ needs.build.outputs.build_number }}
     permissions:
       id-token: write
       contents: read
@@ -91,6 +98,8 @@ jobs:
     if: github.event_name == 'schedule'
     needs: [build]
     runs-on: github-ubuntu-latest-m
+    env:
+      BUILD_NUMBER: ${{ needs.build.outputs.build_number }}
     permissions:
       id-token: write
       contents: read
@@ -110,6 +119,8 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     needs: [build]
     runs-on: github-ubuntu-latest-m
+    env:
+      BUILD_NUMBER: ${{ needs.build.outputs.build_number }}
     permissions:
       id-token: write
       contents: write
@@ -225,6 +236,8 @@ jobs:
     if: github.event_name == 'schedule'
     needs: [build]
     runs-on: github-ubuntu-latest-s
+    env:
+      BUILD_NUMBER: ${{ needs.build.outputs.build_number }}
     strategy:
       matrix:
         include:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         name: Checkout source code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - &mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2025.7.12
       - &maven_cache


### PR DESCRIPTION
build should be the single source of truth for BUILD_NUMBER.

This workflow now exposes the BUILD_NUMBER from the main build job and injects it into downstream jobs so config-maven/get-build-number reuse the same version.

That avoids qa, ruling, and shadow analysis resolving a different artifact version than the one published by build.