### PR TITLE
SONARHTML-395 Handle template-generated labels in S6853

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Thymeleaf.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Thymeleaf.java
@@ -18,6 +18,10 @@ package org.sonar.plugins.html.api;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.sonar.plugins.html.node.Attribute;
 import org.sonar.plugins.html.node.TagNode;
 
 /**
@@ -32,7 +36,27 @@ import org.sonar.plugins.html.node.TagNode;
  */
 public final class Thymeleaf {
 
+  /**
+   * Attributes that ask Thymeleaf to render an external fragment in place of (or inside) the
+   * current element. Statically, the resulting markup is opaque — the rendered fragment can
+   * supply text, controls, or both — so checks should treat these as "do not flag".
+   */
+  public static final Set<String> FRAGMENT_INSERTION_ATTRIBUTES = Set.of("th:insert", "th:include", "th:replace");
+
   private Thymeleaf() {
+  }
+
+  /**
+   * Returns whether the node carries any Thymeleaf fragment-insertion attribute
+   * ({@code th:insert}, {@code th:include}, {@code th:replace}).
+   */
+  public static boolean hasFragmentInsertion(TagNode node) {
+    for (Attribute attribute : node.getAttributes()) {
+      if (FRAGMENT_INSERTION_ATTRIBUTES.contains(attribute.getName().toLowerCase(Locale.ROOT))) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**
@@ -82,6 +106,33 @@ public final class Thymeleaf {
       return value.substring(1, value.length() - 1).trim().isEmpty();
     }
     return false;
+  }
+
+  /**
+   * Returns whether the raw attribute value is absent, blank, or a quoted literal that resolves
+   * to whitespace. Combines a null/blank check with {@link #isEmptyAssignmentValue(String)} so
+   * callers do not have to trim and null-check separately.
+   */
+  public static boolean isEmptyValue(@Nullable String value) {
+    if (value == null) {
+      return true;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() || isEmptyAssignmentValue(trimmed);
+  }
+
+  /**
+   * Returns whether the node sets {@code attributeName} via either the literal {@code th:NAME}
+   * attribute or a {@code th:attr=NAME=...} assignment, with a non-empty value. This is the
+   * Thymeleaf-only counterpart used to enrich attribute-presence checks; combine it with a
+   * plain property lookup at the call site when both forms should be accepted.
+   */
+  public static boolean hasNonEmptyThymeleafAttribute(TagNode node, String attributeName) {
+    String literalValue = node.getAttribute("th:" + attributeName.toLowerCase(Locale.ROOT));
+    if (!isEmptyValue(literalValue)) {
+      return true;
+    }
+    return !isEmptyValue(getAttrAssignmentValue(node, attributeName));
   }
 
   private static List<String> splitAssignments(String thAttrValue) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtils.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtils.java
@@ -16,14 +16,36 @@
  */
 package org.sonar.plugins.html.api.accessibility;
 
+import java.util.Set;
+import org.sonar.plugins.html.api.Thymeleaf;
 import org.sonar.plugins.html.node.TagNode;
 
 import static org.sonar.plugins.html.api.HtmlConstants.isInteractiveElement;
 
 public class AccessibilityUtils {
 
+  /**
+   * Attributes that template engines use to inject text content into an element at render time:
+   * Thymeleaf {@code th:text}/{@code th:utext} and Vue {@code v-text}/{@code v-html}. Centralized
+   * here so accessibility checks that ask "does this element get its text from a template?" all
+   * see the same definition.
+   */
+  public static final Set<String> TEMPLATE_TEXT_ATTRIBUTES = Set.of("th:text", "th:utext", "v-text", "v-html");
+
   private AccessibilityUtils() {
     // utility class
+  }
+
+  /**
+   * Returns whether {@code element} carries any template-text attribute with a usable value.
+   */
+  public static boolean hasNonEmptyTemplateTextAttribute(TagNode element) {
+    for (String attributeName : TEMPLATE_TEXT_ATTRIBUTES) {
+      if (!Thymeleaf.isEmptyValue(element.getAttribute(attributeName))) {
+        return true;
+      }
+    }
+    return false;
   }
 
   public static boolean isHiddenFromScreenReader(TagNode element) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheck.java
@@ -26,6 +26,7 @@ import org.sonar.plugins.html.node.ExpressionNode;
 import org.sonar.plugins.html.node.TagNode;
 import org.sonar.plugins.html.node.TextNode;
 
+import static org.sonar.plugins.html.api.accessibility.AccessibilityUtils.hasNonEmptyTemplateTextAttribute;
 import static org.sonar.plugins.html.api.accessibility.AccessibilityUtils.isHiddenFromScreenReader;
 
 @Rule(key = "S6827")
@@ -113,7 +114,7 @@ public class AnchorsHaveContentCheck extends AbstractPageCheck {
         return true;
       }
     }
-    return element.hasProperty("title") || element.hasProperty("aria-label") || element.hasAttribute("th:text")
-       || element.hasAttribute("th:utext") || element.hasAttribute("v-text") || element.hasAttribute("v-html");
+    return element.hasProperty("title") || element.hasProperty("aria-label")
+      || hasNonEmptyTemplateTextAttribute(element);
   }
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/HeadingHasAccessibleContentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/HeadingHasAccessibleContentCheck.java
@@ -19,6 +19,8 @@ package org.sonar.plugins.html.checks.accessibility;
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.api.Helpers;
 import org.sonar.plugins.html.api.BufferStack;
+import org.sonar.plugins.html.api.Thymeleaf;
+import org.sonar.plugins.html.api.accessibility.AccessibilityUtils;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
 import org.sonar.plugins.html.node.DirectiveNode;
 import org.sonar.plugins.html.node.ExpressionNode;
@@ -36,11 +38,6 @@ import static org.sonar.plugins.html.api.HtmlConstants.hasKnownHTMLTag;
 public class HeadingHasAccessibleContentCheck extends AbstractPageCheck {
   private final List<String> invalidAttributes = List.of(
     "aria-hidden"
-  );
-
-  private final List<String> vueJsContentLikeAttributes = List.of(
-    "v-html",
-    "v-text"
   );
 
   private final BufferStack bufferStack = new BufferStack();
@@ -65,11 +62,11 @@ public class HeadingHasAccessibleContentCheck extends AbstractPageCheck {
       }
     }
 
-    // vueJS attributes that maps to content are considered as content
-    vueJsContentLikeAttributes.forEach(attributeName -> {
+    // template-text attributes (Thymeleaf th:text/th:utext, Vue v-text/v-html) are content
+    AccessibilityUtils.TEMPLATE_TEXT_ATTRIBUTES.forEach(attributeName -> {
       String nodeAttribute = node.getAttribute(attributeName);
 
-      if (nodeAttribute != null && !nodeAttribute.isBlank() && bufferStack.getLevel() > 0) {
+      if (!Thymeleaf.isEmptyValue(nodeAttribute) && bufferStack.getLevel() > 0) {
         bufferStack.write(nodeAttribute);
       }
     });

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheck.java
@@ -21,8 +21,11 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
 import org.sonar.check.Rule;
+import org.sonar.plugins.html.api.Helpers;
+import org.sonar.plugins.html.api.Thymeleaf;
+import org.sonar.plugins.html.api.accessibility.AccessibilityUtils;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
-import org.sonar.plugins.html.node.CommentNode;
+import org.sonar.plugins.html.node.Attribute;
 import org.sonar.plugins.html.node.DirectiveNode;
 import org.sonar.plugins.html.node.ExpressionNode;
 import org.sonar.plugins.html.node.Node;
@@ -59,9 +62,14 @@ public class LabelHasAssociatedControlCheck extends AbstractPageCheck {
   public void startElement(TagNode node) {
     if (isLabel(node)) {
       label = node;
-      foundControl = hasForAttribute(label);
-      foundAccessibleLabel = false;
+      foundControl = hasControlAssociationHint(label);
+      foundAccessibleLabel = hasAccessibleTextHint(label);
       foundLabelBodyContent = false;
+      // A fragment-rendered label is opaque to static analysis — accept both axes.
+      if (Thymeleaf.hasFragmentInsertion(label)) {
+        foundControl = true;
+        foundAccessibleLabel = true;
+      }
     } else {
       if (label != null) {
         foundLabelBodyContent = true;
@@ -69,32 +77,53 @@ public class LabelHasAssociatedControlCheck extends AbstractPageCheck {
       if (isControl(node)) {
         foundControl = true;
       }
-    }
-    if (hasAccessibleLabel(node)) {
-      foundAccessibleLabel = true;
+      if (label != null && hasAccessibleTextHint(node)) {
+        foundAccessibleLabel = true;
+      }
+      // Razor view-component or <partial> child can supply both text and control.
+      if (label != null && Helpers.isRazorFile(getHtmlSourceCode()) && Helpers.isRazorFragmentTagHelper(node)) {
+        foundControl = true;
+        foundAccessibleLabel = true;
+      }
     }
   }
 
-  private static boolean hasForAttribute(TagNode label) {
-    return label.hasProperty("for") ||
-           label.hasProperty("htmlFor") ||
-           // Angular binding
-           label.hasProperty("[for]") ||
-           // Vue shorthand binding
-           label.hasProperty(":for") ||
-           // Vue full binding syntax
-           label.hasProperty("v-bind:for") ||
-           // ASP.NET Core Tag Helper
-           label.hasProperty("asp-for");
+  private static boolean hasControlAssociationHint(TagNode label) {
+    return hasPropertyHint(label, "for")
+      || hasPropertyHint(label, "htmlFor")
+      || hasAttributeHint(label, "asp-for")
+      || Thymeleaf.hasNonEmptyThymeleafAttribute(label, "for");
   }
 
-  private static boolean hasAccessibleLabel(TagNode node) {
-    return
-      node.hasProperty("alt") ||
-      node.hasProperty("aria-labelledby") ||
-      node.hasProperty("aria-label") ||
+  private static boolean hasAccessibleTextHint(TagNode node) {
+    return hasPropertyHint(node, "alt")
+      || hasPropertyHint(node, "aria-labelledby")
+      || hasPropertyHint(node, "aria-label")
+      // Angular [innerText]/[innerHTML]/[textContent] write text content at runtime.
+      || hasPropertyHint(node, "innerText")
+      || hasPropertyHint(node, "innerHTML")
+      || hasPropertyHint(node, "textContent")
+      // Thymeleaf th:aria-label / th:attr="aria-label=..." (and aria-labelledby/alt variants).
+      || Thymeleaf.hasNonEmptyThymeleafAttribute(node, "aria-label")
+      || Thymeleaf.hasNonEmptyThymeleafAttribute(node, "aria-labelledby")
+      || Thymeleaf.hasNonEmptyThymeleafAttribute(node, "alt")
+      || AccessibilityUtils.hasNonEmptyTemplateTextAttribute(node)
       // see https://sonarsource.github.io/rspec/#/rspec/S1926
-      "FMT:MESSAGE".equalsIgnoreCase(node.getNodeName());
+      || "FMT:MESSAGE".equalsIgnoreCase(node.getNodeName());
+  }
+
+  // Property lookup that accepts Angular/Vue binding forms even with empty value — the binding name itself is the hint.
+  private static boolean hasPropertyHint(TagNode node, String propertyName) {
+    Attribute property = node.getProperty(propertyName);
+    return property != null && (isBindingForm(property, propertyName) || !Thymeleaf.isEmptyValue(property.getValue()));
+  }
+
+  private static boolean hasAttributeHint(TagNode node, String attributeName) {
+    return !Thymeleaf.isEmptyValue(node.getAttribute(attributeName));
+  }
+
+  private static boolean isBindingForm(Attribute attribute, String canonicalName) {
+    return !canonicalName.equalsIgnoreCase(attribute.getName());
   }
 
   private static boolean isLabel(TagNode node) {
@@ -116,13 +145,11 @@ public class LabelHasAssociatedControlCheck extends AbstractPageCheck {
       if (RAZOR_CONTROL_PATTERN.matcher(textNode.getCode()).find()) {
         foundControl = true;
       }
-    }
-  }
-
-  @Override
-  public void comment(CommentNode node) {
-    if (label != null) {
-      foundLabelBodyContent = true;
+      // Razor fragment rendering (@Html.PartialAsync, @RenderBody, ...) is opaque.
+      if (Helpers.isRazorFile(getHtmlSourceCode()) && Helpers.containsRazorFragmentRendering(textNode.getCode())) {
+        foundControl = true;
+        foundAccessibleLabel = true;
+      }
     }
   }
 
@@ -146,7 +173,7 @@ public class LabelHasAssociatedControlCheck extends AbstractPageCheck {
   @Override
   public void endElement(TagNode node) {
     if (isLabel(node)) {
-      if (label != null && label.hasProperty("asp-for") && !foundLabelBodyContent) {
+      if (label != null && hasAttributeHint(label, "asp-for") && !foundLabelBodyContent) {
         foundAccessibleLabel = true;
       }
       if ((!foundAccessibleLabel || !foundControl) && label != null) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ImgWithoutAltCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ImgWithoutAltCheck.java
@@ -16,7 +16,6 @@
  */
 package org.sonar.plugins.html.checks.sonar;
 
-import java.util.Locale;
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.api.Thymeleaf;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
@@ -99,14 +98,7 @@ public class ImgWithoutAltCheck extends AbstractPageCheck {
     if (value != null && !value.trim().isEmpty()) {
       return true;
     }
-
-    String thymeleafValue = node.getAttribute("th:" + attributeName.toLowerCase(Locale.ROOT));
-    if (thymeleafValue != null) {
-      return !Thymeleaf.isEmptyAssignmentValue(thymeleafValue.trim());
-    }
-
-    String thymeleafAssignedValue = Thymeleaf.getAttrAssignmentValue(node, attributeName);
-    return thymeleafAssignedValue != null && !Thymeleaf.isEmptyAssignmentValue(thymeleafAssignedValue);
+    return Thymeleaf.hasNonEmptyThymeleafAttribute(node, attributeName);
   }
 
   /**

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheck.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.api.Helpers;
+import org.sonar.plugins.html.api.Thymeleaf;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
 import org.sonar.plugins.html.node.Attribute;
 import org.sonar.plugins.html.node.Node;
@@ -31,8 +32,6 @@ import org.sonar.plugins.html.node.TextNode;
 
 @Rule(key = "S5256")
 public class TableWithoutHeaderCheck extends AbstractPageCheck {
-
-  private static final Set<String> THYMELEAF_FRAGMENT_INSERTION_KEYWORDS = Set.of("th:insert", "th:include", "th:replace");
 
   private final Set<TagNode> tablesWithRazorFragmentRendering = new HashSet<>();
 
@@ -127,7 +126,7 @@ public class TableWithoutHeaderCheck extends AbstractPageCheck {
 
   private static boolean hasThymeleafFragmentInsertionFromTableChildren(List<TagNode> nodes) {
     for (TagNode node : nodes) {
-      if (node.getAttributes().stream().map(Attribute::getName).anyMatch(THYMELEAF_FRAGMENT_INSERTION_KEYWORDS::contains)
+      if (node.getAttributes().stream().map(Attribute::getName).anyMatch(Thymeleaf.FRAGMENT_INSERTION_ATTRIBUTES::contains)
         || hasThymeleafFragmentInsertionFromTableChildren(node.getChildren())) {
         return true;
       }

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S6853.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S6853.html
@@ -21,7 +21,21 @@
   <li><code>&lt;textarea&gt;</code></li>
 </ul>
 <h3>Exceptions</h3>
-<p>Custom components may contain control elements, therefore label elements containing custom elements do not raise issues.</p>
+<p>This rule accepts some server-side and template constructs when they generate the association, the label text, or the control at runtime.</p>
+<ul>
+  <li><code>&lt;label asp-for="..."&gt;</code> counts as an explicit association. If its body is empty or whitespace-only, ASP.NET Core generates the
+  label text.</li>
+  <li>Angular, Vue, and Thymeleaf bindings that generate the association or the accessible text are accepted, for example <code>[for]</code>,
+  <code>:for</code>, <code>v-bind:for</code>, <code>[innerText]</code>, <code>[innerHTML]</code>, <code>[textContent]</code>, <code>v-text</code>,
+  <code>v-html</code>, <code>th:for</code>, <code>th:text</code>, <code>th:utext</code>, and <code>th:attr</code> assignments to <code>for</code>,
+  <code>aria-label</code>, or <code>aria-labelledby</code>.</li>
+  <li>Razor helpers and fragment renderers that are opaque to static analysis are accepted, including <code>@Html.TextBoxFor(...)</code> and related
+  form helpers, <code>&lt;partial&gt;</code>, <code>&lt;vc:...&gt;</code>, <code>@await Html.PartialAsync(...)</code>, <code>@{ await
+  Html.RenderPartialAsync(...); }</code>, and Thymeleaf fragment insertion with <code>th:insert</code>, <code>th:include</code>, or
+  <code>th:replace</code>.</li>
+  <li>Server-side expressions that generate label text are accepted, for example JSP expressions or directives, PHP expressions, and
+  <code>&lt;fmt:message&gt;</code>.</li>
+</ul>
 <h2>How to fix it</h2>
 <p>Make sure the <code>&lt;label&gt;</code> has text that describes the control.</p>
 <p>An implicit association wraps the control element inside the <code>&lt;label&gt;</code>. An explicit association keeps the label and control
@@ -40,18 +54,14 @@ control element, add one.</p>
 </pre>
 <h4>Compliant solution</h4>
 <pre data-diff-id="1" data-diff-type="compliant">
-&lt;!-- Label with text --&gt;
+&lt;!-- Explicit association --&gt;
 &lt;label for="favorite-sport"&gt;Favorite sport&lt;/label&gt;
 &lt;input id="favorite-sport" type="text" /&gt;
 
-&lt;!-- Explicit association --&gt;
-&lt;label for="favorite-food"&gt;Favorite food&lt;/label&gt;
-&lt;input id="favorite-food" type="text" /&gt;
-
 &lt;!-- Implicit association --&gt;
 &lt;label&gt;
-    Favorite place
-    &lt;input id="favorite-place" type="text" /&gt;
+    Favorite food
+    &lt;input id="favorite-food" type="text" /&gt;
 &lt;/label&gt;
 </pre>
 <h2>Resources</h2>

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/ThymeleafTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/ThymeleafTest.java
@@ -106,6 +106,55 @@ class ThymeleafTest {
     assertThat(Thymeleaf.isEmptyAssignmentValue("foo")).isFalse();
   }
 
+  @Test
+  void isEmptyValue_nullOrBlank() {
+    assertThat(Thymeleaf.isEmptyValue(null)).isTrue();
+    assertThat(Thymeleaf.isEmptyValue("")).isTrue();
+    assertThat(Thymeleaf.isEmptyValue("   ")).isTrue();
+  }
+
+  @Test
+  void isEmptyValue_emptyQuotedLiteralWithPadding() {
+    assertThat(Thymeleaf.isEmptyValue(" '' ")).isTrue();
+    assertThat(Thymeleaf.isEmptyValue("\"  \"")).isTrue();
+  }
+
+  @Test
+  void isEmptyValue_nonEmptyValues() {
+    assertThat(Thymeleaf.isEmptyValue("foo")).isFalse();
+    assertThat(Thymeleaf.isEmptyValue("'foo'")).isFalse();
+    assertThat(Thymeleaf.isEmptyValue("#{logo}")).isFalse();
+  }
+
+  @Test
+  void hasNonEmptyThymeleafAttribute_returnsFalse_whenNeitherFormIsPresent() {
+    assertThat(Thymeleaf.hasNonEmptyThymeleafAttribute(tagWithoutThAttr(), "alt")).isFalse();
+  }
+
+  @Test
+  void hasNonEmptyThymeleafAttribute_returnsTrue_whenLiteralIsSet() {
+    TagNode node = new TagNode();
+    node.getAttributes().add(new Attribute("th:alt", "#{logo}"));
+    assertThat(Thymeleaf.hasNonEmptyThymeleafAttribute(node, "alt")).isTrue();
+  }
+
+  @Test
+  void hasNonEmptyThymeleafAttribute_returnsFalse_whenLiteralIsEmpty() {
+    TagNode node = new TagNode();
+    node.getAttributes().add(new Attribute("th:alt", "''"));
+    assertThat(Thymeleaf.hasNonEmptyThymeleafAttribute(node, "alt")).isFalse();
+  }
+
+  @Test
+  void hasNonEmptyThymeleafAttribute_returnsTrue_whenAssignedViaThAttr() {
+    assertThat(Thymeleaf.hasNonEmptyThymeleafAttribute(tagWithThAttr("alt=#{logo}"), "alt")).isTrue();
+  }
+
+  @Test
+  void hasNonEmptyThymeleafAttribute_returnsFalse_whenAssignmentIsEmpty() {
+    assertThat(Thymeleaf.hasNonEmptyThymeleafAttribute(tagWithThAttr("alt=''"), "alt")).isFalse();
+  }
+
   private static TagNode tagWithThAttr(String thAttrValue) {
     TagNode node = new TagNode();
     node.getAttributes().add(new Attribute("th:attr", thAttrValue));

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/HeadingHasAccessibleContentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/HeadingHasAccessibleContentCheckTest.java
@@ -51,7 +51,10 @@ class HeadingHasAccessibleContentCheckTest {
       .next().atLine(34)
       .next().atLine(37)
       .next().atLine(43)
-      .next().atLine(72);
+      .next().atLine(72)
+      .next().atLine(97)
+      .next().atLine(98)
+      .noMore();
   }
 
   @Test

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheckTest.java
@@ -40,6 +40,7 @@ class LabelHasAssociatedControlCheckTest {
       .next().atLine(9)
       .next().atLine(11)
       .next().atLine(16)
+      .next().atLine(30)
       .noMore();
   }
 
@@ -57,6 +58,8 @@ class LabelHasAssociatedControlCheckTest {
       .next().atLine(10)
       .next().atLine(12)
       .next().atLine(14)
+      .next().atLine(15)
+      .next().atLine(16)
       .noMore();
   }
 
@@ -111,7 +114,24 @@ class LabelHasAssociatedControlCheckTest {
     checkMessagesVerifier.verify(sourceCode.getIssues())
             .next().atLine(11).withMessage("A form label must be associated with a control and have accessible text.")
             .next().atLine(12)
-            .next().atLine(13)
+            .noMore();
+  }
+
+  @Test
+  void templateGeneratedLabels() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+            new File("src/test/resources/checks/LabelHasAssociatedControlCheck/templateGenerated.html"),
+            new LabelHasAssociatedControlCheck());
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+            .next().atLine(18).withMessage("A form label must be associated with a control and have accessible text.")
+            .next().atLine(21)
+            .next().atLine(22)
+            .next().atLine(25)
+            .next().atLine(26)
+            .next().atLine(29)
+            .next().atLine(30)
+            .next().atLine(33)
+            .next().atLine(34)
             .noMore();
   }
 

--- a/sonar-html-plugin/src/test/resources/checks/HeadingHasAccessibleContentCheck/file.html
+++ b/sonar-html-plugin/src/test/resources/checks/HeadingHasAccessibleContentCheck/file.html
@@ -90,3 +90,9 @@
 </h1>
 
 <h7></h7> <!-- Compliant: out of scope -->
+
+<h1 th:text="#{title}"></h1>  <!-- Compliant: Thymeleaf renders text at runtime -->
+<h1 th:utext="#{title}"></h1> <!-- Compliant: Thymeleaf renders unescaped text at runtime -->
+
+<h1 th:text="''"></h1>       <!-- Noncompliant: empty Thymeleaf text renders no heading content -->
+<h1 th:utext="'  '"></h1>   <!-- Noncompliant: blank Thymeleaf text renders no heading content -->

--- a/sonar-html-plugin/src/test/resources/checks/LabelHasAssociatedControlCheck/aspFor.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/LabelHasAssociatedControlCheck/aspFor.cshtml
@@ -10,4 +10,6 @@
 <!-- Noncompliant: non-empty body suppresses the generated label text -->
 <label asp-for="ModelProperty"><input asp-for="ModelProperty" /></label>
 <label asp-for="ModelProperty"><span></span></label>
+
+<!-- Compliant: an HTML comment is not body content; Razor still generates the label text -->
 <label asp-for="ModelProperty"><!-- comment --></label>

--- a/sonar-html-plugin/src/test/resources/checks/LabelHasAssociatedControlCheck/binding.html
+++ b/sonar-html-plugin/src/test/resources/checks/LabelHasAssociatedControlCheck/binding.html
@@ -14,3 +14,8 @@
 <!-- Noncompliant: No for attribute and no nested control -->
 <label>Just text</label>
 <label [class]="someClass">Just text</label>
+
+<!-- Compliant: Angular content-binding properties write label text at runtime -->
+<label [for]="inputId" [innerText]="labelText"></label>
+<label [for]="inputId" [innerHTML]="labelMarkup"></label>
+<label [for]="inputId" [textContent]="labelText"></label>

--- a/sonar-html-plugin/src/test/resources/checks/LabelHasAssociatedControlCheck/for.html
+++ b/sonar-html-plugin/src/test/resources/checks/LabelHasAssociatedControlCheck/for.html
@@ -12,3 +12,5 @@
 <div><label>foo</label><input id="js_id_2" /></div>
 <label htmlFor="js_id">foo</label>
 <label htmlFor="js_id"></label> <!-- Noncompliant -->
+<label for="" alt="foo" /> <!-- Noncompliant: an empty "for" no longer counts as a control association -->
+<label for="   " alt="foo" /> <!-- Noncompliant: whitespace-only is also empty -->

--- a/sonar-html-plugin/src/test/resources/checks/LabelHasAssociatedControlCheck/nesting.html
+++ b/sonar-html-plugin/src/test/resources/checks/LabelHasAssociatedControlCheck/nesting.html
@@ -26,3 +26,5 @@
 <label><select />foo</label>
 <!-- coverage -->
 </label>
+<!-- Razor-looking text in a non-Razor file does not count as a control -->
+<label>@Html.PartialAsync("X")</label> <!-- Noncompliant -->

--- a/sonar-html-plugin/src/test/resources/checks/LabelHasAssociatedControlCheck/razor.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/LabelHasAssociatedControlCheck/razor.cshtml
@@ -15,3 +15,11 @@
 <label>Just text</label>
 <label>@Html.DisplayFor(model => model.Name) Name</label>
 <label>@Html.LabelFor(model => model.Name)</label>
+
+<!-- Compliant: Razor fragment-rendering child tag-helpers are opaque -->
+<label><partial name="MyPartial" /></label>
+<label><vc:my-component /></label>
+
+<!-- Compliant: Razor fragment-rendering expressions are opaque -->
+<label>@await Html.PartialAsync("X")</label>
+<label>@{ await Html.RenderPartialAsync("Y"); }</label>

--- a/sonar-html-plugin/src/test/resources/checks/LabelHasAssociatedControlCheck/templateGenerated.html
+++ b/sonar-html-plugin/src/test/resources/checks/LabelHasAssociatedControlCheck/templateGenerated.html
@@ -1,0 +1,39 @@
+<!-- Compliant: Thymeleaf can generate both the label target and the text -->
+<label th:for="${#ids.prev('title')}" th:text="#{publication.title}"></label>
+
+<!-- Compliant: Thymeleaf th:attr can generate the target and descendants can generate the text -->
+<label th:attr="class='field-label', for=${dynamicId}"><span th:text="#{publication.subtitle}"></span></label>
+
+<!-- Compliant: Thymeleaf th:attr can generate both the target and the accessible-text attribute -->
+<label th:attr="aria-label=#{publication.title}, for=${dynamicId}"></label>
+<label th:attr="aria-labelledby=#{publication.titleId}, for=${dynamicId}"></label>
+<label th:aria-label="#{publication.title}" th:for="${dynamicId}"></label>
+
+<!-- Compliant: Vue text directives generate accessible label text -->
+<label :for="inputId" v-text="labelText"></label>
+<label :for="inputId" v-html="labelMarkup"></label>
+<label v-bind:for="inputId" v-text="labelText"></label>
+
+<!-- Noncompliant: template association without any accessible text -->
+<label th:for="${#ids.prev('title')}"></label>
+
+<!-- Noncompliant: generated text without any control association -->
+<label th:text="#{publication.title}"></label>
+<label v-text="labelText"></label>
+
+<!-- Noncompliant: empty generated text still fails -->
+<label th:for="${#ids.prev('title')}" th:text="''"></label>
+<label th:attr="for=${dynamicId}" th:utext="'  '"></label>
+
+<!-- Noncompliant: th:attr text/utext assignments generate attributes, not element body text -->
+<label th:attr="for=${dynamicId}, text=#{publication.title}"></label>
+<label th:attr="for=${dynamicId}, utext=#{publication.title}"></label>
+
+<!-- Noncompliant: Razor tag-helper children are only opaque in Razor files -->
+<label><partial name="LabelAndControl" /></label>
+<label><vc:label-and-control /></label>
+
+<!-- Compliant: Thymeleaf fragment-insertion attributes make the label content opaque -->
+<label th:insert="~{fragments :: titleLabel}"></label>
+<label th:replace="~{fragments :: titleLabel}"></label>
+<label th:include="~{fragments :: titleLabel}"></label>

--- a/sonarpedia.json
+++ b/sonarpedia.json
@@ -3,7 +3,7 @@
   "languages": [
     "HTML"
   ],
-  "latest-update": "2026-06-09T15:12:04.282063400Z",
+  "latest-update": "2026-07-01T11:23:23.141308Z",
   "options": {
     "no-language-in-filenames": true,
     "preserve-filenames": true


### PR DESCRIPTION
## Summary
Handle `S6853` false positives on template-generated labels by recognizing Razor and Thymeleaf patterns that only resolve at render time.

## Changes
- track whether a Razor `asp-for` label is truly empty before trusting its generated text
- recognize Thymeleaf `th:for` and `th:attr` associations, plus template text attributes such as `th:text`, `th:utext`, `v-text`, and `v-html`
- add regression coverage for empty Razor labels and template-generated label content

## Functional Validation
Artifact: [SONARHTML-395-fv.zip](https://github.com/user-attachments/files/29328351/SONARHTML-395-fv.zip)

Once the file is attached to the PR description, unzip and run:
    ./run.sh

Expected output:
```text
******************* MASTER *******************
Analyzing "razor-empty-label.cshtml"...
Results:
    - Rule "S6853" -> L.1
Analyzing "template-generated-label.html"...
Results:
    - Rule "S6853" -> L.1
    - Rule "S6853" -> L.2

****** Branch "fix/sonarhtml-395-handle-template-generated-labels" ******
Analyzing "razor-empty-label.cshtml"...
Results:
    (none)
Analyzing "template-generated-label.html"...
Results:
    (none)
```

----
## Summary by Gitar

- **Improved template handling:**
  - Integrated `AccessibilityUtils` and `Thymeleaf` helpers to identify dynamic content in `HeadingHasAccessibleContentCheck` and `LabelHasAssociatedControlCheck`.
  - Added support for Angular binding properties `[innerText]`, `[innerHTML]`, and `[textContent]` as valid accessible label text.
  - Updated `LabelHasAssociatedControlCheck` to treat HTML comments as transparent rather than blocking label content.
- **Refined association logic:**
  - Updated `hasPropertyHint` to correctly identify template-generated associations even when values are empty.
  - Restricted Razor fragment detection logic to Razor-specific files to avoid false positives in standard HTML.
  - Explicitly ignore `for=""` or whitespace-only associations, which are no longer considered valid controls.
- **Test coverage:**
  - Added extensive regression tests for template-generated labels, Razor-specific fragment rendering, and Angular binding patterns.


<sub>This will update automatically on new commits.</sub>