### PR TITLE
 SONARHTML-401 Bump sslr.version to 1.26.0.4194 and junit version to 6.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <gitRepositoryName>sonar-html</gitRepositoryName>
 
     <jakarta.el.version>4.0.2</jakarta.el.version>
-    <sslr.version>1.25.1.3886</sslr.version>
+    <sslr.version>1.26.0.4194</sslr.version>
     <analyzerCommons.version>2.27.0.5007</analyzerCommons.version>
     <sonar.plugin.api.version>13.8.0.4399</sonar.plugin.api.version>
     <sonarqube.api.impl.version>26.7.0.124771</sonarqube.api.impl.version>
@@ -86,7 +86,7 @@
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>6.1.1</version>
+        <version>6.1.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
- **Dependency updates:**
  - Bumped `sslr.version` from `1.25.1.3886` to `1.26.0.4194` in `pom.xml`.
  - Updated `junit-bom` version from `6.1.1` to `6.1.2` in `pom.xml`.