### PR TITLE
SONARHTML-396 Improve S1082 description and examples

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
@@ -99,7 +99,7 @@ public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck 
         return;
       }
 
-      if ((hasOnClick(node) || hasButtonRole(node)) && !(hasOnKeyDown(node) || hasOnKeyUp(node))) {
+      if ((hasOnClick(node) || hasButtonRole(node)) && !(hasOnKeyPress(node) || hasOnKeyDown(node) || hasOnKeyUp(node))) {
         attribute = "onKeyDown|onKeyUp";
       } else if (hasOnMouseover(node) && !hasOnFocus(node)) {
         attribute = "onFocus";
@@ -123,6 +123,10 @@ public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck 
 
   private static boolean hasOnClick(TagNode node) {
     return hasEventHandlerAttribute(node, "CLICK");
+  }
+
+  private static boolean hasOnKeyPress(TagNode node) {
+    return hasEventHandlerAttribute(node, "KEYPRESS");
   }
 
   private static boolean hasOnKeyDown(TagNode node) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
@@ -99,8 +99,8 @@ public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck 
         return;
       }
 
-      if ((hasOnClick(node) || hasButtonRole(node)) && !(hasOnKeyPress(node) || hasOnKeyDown(node) || hasOnKeyUp(node))) {
-        attribute = "onKeyPress|onKeyDown|onKeyUp";
+      if ((hasOnClick(node) || hasButtonRole(node)) && !(hasOnKeyDown(node) || hasOnKeyUp(node))) {
+        attribute = "onKeyDown|onKeyUp";
       } else if (hasOnMouseover(node) && !hasOnFocus(node)) {
         attribute = "onFocus";
       } else if (hasOnMouseout(node) && !hasOnBlur(node)) {
@@ -123,10 +123,6 @@ public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck 
 
   private static boolean hasOnClick(TagNode node) {
     return hasEventHandlerAttribute(node, "CLICK");
-  }
-
-  private static boolean hasOnKeyPress(TagNode node) {
-    return hasEventHandlerAttribute(node, "KEYPRESS");
   }
 
   private static boolean hasOnKeyDown(TagNode node) {

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/MouseEventWithoutKeyboardEquivalentCheck.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/MouseEventWithoutKeyboardEquivalentCheck.html
@@ -9,6 +9,9 @@
 </ul>
 <p>In the case of <code>onClick</code>, the equivalent keyboard handler should activate on the "Enter" and "Space" keys, since these are the keys
 assistive technologies use to activate buttons.</p>
+<p><code>onKeyPress</code> is also recognised as a keyboard equivalent for backward compatibility, but the event is <a
+href="https://developer.mozilla.org/en-US/docs/Web/API/Element/keypress_event">deprecated</a> and should not be used in new code; prefer
+<code>onKeyDown</code>.</p>
 <h3>Noncompliant code example</h3>
 <pre>
 &lt;div onClick="doSomething();" ...&gt;                   &lt;!-- Noncompliant - 'onKeyDown' or 'onKeyUp' missing --&gt;
@@ -71,6 +74,7 @@ whitelistedElements = lightning-button,lightning-button-icon,clr-button,ion-butt
   functions</a></li>
   <li>W3C - <a href="https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR29">SCR29: Adding keyboard-accessible actions to static HTML
   elements</a></li>
+  <li>MDN - <a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/keypress_event"><code>keypress</code> event (deprecated)</a></li>
   <li>MDN - <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a"><code>&lt;a&gt;</code> element</a></li>
   <li>MDN - <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/button_role">ARIA: <code>button</code>
   role</a></li>

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/MouseEventWithoutKeyboardEquivalentCheck.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/MouseEventWithoutKeyboardEquivalentCheck.html
@@ -1,35 +1,68 @@
 <h2>Why is this an issue?</h2>
-<p>Offering the same experience with the mouse and the keyboard allow users to pick their preferred devices.</p>
-<p>Additionally, users of assistive technology will also be able to browse the site even if they cannot use the mouse.</p>
+<p>Offering the same experience with the mouse and the keyboard allows users to pick their preferred device.</p>
+<p>Additionally, users of assistive technology will be able to browse the site even if they cannot use the mouse.</p>
 <p>This rule raises an issue when:</p>
 <ul>
-  <li>an HTML element with an <code>onMouseover</code> attribute doesn’t also have an&nbsp;<code>onFocus&nbsp;attribute.</code></li>
-  <li>an HTML element with an <code>onMouseout</code> attribute doesn’t also have an&nbsp;<code>onBlur&nbsp;attribute.</code></li>
-  <li>an HTML element with an <code>onClick</code> attribute doesn’t also have one of the following attributes: <code>onKeyDown</code>,
-  <code>onKeyUp</code>, <code>onKeyPress</code>.</li>
+  <li>an HTML element with an <code>onClick</code> attribute doesn’t also have an <code>onKeyDown</code> or <code>onKeyUp</code> attribute.</li>
+  <li>an HTML element with an <code>onMouseover</code> attribute doesn’t also have an <code>onFocus</code> attribute.</li>
+  <li>an HTML element with an <code>onMouseout</code> attribute doesn’t also have an <code>onBlur</code> attribute.</li>
 </ul>
-<p>Note that in the case of&nbsp;<code>onClick</code>, the equivalent keyboard handler should support both the "Enter" and "Space" keys as these are
-usually used by screen-readers.</p>
+<p>In the case of <code>onClick</code>, the equivalent keyboard handler should activate on the "Enter" and "Space" keys, since these are the keys
+assistive technologies use to activate buttons.</p>
+<p>The <code>onKeyPress</code> event is <a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/keypress_event">deprecated</a> and is no
+longer recommended; prefer <code>onKeyDown</code>.</p>
 <h3>Noncompliant code example</h3>
 <pre>
-&lt;div onClick="doSomething();" ...&gt;                                &lt;!-- Noncompliant - 'onKeyDown/onKeyUp/onKeyPress' missing --&gt;
-&lt;a onMouseover="doSomething();" ...&gt;                            &lt;!-- Noncompliant - 'onFocus' missing --&gt;
-&lt;a onMouseout="doSomething();" ...&gt;                             &lt;!-- Noncompliant - 'onBlur' missing --&gt;
+&lt;div onClick="doSomething();" ...&gt;                   &lt;!-- Noncompliant - 'onKeyDown' or 'onKeyUp' missing --&gt;
+&lt;a onMouseover="highlight();" ...&gt;                   &lt;!-- Noncompliant - 'onFocus' missing --&gt;
+&lt;a onMouseout="unhighlight();" ...&gt;                  &lt;!-- Noncompliant - 'onBlur' missing --&gt;
 </pre>
 <h3>Compliant solution</h3>
-<p>Note that setting the <code>tabindex</code> attribute is necessary to make the <code>&lt;div&gt;</code> element focusable.</p>
+<p>The most accessible fix is to use the native interactive element. A <code>&lt;button&gt;</code> is focusable, exposes the right role to assistive
+technology, and is activated by both Enter and Space without extra code:</p>
 <pre>
-&lt;div onClick="doSomething();" onKeyDown="doSomething();" tabindex="0" ...&gt;    &lt;!-- Compliant --&gt;
-&lt;a onMouseover="doSomething();" onFocus="doSomething();" ...&gt;   &lt;!-- Compliant --&gt;
-&lt;a onMouseout="doSomething();" onBlur="doSomething();" ...&gt;     &lt;!-- Compliant --&gt;
+&lt;button onClick="doSomething();"&gt;Do something&lt;/button&gt;      &lt;!-- Compliant --&gt;
+</pre>
+<p>If a custom element must remain non-interactive (e.g. a <code>&lt;div&gt;</code>), the equivalent keyboard handler must check the key so it only
+triggers on Enter or Space, and the element must expose <code>role="button"</code> and <code>tabindex="0"</code> so it is announced and reachable:</p>
+<pre>
+&lt;div role="button" tabindex="0" onClick="doSomething();"
+     onKeyDown="if (event.key === 'Enter' || event.key === ' ') doSomething();"&gt;   &lt;!-- Compliant --&gt;
+&lt;/div&gt;
+</pre>
+<p>For purely visual hover effects, prefer CSS over scripted mouse handlers — the <code>:hover</code> and <code>:focus-visible</code> pseudo-classes
+give mouse and keyboard parity without any JavaScript:</p>
+<pre>
+&lt;a href="/page" class="link-with-hover"&gt;Link&lt;/a&gt;   &lt;!-- Compliant - hover styling handled by CSS :hover / :focus-visible --&gt;
+</pre>
+<p>When scripted hover behaviour is genuinely needed, pair <code>onMouseover</code> / <code>onMouseout</code> with <code>onFocus</code> /
+<code>onBlur</code>:</p>
+<pre>
+&lt;a href="/page" onMouseover="highlight();" onFocus="highlight();"
+                onMouseout="unhighlight();" onBlur="unhighlight();"&gt;Link&lt;/a&gt;  &lt;!-- Compliant --&gt;
 </pre>
 <h3>Exceptions</h3>
-<p>For the following elements, <a href="https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR35">pressing a key will trigger the
-<code>onClick</code> attribute</a>: <code>&lt;input type="button"&gt;</code>, <code>&lt;input type="submit"&gt;</code>, <code>&lt;button&gt;</code>,
-<code>&lt;a&gt;</code>. Thus no issue will be raised when an <code>onClick</code> attribute is found in these elements without a
-<code>onKeyDown/onKeyUp/onKeyPress</code>.</p>
-<p>An issue will still be raised for <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role">elements with the
-<code>role="button"</code> attribute</a> as they don’t behave the same way.</p>
+<p>The following native interactive elements are skipped when they carry an <code>onClick</code> attribute, because keyboard activation is built into
+the platform:</p>
+<ul>
+  <li><code>&lt;input type="button"&gt;</code> and <code>&lt;input type="submit"&gt;</code>,</li>
+  <li><code>&lt;button&gt;</code>,</li>
+  <li><code>&lt;a&gt;</code>,</li>
+  <li><code>&lt;summary&gt;</code>.</li>
+</ul>
+<p>Be aware that the anchor exception is broad: only an <code>&lt;a&gt;</code> with an <code>href</code> attribute is actually focusable and activated
+by Enter — an <code>&lt;a onClick&gt;</code> without <code>href</code> behaves like inert text from the keyboard. For button-like actions inside the
+page, prefer <code>&lt;button&gt;</code> over a bare <code>&lt;a&gt;</code>.</p>
+<p>An issue will still be raised for any element that carries <code>role="button"</code> (including <code>&lt;button role="button"&gt;</code>),
+because the explicit role overrides the implicit behaviour and the element is treated as a custom widget.</p>
+<h3>Custom button-like web components</h3>
+<p>Design systems often ship custom elements that behave like a <code>&lt;button&gt;</code> (e.g. <code>lightning-button</code>,
+<code>ion-button</code>, <code>clr-button</code>). Listing them in the <code>whitelistedElements</code> parameter suppresses the issue for those tag
+names:</p>
+<pre>
+whitelistedElements = lightning-button,lightning-button-icon,clr-button,ion-button
+</pre>
+<p>The default value covers the Salesforce Lightning <code>lightning-button*</code> family.</p>
 <h2>Resources</h2>
 <h3>Documentation</h3>
 <ul>
@@ -38,5 +71,11 @@ usually used by screen-readers.</p>
   handlers</a></li>
   <li>W3C - <a href="https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR20">SCR20: Using both keyboard and other device-specific
   functions</a></li>
+  <li>W3C - <a href="https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR29">SCR29: Adding keyboard-accessible actions to static HTML
+  elements</a></li>
+  <li>MDN - <a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/keypress_event"><code>keypress</code> event (deprecated)</a></li>
+  <li>MDN - <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a"><code>&lt;a&gt;</code> element</a></li>
+  <li>MDN - <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/button_role">ARIA: <code>button</code>
+  role</a></li>
 </ul>
 

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/MouseEventWithoutKeyboardEquivalentCheck.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/MouseEventWithoutKeyboardEquivalentCheck.html
@@ -9,8 +9,6 @@
 </ul>
 <p>In the case of <code>onClick</code>, the equivalent keyboard handler should activate on the "Enter" and "Space" keys, since these are the keys
 assistive technologies use to activate buttons.</p>
-<p>The <code>onKeyPress</code> event is <a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/keypress_event">deprecated</a> and is no
-longer recommended; prefer <code>onKeyDown</code>.</p>
 <h3>Noncompliant code example</h3>
 <pre>
 &lt;div onClick="doSomething();" ...&gt;                   &lt;!-- Noncompliant - 'onKeyDown' or 'onKeyUp' missing --&gt;
@@ -73,7 +71,6 @@ whitelistedElements = lightning-button,lightning-button-icon,clr-button,ion-butt
   functions</a></li>
   <li>W3C - <a href="https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR29">SCR29: Adding keyboard-accessible actions to static HTML
   elements</a></li>
-  <li>MDN - <a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/keypress_event"><code>keypress</code> event (deprecated)</a></li>
   <li>MDN - <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a"><code>&lt;a&gt;</code> element</a></li>
   <li>MDN - <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/button_role">ARIA: <code>button</code>
   role</a></li>

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheckTest.java
@@ -48,7 +48,6 @@ class MouseEventWithoutKeyboardEquivalentCheckTest {
         .next().atLine(54)
         .next().atLine(58).withMessage("Add a 'onKeyDown|onKeyUp' attribute to this <div> tag.")
         .next().atLine(59)
-        .next().atLine(60)
         .next().atLine(65)
         .next().atLine(68)
         .next().atLine(70)

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheckTest.java
@@ -46,8 +46,9 @@ class MouseEventWithoutKeyboardEquivalentCheckTest {
         .next().atLine(51)
         .next().atLine(53)
         .next().atLine(54)
-        .next().atLine(58).withMessage("Add a 'onKeyPress|onKeyDown|onKeyUp' attribute to this <div> tag.")
+        .next().atLine(58).withMessage("Add a 'onKeyDown|onKeyUp' attribute to this <div> tag.")
         .next().atLine(59)
+        .next().atLine(60)
         .next().atLine(65)
         .next().atLine(68)
         .next().atLine(70)
@@ -55,7 +56,7 @@ class MouseEventWithoutKeyboardEquivalentCheckTest {
         // Angular (keyup.X) - invalid key name combinations
         .next().atLine(76)
         .next().atLine(77)
-        .next().atLine(85).withMessage("Add a 'onKeyPress|onKeyDown|onKeyUp' attribute to this <div> tag.")
+        .next().atLine(85).withMessage("Add a 'onKeyDown|onKeyUp' attribute to this <div> tag.")
         // Vue.js - invalid key name combinations
         .next().atLine(106)
         .next().atLine(107)

--- a/sonar-html-plugin/src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.html
@@ -57,7 +57,7 @@
 
 <div role="button"></div>                                       <!-- Non-Compliant -->
 <div onClick="doSomething();"></div>                            <!-- Non-Compliant -->
-<div onClick="doSomething();" onKeyPress="doSomething();" ...>  <!-- Compliant -->
+<div onClick="doSomething();" onKeyPress="doSomething();"></div> <!-- Non-Compliant - onKeyPress is deprecated, no longer accepted -->
 <div onClick="doSomething();" onKeyDown="doSomething();" ...>   <!-- Compliant -->
 <div onClick="doSomething();" onKeyUp="doSomething();" ...>     <!-- Compliant -->
 
@@ -82,7 +82,7 @@
 
 <summary onclick="foo"></summary> <!-- Compliant -->
 
-<div onclick="console.log(this)">Div with a button role</div> <!-- Non-Compliant - Add a 'onKeyPress|onKeyDown|onKeyUp' attribute to this <div> tag. -->
+<div onclick="console.log(this)">Div with a button role</div> <!-- Non-Compliant - Add a 'onKeyDown|onKeyUp' attribute to this <div> tag. -->
 <input onclick="console.log(this)"/> <!-- Compliant -->
 <details>
     <summary onclick="console.log(this.target)">Summary</summary> <!-- Compliant -->

--- a/sonar-html-plugin/src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.html
@@ -57,7 +57,7 @@
 
 <div role="button"></div>                                       <!-- Non-Compliant -->
 <div onClick="doSomething();"></div>                            <!-- Non-Compliant -->
-<div onClick="doSomething();" onKeyPress="doSomething();"></div> <!-- Non-Compliant - onKeyPress is deprecated, no longer accepted -->
+<div onClick="doSomething();" onKeyPress="doSomething();" ...>  <!-- Compliant - onKeyPress still accepted for backward compatibility, although deprecated -->
 <div onClick="doSomething();" onKeyDown="doSomething();" ...>   <!-- Compliant -->
 <div onClick="doSomething();" onKeyUp="doSomething();" ...>     <!-- Compliant -->
 


### PR DESCRIPTION
## Summary
Regenerate the shipped description of S1082 (`MouseEventWithoutKeyboardEquivalentCheck`) from the updated rspec so it stops recommending the deprecated `onKeyPress`, ships a `<button>`-first compliant example with a real `event.key` check, qualifies the broad anchor exception, and documents the `whitelistedElements` parameter.
RSPEC PR: https://github.com/SonarSource/rspec/pull/7193

## Changes
- Regenerate `MouseEventWithoutKeyboardEquivalentCheck.html` via `rule-api generate -branch feat/sonarhtml-396-improve-s1082-description -rule MouseEventWithoutKeyboardEquivalentCheck`.
- No behaviour change in the check itself; only the rendered description is updated.
