### PR TITLE
SONARHTML-410 Improve S6845 description guidance

### DIFF
--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S6845.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S6845.html
@@ -9,21 +9,33 @@
   <li>Increased Tab Ring Size: It unnecessarily increases the size of the page’s tab ring, making navigation more cumbersome.</li>
 </ul>
 <h2>How to fix it</h2>
-<p>Simply remove the <code>tabIndex</code> attribute or set it to <code>"-1"</code> to fix the issue.</p>
+<p>If the element is not meant to be interactive, remove the <code>tabindex</code> attribute or set it to <code>-1</code> so it is skipped by
+sequential keyboard navigation.</p>
+<p>If the element is meant to be interactive, prefer a native interactive element such as <code>&lt;button&gt;</code> or <code>&lt;a href&gt;</code>.
+When a custom widget is required, give it the appropriate interactive <code>role</code>, keep it keyboard reachable, and implement the keyboard
+behavior that role expects.</p>
 <h3>Code examples</h3>
 <h4>Noncompliant code example</h4>
 <pre data-diff-id="1" data-diff-type="noncompliant">
-&lt;div tabIndex="0" /&gt;
+&lt;div tabindex="0"&gt;Save&lt;/div&gt;
 </pre>
 <h4>Compliant solution</h4>
 <pre data-diff-id="1" data-diff-type="compliant">
-&lt;div /&gt;
+&lt;button type="button"&gt;Save&lt;/button&gt;
+</pre>
+<h4>Alternative compliant solution</h4>
+<pre>
+&lt;div role="button" tabindex="0" onclick="save()"
+     onkeydown="if (event.key === 'Enter' || event.key === ' ') save();"&gt;
+  Save
+&lt;/div&gt;
 </pre>
 <h2>Resources</h2>
 <h3>Documentation</h3>
 <ul>
   <li>MDN web docs - <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex">tabindex</a></li>
   <li>The a11y project - <a href="https://www.a11yproject.com/posts/how-to-use-the-tabindex-attribute/">Use the tabindex attribute</a></li>
-  <li>W3C - <a href="https://www.w3.org/WAI/WCAG22/Understanding/focus-order">WCAG 2.2 - 2.4.3 Focus Order</a></li>
+  <li>MDN web docs - <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/button_role">ARIA: button role</a></li>
+  <li>W3C - <a href="https://www.w3.org/WAI/WCAG22/Understanding/keyboard">WCAG 2.2 - 2.1.1 Keyboard</a></li>
 </ul>
 

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S6845.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S6845.html
@@ -1,6 +1,6 @@
 <p>Navigation using the Tab key should be restricted to elements on the page that users can interact with.</p>
 <h2>Why is this an issue?</h2>
-<p>The misuse of the <code>tabIndex</code> attribute can lead to several issues:</p>
+<p>The misuse of the <code>tabindex</code> attribute can lead to several issues:</p>
 <ul>
   <li>Navigation Confusion: It can confuse users who rely on keyboard navigation, as they might expect to tab through interactive elements like links
   and buttons, not static content.</li>
@@ -23,11 +23,19 @@ behavior that role expects.</p>
 <pre data-diff-id="1" data-diff-type="compliant">
 &lt;button type="button"&gt;Save&lt;/button&gt;
 </pre>
-<h4>Alternative compliant solution</h4>
+<h4>Compliant solution</h4>
 <pre>
 &lt;div role="button" tabindex="0" onclick="save()"
      onkeydown="if (event.key === 'Enter' || event.key === ' ') save();"&gt;
   Save
+&lt;/div&gt;
+</pre>
+<h3>Exception</h3>
+<p>This rule accepts <code>tabindex="0"</code> on elements with <code>role="tabpanel"</code>. This matches the WAI-ARIA Tabs pattern, which allows the
+tabpanel itself to receive focus when its first meaningful content is not focusable.</p>
+<pre>
+&lt;div role="tabpanel" tabindex="0"&gt;
+  &lt;!-- tab content --&gt;
 &lt;/div&gt;
 </pre>
 <h2>Resources</h2>
@@ -36,6 +44,7 @@ behavior that role expects.</p>
   <li>MDN web docs - <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex">tabindex</a></li>
   <li>The a11y project - <a href="https://www.a11yproject.com/posts/how-to-use-the-tabindex-attribute/">Use the tabindex attribute</a></li>
   <li>MDN web docs - <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/button_role">ARIA: button role</a></li>
+  <li>WAI-ARIA Authoring Practices Guide - <a href="https://www.w3.org/WAI/ARIA/apg/patterns/tabs/">Tabs pattern</a></li>
   <li>W3C - <a href="https://www.w3.org/WAI/WCAG22/Understanding/keyboard">WCAG 2.2 - 2.1.1 Keyboard</a></li>
 </ul>
 

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S6845.json
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S6845.json
@@ -1,5 +1,5 @@
 {
-  "title": "Non-interactive DOM elements should not have the `tabIndex` property",
+  "title": "Non-interactive DOM elements should not have the `tabindex` attribute",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {


### PR DESCRIPTION
## Summary
Regenerates the S6845 HTML rule page from the updated RSPEC so the HTML variant explains both how to remove unnecessary focus stops and how to fix intentionally interactive widgets.
RSPEC PR: https://github.com/SonarSource/rspec/pull/7408

## Changes
- regenerate the S6845 HTML rule description from the updated RSPEC branch
