### PR TITLE
SONARHTML-394 Refresh S6853 docs

### DIFF
--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S6853.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S6853.html
@@ -1,7 +1,6 @@
-<p>A <code>&lt;label&gt;</code> element should wrap a control element or have an <code>&lt;htmlFor&gt;</code> attribute referencing a control and text
-content.</p>
+<p>A <code>&lt;label&gt;</code> element should have text content and be associated with a control.</p>
 <h2>Why is this an issue?</h2>
-<p>When a label element lacks a text label or an associated control, it can lead to several issues:</p>
+<p>When a label element lacks text content or an associated control, it can lead to several issues:</p>
 <ol>
   <li><strong>Poor Accessibility</strong>: Screen readers rely on correctly associated labels to describe the function of the form control. If the
   label is not properly associated with a control, it can make the form difficult or impossible for visually impaired users to understand or interact
@@ -12,31 +11,53 @@ content.</p>
   correctly associated, it can make the code more difficult to navigate and debug, especially for new developers or those unfamiliar with the
   codebase.</li>
 </ol>
-<p>Control elements are: * <code>&lt;input&gt;</code> * <code>&lt;meter&gt;</code> * <code>&lt;output&gt;</code> * <code>&lt;progress&gt;</code> *
-<code>&lt;select&gt;</code> * <code>&lt;textarea&gt;</code></p>
+<p>Control elements include:</p>
+<ul>
+  <li><code>&lt;input&gt;</code></li>
+  <li><code>&lt;meter&gt;</code></li>
+  <li><code>&lt;output&gt;</code></li>
+  <li><code>&lt;progress&gt;</code></li>
+  <li><code>&lt;select&gt;</code></li>
+  <li><code>&lt;textarea&gt;</code></li>
+</ul>
 <h3>Exceptions</h3>
 <p>Custom components may contain control elements, therefore label elements containing custom elements do not raise issues.</p>
 <h2>How to fix it</h2>
-<p>If you have a pair of control and <code>&lt;label&gt;</code> elements, make sure that the <code>&lt;label&gt;</code> wraps the control element. If
-you lack a control element, add one.</p>
-<p>It is strongly recommended to avoid using generated <code>id</code>s since they must be deterministic.</p>
+<p>Make sure the <code>&lt;label&gt;</code> has text that describes the control.</p>
+<p>An implicit association wraps the control element inside the <code>&lt;label&gt;</code>. An explicit association keeps the label and control
+separate, and links them with the label’s <code>for</code> attribute and the control’s <code>id</code>. Both approaches are compliant. If you lack a
+control element, add one.</p>
 <h3>Code examples</h3>
 <h4>Noncompliant code example</h4>
 <pre data-diff-id="1" data-diff-type="noncompliant">
-&lt;input type="text" /&gt;
+&lt;!-- Non-compliant: label without text --&gt;
+&lt;label for="favorite-sport"&gt;&lt;/label&gt;
+&lt;input id="favorite-sport" type="text" /&gt;
+
+&lt;!-- Non-compliant: missing "for" attribute on label --&gt;
 &lt;label&gt;Favorite food&lt;/label&gt;
+&lt;input id="favorite-food" type="text" /&gt;
 </pre>
 <h4>Compliant solution</h4>
 <pre data-diff-id="1" data-diff-type="compliant">
+&lt;!-- Label with text --&gt;
+&lt;label for="favorite-sport"&gt;Favorite sport&lt;/label&gt;
+&lt;input id="favorite-sport" type="text" /&gt;
+
+&lt;!-- Explicit association --&gt;
+&lt;label for="favorite-food"&gt;Favorite food&lt;/label&gt;
+&lt;input id="favorite-food" type="text" /&gt;
+
+&lt;!-- Implicit association --&gt;
 &lt;label&gt;
-  &lt;input type="text" /&gt;
-  Favorite food
+    Favorite place
+    &lt;input id="favorite-place" type="text" /&gt;
 &lt;/label&gt;
 </pre>
 <h2>Resources</h2>
 <h3>Documentation</h3>
 <ul>
-  <li>MDN web docs - <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label">The Label element</a></li>
+  <li>MDN web docs - <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/label">The Label element</a></li>
   <li>W3C - <a href="https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships">WCAG 2.2 - 1.3.1 Info and Relationships</a></li>
   <li>W3C - <a href="https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions">WCAG 2.2 - 3.3.2 Labels or Instructions</a></li>
   <li>W3C - <a href="https://www.w3.org/WAI/WCAG22/Techniques/html/H44">H44: Using label elements to associate text labels with form controls</a></li>


### PR DESCRIPTION
## Summary
Regenerate S6853 in sonar-html so the shipped rule description reflects the updated HTML example set from rspec.
RSPEC PR: https://github.com/SonarSource/rspec/pull/7179

## Changes
- Refresh the generated `S6853.html` resource from the updated rspec branch.
- Ship the new grouped non-compliant and compliant HTML examples for favorite sport, food, and place.
