### PR TITLE
JS-2013 Sync S6842 compliant example

### DIFF
--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S6842.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S6842.html
@@ -21,7 +21,7 @@ important to ensure that non-interactive DOM elements are not given interactive 
 </pre>
 <h4>Compliant solution</h4>
 <pre data-diff-id="1" data-diff-type="compliant">
-&lt;li role="listitem"&gt;Foo&lt;/li&gt;
+&lt;button type="button"&gt;Foo&lt;/button&gt;
 </pre>
 <h2>Resources</h2>
 <h3>Documentation</h3>


### PR DESCRIPTION
## Summary
Regenerate the `S6842` HTML rule description from the updated rspec branch so the published example stops recommending a redundant `listitem` role.
RSPEC PR: https://github.com/SonarSource/rspec/pull/7325

## Changes
- sync the generated `S6842.html` rule description from the updated rspec branch
- replace the redundant `role="listitem"` compliant example with a native button example
- keep the shipped Web rule description aligned with the rspec source

## Functional Validation
Artifact: `JS-2013-fv.zip`

Once the file is attached to the PR description, unzip and run:
    ./run.sh

Expected output:
```text
******************* MASTER *******************
RSPEC javascript compliant example:
    function myListElement() {
        return <li role="listitem">Foo</li>;
    }
RSPEC html compliant example:
    <li role="listitem">Foo</li>
sonar-html generated compliant example:
    <li role="listitem">Foo</li>

****** Branch "fix/js-2013-s6842-meaningful-example" ******
RSPEC javascript compliant example:
    function myButton() {
        return <button type="button">Foo</button>;
    }
RSPEC html compliant example:
    <button type="button">Foo</button>
sonar-html generated compliant example:
    <button type="button">Foo</button>
```

:warning::warning: This is not ready for review :warning::warning:
