### PR TITLE
CLP-175 Switch Renovate preset to quality-corelang-squad

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>SonarSource/core-languages-tooling-public:renovate-config"
+    "github>SonarSource/renovate-config:quality-corelang-squad"
   ],
   "ignorePaths": [
     "its/sources/**",


### PR DESCRIPTION
Part of CLP-11.

This PR switches the shared Renovate preset reference from `local>SonarSource/core-languages-tooling-public:renovate-config` to `github>SonarSource/renovate-config:quality-corelang-squad`.

Expected current effective delta:
- none
