### PR TITLE
SONARHTML-409 Allow tabpanel with non-negative tabIndex

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheck.java
@@ -57,13 +57,43 @@ public class NoNoninteractiveTabIndexCheck extends AbstractPageCheck {
    * @return true when the element declares an interactive role or the tabpanel role
    */
   private static boolean hasAllowedRole(TagNode node) {
-    var role = node.getPropertyValue("role");
+    var role = resolveStaticRole(node);
     if (role == null) {
       return false;
     }
 
-    var normalizedRole = role.replace("\"", "").replace("'", "").trim();
-    return "tabpanel".equalsIgnoreCase(normalizedRole)
-      || INTERACTIVE_ROLES.stream().anyMatch(normalizedRole::equalsIgnoreCase);
+    return "tabpanel".equalsIgnoreCase(role)
+      || INTERACTIVE_ROLES.stream().anyMatch(role::equalsIgnoreCase);
+  }
+
+  private static String resolveStaticRole(TagNode node) {
+    var roleAttribute = node.getProperty("role");
+    if (roleAttribute == null) {
+      return null;
+    }
+
+    var roleValue = roleAttribute.getValue();
+    if (roleAttribute.getName().equalsIgnoreCase("role")) {
+      var normalizedRole = roleValue.trim();
+      return normalizedRole.isEmpty() ? null : normalizedRole;
+    }
+
+    // Bound role values are only trusted when they are explicit string literals.
+    if (!isStaticStringLiteral(roleValue)) {
+      return null;
+    }
+
+    var normalizedRole = roleValue.substring(1, roleValue.length() - 1).trim();
+    return normalizedRole.isEmpty() ? null : normalizedRole;
+  }
+
+  private static boolean isStaticStringLiteral(String value) {
+    if (value == null || value.length() < 2) {
+      return false;
+    }
+
+    char first = value.charAt(0);
+    char last = value.charAt(value.length() - 1);
+    return (first == '\'' && last == '\'') || (first == '"' && last == '"');
   }
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheck.java
@@ -88,7 +88,7 @@ public class NoNoninteractiveTabIndexCheck extends AbstractPageCheck {
   }
 
   private static boolean isStaticStringLiteral(String value) {
-    if (value == null || value.length() < 2) {
+    if (value.length() < 2) {
       return false;
     }
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheck.java
@@ -27,7 +27,7 @@ import org.sonar.plugins.html.node.TagNode;
 @Rule(key = "S6845")
 public class NoNoninteractiveTabIndexCheck extends AbstractPageCheck {
 
-  private static final String MESSAGE = "\"tabIndex\" should only be declared on interactive elements.";
+  private static final String MESSAGE = "\"tabindex\" should only be declared on interactive elements.";
 
   @Override
   public void startElement(TagNode node) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheck.java
@@ -16,7 +16,7 @@
  */
 package org.sonar.plugins.html.checks.accessibility;
 
-import static org.sonar.plugins.html.api.HtmlConstants.hasInteractiveRole;
+import static org.sonar.plugins.html.api.HtmlConstants.INTERACTIVE_ROLES;
 import static org.sonar.plugins.html.api.HtmlConstants.hasKnownHTMLTag;
 import static org.sonar.plugins.html.api.HtmlConstants.isInteractiveElement;
 
@@ -31,7 +31,7 @@ public class NoNoninteractiveTabIndexCheck extends AbstractPageCheck {
 
   @Override
   public void startElement(TagNode node) {
-    if (!hasKnownHTMLTag(node) || isInteractiveElement(node) || hasInteractiveRole(node)) {
+    if (!hasKnownHTMLTag(node) || isInteractiveElement(node) || hasAllowedRole(node)) {
       return;
     }
 
@@ -48,5 +48,22 @@ public class NoNoninteractiveTabIndexCheck extends AbstractPageCheck {
     } catch (NumberFormatException e) {
       // ignore
     }
+  }
+
+  /**
+   * Returns whether the element declares a role that allows a non-negative tabindex.
+   *
+   * @param node the element whose role declaration is inspected
+   * @return true when the element declares an interactive role or the tabpanel role
+   */
+  private static boolean hasAllowedRole(TagNode node) {
+    var role = node.getPropertyValue("role");
+    if (role == null) {
+      return false;
+    }
+
+    var normalizedRole = role.replace("\"", "").replace("'", "").trim();
+    return "tabpanel".equalsIgnoreCase(normalizedRole)
+      || INTERACTIVE_ROLES.stream().anyMatch(normalizedRole::equalsIgnoreCase);
   }
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheckTest.java
@@ -35,12 +35,13 @@ class NoNoninteractiveTabIndexCheckTest {
       new NoNoninteractiveTabIndexCheck());
 
     checkMessagesVerifier.verify(sourceCode.getIssues())
-      .next().atLine(18).withMessage("\"tabIndex\" should only be declared on interactive elements.")
-      .next().atLine(19)
-      .next().atLine(20)
+      .next().atLine(21).withMessage("\"tabIndex\" should only be declared on interactive elements.")
+      .next().atLine(22)
       .next().atLine(23)
-      .next().atLine(24)
-      .next().atLine(25)
+      .next().atLine(26)
+      .next().atLine(27)
+      .next().atLine(28)
+      .next().atLine(29)
       .noMore();
   }
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheckTest.java
@@ -42,6 +42,7 @@ class NoNoninteractiveTabIndexCheckTest {
       .next().atLine(27)
       .next().atLine(28)
       .next().atLine(29)
+      .next().atLine(30)
       .noMore();
   }
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheckTest.java
@@ -35,7 +35,7 @@ class NoNoninteractiveTabIndexCheckTest {
       new NoNoninteractiveTabIndexCheck());
 
     checkMessagesVerifier.verify(sourceCode.getIssues())
-      .next().atLine(21).withMessage("\"tabIndex\" should only be declared on interactive elements.")
+      .next().atLine(21).withMessage("\"tabindex\" should only be declared on interactive elements.")
       .next().atLine(22)
       .next().atLine(23)
       .next().atLine(26)

--- a/sonar-html-plugin/src/test/resources/checks/NoNoninteractiveTabIndexCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/NoNoninteractiveTabIndexCheck.html
@@ -27,3 +27,4 @@
 <div [attr.tabindex]="0" />
 <div :tabindex="0" />
 <div :role="'tooltip'" tabIndex="0" />
+<div :role="tabpanel" tabIndex="0" />

--- a/sonar-html-plugin/src/test/resources/checks/NoNoninteractiveTabIndexCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/NoNoninteractiveTabIndexCheck.html
@@ -13,6 +13,9 @@
 <!-- Compliant-s -->
 <div />
 <div tabindex="-1"/>
+<div role="tabpanel" tabIndex="0" />
+<div :role="'tabpanel'" tabIndex="0" />
+<div :role="'button'" tabIndex="0" />
 
 <!-- Noncompliant-s -->
 <div tabIndex="0" />
@@ -23,3 +26,4 @@
 <div [tabindex]="0" />
 <div [attr.tabindex]="0" />
 <div :tabindex="0" />
+<div :role="'tooltip'" tabIndex="0" />


### PR DESCRIPTION
## Summary
This fixes S6845 false positives on HTML elements that use the `tabpanel` role with a non-negative `tabIndex`.
It also recognizes the same exception for static framework-bound role literals so the HTML rule aligns with the JS/TS variant.

## Changes
- Allow `tabpanel` as an exception for S6845 in the HTML check.
- Read static role bindings through `getPropertyValue("role")` so framework-bound `tabpanel` and interactive roles are handled consistently.
- Add regression coverage for compliant `tabpanel`/interactive role bindings and a noncompliant `tooltip` counterexample.

## Functional Validation
Artifact: [SONARHTML-409-fv.zip](https://github.com/user-attachments/files/30079671/SONARHTML-409-fv.zip)

Once the file is attached to the PR description, unzip and run:
    ./run.sh

Expected output:
```text
******************* MASTER *******************
Analyzing "tabpanel-tabindex.html"...
Results:
    - Rule "S6845" -> L.1
    - Rule "S6845" -> L.2
    - Rule "S6845" -> L.3

****** Branch "fix/sonarhtml-409-allow-tabpanel-tabindex" ******
Analyzing "tabpanel-tabindex.html"...
Results:
    - Rule "S6845" -> L.3
```
