### PR TITLE
SONARHTML-411 Fix nested Razor false positive in S7930

### DIFF
--- a/its/ruling/src/test/resources/expected/Web-S7930.json
+++ b/its/ruling/src/test/resources/expected/Web-S7930.json
@@ -55,10 +55,6 @@
 "project:external_webkit-jb-mr1/Tools/CSSTestSuiteHarness/harness/harness.html": [
 229
 ],
-"project:phpMyAdmin-4.0.4-english/libraries/mult_submits.inc.php": [
-308,
-337
-],
 "project:sonar-master/plugins/sonar-core-plugin/src/main/resources/org/sonar/plugins/core/widgets/hotspots/hotspot_most_violated_rules.html.erb": [
 66
 ],

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -106,7 +106,7 @@ public final class TemplateConditionalScopeTracker {
     FragmentScanState state = new FragmentScanState();
     while (state.index < text.length()) {
       if (consumeProtectedCharacter(text, state)
-        || consumeCommentOrStringStart(text, directive, state)
+        || consumeCommentOrStringStart(text, directive, isScanningConditionalHeader(), state)
         || consumeConditionalHeaderCharacter(text, state)
         || consumeConditionalToken(text, directive, state)
         || consumeStructuralToken(text, state)) {
@@ -164,13 +164,18 @@ public final class TemplateConditionalScopeTracker {
    *
    * @param text the fragment being scanned
    * @param directive whether the fragment comes from a directive node
+   * @param insideConditionalHeader whether the scan is inside a conditional header's parentheses
    * @param state the mutable scan state
    * @return {@code true} when a comment or string opener was consumed
    */
-  private static boolean consumeCommentOrStringStart(String text, boolean directive, FragmentScanState state) {
+  private static boolean consumeCommentOrStringStart(String text, boolean directive, boolean insideConditionalHeader, FragmentScanState state) {
     if (!directive && startsWith(text, state.index, "@*")) {
       state.index = skipDelimitedBlock(text, state.index + 2, "*@");
       return true;
+    }
+    // Only code (directives, conditional headers) has comments and strings; plain markup text does not
+    if (!directive && !insideConditionalHeader) {
+      return false;
     }
     if (startsWith(text, state.index, "/*")) {
       state.inBlockComment = true;
@@ -461,6 +466,10 @@ public final class TemplateConditionalScopeTracker {
     pendingConditionalHeaderParenthesisDepth = 0;
   }
 
+  private boolean isScanningConditionalHeader() {
+    return awaitingConditionalHeaderParenthesis || pendingConditionalHeaderParenthesisDepth > 0;
+  }
+
   private static boolean isJstlConditionalTag(TagNode node) {
     String nodeName = node.getNodeName();
     return nodeName != null && JSTL_CONDITIONAL_TAGS.contains(nodeName.toLowerCase(Locale.ROOT));
@@ -563,7 +572,7 @@ public final class TemplateConditionalScopeTracker {
    * @return {@code true} when the current position was consumed as part of the header
    */
   private boolean consumeConditionalHeaderCharacter(String text, FragmentScanState state) {
-    if (!awaitingConditionalHeaderParenthesis && pendingConditionalHeaderParenthesisDepth == 0) {
+    if (!isScanningConditionalHeader()) {
       return false;
     }
 
@@ -597,7 +606,7 @@ public final class TemplateConditionalScopeTracker {
     FragmentScanState state = new FragmentScanState(index);
     int parenthesisDepth = 0;
     while (state.index < text.length()) {
-      if (consumeProtectedCharacter(text, state) || consumeCommentOrStringStart(text, true, state)) {
+      if (consumeProtectedCharacter(text, state) || consumeCommentOrStringStart(text, true, false, state)) {
         continue;
       }
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -58,7 +58,8 @@ public final class TemplateConditionalScopeTracker {
   private int nestedTextBlockDepth;
   private int tagConditionalDepth;
   private boolean pendingBranchContinuation;
-  private int scriptOrStyleDepth;
+  private int scriptDepth;
+  private int styleDepth;
 
   public void reset() {
     textConditionalDepth = 0;
@@ -69,7 +70,8 @@ public final class TemplateConditionalScopeTracker {
     nestedTextBlockDepth = 0;
     tagConditionalDepth = 0;
     pendingBranchContinuation = false;
-    scriptOrStyleDepth = 0;
+    scriptDepth = 0;
+    styleDepth = 0;
   }
 
   public void visitText(TextNode textNode) {
@@ -86,8 +88,10 @@ public final class TemplateConditionalScopeTracker {
     if (isJstlConditionalTag(node)) {
       tagConditionalDepth++;
     }
-    if (isScriptOrStyle(node)) {
-      scriptOrStyleDepth++;
+    if (isScriptTag(node)) {
+      scriptDepth++;
+    } else if (isStyleTag(node)) {
+      styleDepth++;
     }
   }
 
@@ -95,8 +99,10 @@ public final class TemplateConditionalScopeTracker {
     if (isJstlConditionalTag(node) && tagConditionalDepth > 0) {
       tagConditionalDepth--;
     }
-    if (isScriptOrStyle(node) && scriptOrStyleDepth > 0) {
-      scriptOrStyleDepth--;
+    if (isScriptTag(node) && scriptDepth > 0) {
+      scriptDepth--;
+    } else if (isStyleTag(node) && styleDepth > 0) {
+      styleDepth--;
     }
   }
 
@@ -122,9 +128,11 @@ public final class TemplateConditionalScopeTracker {
     }
     while (state.index < text.length()) {
       boolean fullCode = directive || isScanningConditionalHeader();
-      boolean strings = fullCode || scriptOrStyleDepth > 0;
+      boolean hashComments = fullCode;
+      boolean slashComments = fullCode || scriptDepth > 0;
+      boolean strings = fullCode || scriptDepth > 0 || styleDepth > 0;
       if (consumeProtectedCharacter(text, state)
-        || consumeCommentOrStringStart(text, directive, fullCode, strings, state)
+        || consumeCommentOrStringStart(text, directive, hashComments, slashComments, strings, state)
         || consumeConditionalHeaderCharacter(text, state)
         || consumeConditionalToken(text, directive, state)
         || consumeStructuralToken(text, state)) {
@@ -182,12 +190,13 @@ public final class TemplateConditionalScopeTracker {
    *
    * @param text the fragment being scanned
    * @param directive whether the fragment comes from a directive node
-   * @param lineComments whether {@code #} and {@code //} start line comments here (full code only)
-   * @param strings whether quoted strings and block comments are active here (code and script/style)
+   * @param hashComments whether {@code #} starts a line comment here (full code only)
+   * @param slashComments whether {@code //} starts a line comment here (full code and script bodies)
+   * @param strings whether quoted strings and block comments are active here (code, script and style)
    * @param state the mutable scan state
    * @return {@code true} when a comment or string opener was consumed
    */
-  private static boolean consumeCommentOrStringStart(String text, boolean directive, boolean lineComments, boolean strings, FragmentScanState state) {
+  private static boolean consumeCommentOrStringStart(String text, boolean directive, boolean hashComments, boolean slashComments, boolean strings, FragmentScanState state) {
     char current = text.charAt(state.index);
     // Razor comment: only in template markup, may wrap structural braces
     if (!directive && startsWith(text, state.index, "@*")) {
@@ -199,12 +208,12 @@ public final class TemplateConditionalScopeTracker {
       state.index += 2;
       return true;
     }
-    if (lineComments && startsWith(text, state.index, "//")) {
+    if (slashComments && startsWith(text, state.index, "//")) {
       state.inLineComment = true;
       state.index += 2;
       return true;
     }
-    if (lineComments && current == '#') {
+    if (hashComments && current == '#') {
       state.inLineComment = true;
       state.index++;
       return true;
@@ -539,10 +548,12 @@ public final class TemplateConditionalScopeTracker {
     return nodeName != null && JSTL_CONDITIONAL_TAGS.contains(nodeName.toLowerCase(Locale.ROOT));
   }
 
-  private static boolean isScriptOrStyle(TagNode node) {
-    String nodeName = node.getNodeName();
-    return nodeName != null
-      && ("script".equalsIgnoreCase(nodeName) || "style".equalsIgnoreCase(nodeName));
+  private static boolean isScriptTag(TagNode node) {
+    return "script".equalsIgnoreCase(node.getNodeName());
+  }
+
+  private static boolean isStyleTag(TagNode node) {
+    return "style".equalsIgnoreCase(node.getNodeName());
   }
 
   private static boolean hasConditionalAttribute(TagNode node) {
@@ -684,7 +695,7 @@ public final class TemplateConditionalScopeTracker {
     FragmentScanState state = new FragmentScanState(index);
     int parenthesisDepth = 0;
     while (state.index < text.length()) {
-      if (consumeProtectedCharacter(text, state) || consumeCommentOrStringStart(text, true, true, true, state)) {
+      if (consumeProtectedCharacter(text, state) || consumeCommentOrStringStart(text, true, true, true, true, state)) {
         continue;
       }
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -52,6 +52,8 @@ public final class TemplateConditionalScopeTracker {
   private int textConditionalDepth;
   private int braceBasedTextConditionalDepth;
   private int pendingConditionalBranchOpenings;
+  private boolean awaitingConditionalHeaderParenthesis;
+  private int pendingConditionalHeaderParenthesisDepth;
   private int nestedTextBlockDepth;
   private int tagConditionalDepth;
 
@@ -59,6 +61,8 @@ public final class TemplateConditionalScopeTracker {
     textConditionalDepth = 0;
     braceBasedTextConditionalDepth = 0;
     pendingConditionalBranchOpenings = 0;
+    awaitingConditionalHeaderParenthesis = false;
+    pendingConditionalHeaderParenthesisDepth = 0;
     nestedTextBlockDepth = 0;
     tagConditionalDepth = 0;
   }
@@ -103,6 +107,7 @@ public final class TemplateConditionalScopeTracker {
     while (state.index < text.length()) {
       if (consumeProtectedCharacter(text, state)
         || consumeCommentOrStringStart(text, directive, state)
+        || consumeConditionalHeaderCharacter(text, state)
         || consumeConditionalToken(text, directive, state)
         || consumeStructuralToken(text, state)) {
         continue;
@@ -231,7 +236,7 @@ public final class TemplateConditionalScopeTracker {
     if (conditionalStartLength > 0) {
       textConditionalDepth++;
       if (isBraceDelimitedPhpConditional(text, state.index + conditionalStartLength)) {
-        openBraceBasedConditional();
+        openBraceBasedConditionalBeforeHeaderParenthesis();
       }
       state.index += conditionalStartLength;
       return true;
@@ -267,7 +272,7 @@ public final class TemplateConditionalScopeTracker {
     }
     if (conditionalStartLength > 0) {
       textConditionalDepth++;
-      openBraceBasedConditional();
+      openTemplateBraceBasedConditional(text.charAt(state.index + conditionalStartLength - 1));
       state.index += conditionalStartLength;
       return true;
     }
@@ -322,6 +327,7 @@ public final class TemplateConditionalScopeTracker {
   private boolean consumeOpeningBrace(FragmentScanState state) {
     if (pendingConditionalBranchOpenings > 0) {
       pendingConditionalBranchOpenings--;
+      clearConditionalHeaderTracking();
     } else if (braceBasedTextConditionalDepth > 0) {
       nestedTextBlockDepth++;
     }
@@ -339,25 +345,38 @@ public final class TemplateConditionalScopeTracker {
   private boolean consumeClosingBrace(String text, FragmentScanState state) {
     if (nestedTextBlockDepth > 0) {
       nestedTextBlockDepth--;
+    } else if (continueBraceBasedConditional(text, state)) {
+      return true;
     } else {
-      closeBraceBasedConditional(text, state.index);
+      closeBraceBasedConditional();
     }
     state.index++;
     return true;
   }
 
   /**
-   * Closes a brace-delimited conditional when the current brace ends its active branch.
+   * Continues a brace-delimited conditional chain after a closing brace, for example on
+   * {@code } else if (...) { } or {@code } @else { }.
    *
    * @param text the fragment being scanned
-   * @param closingBraceIndex the index of the closing brace being processed
+   * @param state the mutable scan state
+   * @return {@code true} when the closing brace starts a continuation branch
    */
-  private void closeBraceBasedConditional(String text, int closingBraceIndex) {
-    if (braceBasedTextConditionalDepth == 0) {
-      return;
+  private boolean continueBraceBasedConditional(String text, FragmentScanState state) {
+    int continuationIndex = conditionalContinuationEndIndex(text, state.index);
+    if (continuationIndex < 0) {
+      return false;
     }
-    if (isConditionalContinuation(text, closingBraceIndex)) {
-      pendingConditionalBranchOpenings++;
+    pendingConditionalBranchOpenings++;
+    state.index = continuationIndex;
+    return true;
+  }
+
+  /**
+   * Closes a brace-delimited conditional when the current brace ends its active branch.
+   */
+  private void closeBraceBasedConditional() {
+    if (braceBasedTextConditionalDepth == 0) {
       return;
     }
 
@@ -374,6 +393,44 @@ public final class TemplateConditionalScopeTracker {
   private void openBraceBasedConditional() {
     braceBasedTextConditionalDepth++;
     pendingConditionalBranchOpenings++;
+    clearConditionalHeaderTracking();
+  }
+
+  /**
+   * Marks a brace-delimited conditional as open when its condition starts after the keyword, as in PHP.
+   */
+  private void openBraceBasedConditionalBeforeHeaderParenthesis() {
+    openBraceBasedConditional();
+    awaitingConditionalHeaderParenthesis = true;
+  }
+
+  /**
+   * Marks a brace-delimited conditional as open when the opening parenthesis was already consumed.
+   */
+  private void openBraceBasedConditionalInsideHeaderParenthesis() {
+    openBraceBasedConditional();
+    pendingConditionalHeaderParenthesisDepth = 1;
+  }
+
+  /**
+   * Marks a brace-delimited conditional as open when the branch opening brace was already consumed.
+   */
+  private void openConsumedBraceBasedConditional() {
+    braceBasedTextConditionalDepth++;
+    clearConditionalHeaderTracking();
+  }
+
+  /**
+   * Opens a brace-based template conditional according to the delimiter that ended the matched token.
+   *
+   * @param endingDelimiter the matched {@code (} or {@code {}
+   */
+  private void openTemplateBraceBasedConditional(char endingDelimiter) {
+    if (endingDelimiter == '{') {
+      openConsumedBraceBasedConditional();
+    } else {
+      openBraceBasedConditionalInsideHeaderParenthesis();
+    }
   }
 
   private void applyTextConditionalClosings(int closingCount) {
@@ -391,7 +448,16 @@ public final class TemplateConditionalScopeTracker {
   private void clearBraceTracking() {
     braceBasedTextConditionalDepth = 0;
     pendingConditionalBranchOpenings = 0;
+    clearConditionalHeaderTracking();
     nestedTextBlockDepth = 0;
+  }
+
+  /**
+   * Clears the transient state used while scanning a conditional header before its branch opening brace.
+   */
+  private void clearConditionalHeaderTracking() {
+    awaitingConditionalHeaderParenthesis = false;
+    pendingConditionalHeaderParenthesisDepth = 0;
   }
 
   private static boolean isJstlConditionalTag(TagNode node) {
@@ -426,21 +492,37 @@ public final class TemplateConditionalScopeTracker {
   }
 
   /**
-   * Checks whether a closing brace at the provided index is followed by an else-like continuation.
+   * Returns the index immediately after an else-like continuation keyword that follows a closing brace.
    *
    * @param text the scanned fragment
    * @param closingBraceIndex the index of the closing brace to inspect
-   * @return {@code true} when the brace continues the current conditional chain
+   * @return the index after the continuation keyword, or {@code -1} when the brace ends the chain
    */
-  private static boolean isConditionalContinuation(String text, int closingBraceIndex) {
+  private int conditionalContinuationEndIndex(String text, int closingBraceIndex) {
+    if (braceBasedTextConditionalDepth == 0) {
+      return -1;
+    }
+
     int index = skipLeadingTrivia(text, closingBraceIndex + 1);
     if (index < text.length() && text.charAt(index) == '@') {
       index++;
     }
 
-    return startsWithKeyword(text, index, "elseif")
-      || startsWithElseIf(text, index)
-      || startsWithKeyword(text, index, "else");
+    if (startsWithKeyword(text, index, "elseif")) {
+      awaitingConditionalHeaderParenthesis = true;
+      pendingConditionalHeaderParenthesisDepth = 0;
+      return index + "elseif".length();
+    }
+    if (startsWithElseIf(text, index)) {
+      awaitingConditionalHeaderParenthesis = true;
+      pendingConditionalHeaderParenthesisDepth = 0;
+      return skipWhitespace(text, index + 4) + "if".length();
+    }
+    if (startsWithKeyword(text, index, "else")) {
+      clearConditionalHeaderTracking();
+      return index + "else".length();
+    }
+    return -1;
   }
 
   private static boolean startsWithElseIf(String text, int index) {
@@ -473,6 +555,37 @@ public final class TemplateConditionalScopeTracker {
   }
 
   /**
+   * Consumes characters that belong to a still-open conditional header before its branch opening brace.
+   *
+   * @param text the fragment being scanned
+   * @param state the mutable scan state
+   * @return {@code true} when the current position was consumed as part of the header
+   */
+  private boolean consumeConditionalHeaderCharacter(String text, FragmentScanState state) {
+    if (!awaitingConditionalHeaderParenthesis && pendingConditionalHeaderParenthesisDepth == 0) {
+      return false;
+    }
+
+    if (awaitingConditionalHeaderParenthesis) {
+      if (text.charAt(state.index) == '(') {
+        awaitingConditionalHeaderParenthesis = false;
+        pendingConditionalHeaderParenthesisDepth = 1;
+      }
+      state.index++;
+      return true;
+    }
+
+    char current = text.charAt(state.index);
+    if (current == '(') {
+      pendingConditionalHeaderParenthesisDepth++;
+    } else if (current == ')') {
+      pendingConditionalHeaderParenthesisDepth--;
+    }
+    state.index++;
+    return true;
+  }
+
+  /**
    * Determines whether a PHP conditional uses structural braces rather than alternative syntax.
    *
    * @param text the unwrapped PHP directive body
@@ -481,16 +594,20 @@ public final class TemplateConditionalScopeTracker {
    */
   private static boolean isBraceDelimitedPhpConditional(String text, int index) {
     FragmentScanState state = new FragmentScanState(index);
+    int parenthesisDepth = 0;
     while (state.index < text.length()) {
       if (consumeProtectedCharacter(text, state) || consumeCommentOrStringStart(text, true, state)) {
         continue;
       }
 
       char current = text.charAt(state.index);
-      if (current == '{') {
+      if (current == '(') {
+        parenthesisDepth++;
+      } else if (current == ')' && parenthesisDepth > 0) {
+        parenthesisDepth--;
+      } else if (parenthesisDepth == 0 && current == '{') {
         return true;
-      }
-      if (current == ':' || current == ';') {
+      } else if (parenthesisDepth == 0 && (current == ':' || current == ';')) {
         return false;
       }
       state.index++;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -43,7 +43,8 @@ public final class TemplateConditionalScopeTracker {
   );
 
   private static final Pattern RAZOR_BLOCK_START_PATTERN = Pattern.compile("@(if|switch)\\s*\\(", Pattern.CASE_INSENSITIVE);
-  private static final Pattern RAZOR_BRANCH_START_PATTERN = Pattern.compile("@(case|default)\\s*[({]", Pattern.CASE_INSENSITIVE);
+  // Angular block control flow branches: @case (value) { and @default { inside an @switch
+  private static final Pattern ANGULAR_BRANCH_START_PATTERN = Pattern.compile("@(case|default)\\s*[({]", Pattern.CASE_INSENSITIVE);
   private static final Pattern PHP_DIRECTIVE_CONDITIONAL_START_PATTERN = Pattern.compile("(if|foreach|for)\\b", Pattern.CASE_INSENSITIVE);
   private static final Pattern TWIG_CONDITIONAL_START_PATTERN = Pattern.compile("\\{%[-\\s]*(if|for)\\b", Pattern.CASE_INSENSITIVE);
   private static final Pattern TWIG_CONDITIONAL_END_PATTERN = Pattern.compile("\\{%[-\\s]*(endif|endfor)\\b", Pattern.CASE_INSENSITIVE);
@@ -289,7 +290,7 @@ public final class TemplateConditionalScopeTracker {
 
     int conditionalStartLength = matchedPrefixLength(RAZOR_BLOCK_START_PATTERN, text, state.index);
     if (conditionalStartLength == 0) {
-      conditionalStartLength = matchedPrefixLength(RAZOR_BRANCH_START_PATTERN, text, state.index);
+      conditionalStartLength = matchedPrefixLength(ANGULAR_BRANCH_START_PATTERN, text, state.index);
     }
     if (conditionalStartLength > 0) {
       textConditionalDepth++;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -631,12 +631,20 @@ public final class TemplateConditionalScopeTracker {
     }
 
     if (awaitingConditionalHeaderParenthesis) {
-      if (text.charAt(state.index) == '(') {
+      char awaited = text.charAt(state.index);
+      if (awaited == '(') {
         awaitingConditionalHeaderParenthesis = false;
         pendingConditionalHeaderParenthesisDepth = 1;
+        state.index++;
+        return true;
       }
-      state.index++;
-      return true;
+      if (Character.isWhitespace(awaited)) {
+        state.index++;
+        return true;
+      }
+      // Expected '(' never arrived: abandon the malformed header and let this char be scanned
+      clearConditionalHeaderTracking();
+      return false;
     }
 
     char current = text.charAt(state.index);

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -99,160 +99,226 @@ public final class TemplateConditionalScopeTracker {
    * @param directive whether the fragment comes from a directive node
    */
   private void scanFragment(String text, boolean directive) {
-    boolean inLineComment = false;
-    boolean inBlockComment = false;
-    boolean escaped = false;
-    char quoteDelimiter = '\0';
-
-    for (int index = 0; index < text.length(); ) {
-      if (inLineComment) {
-        if (isLineBreak(text.charAt(index))) {
-          inLineComment = false;
-        }
-        index++;
+    FragmentScanState state = new FragmentScanState();
+    while (state.index < text.length()) {
+      if (consumeProtectedCharacter(text, state)
+        || consumeCommentOrStringStart(text, directive, state)
+        || consumeConditionalToken(text, directive, state)
+        || consumeStructuralToken(text, state)) {
         continue;
       }
-      if (inBlockComment) {
-        if (startsWith(text, index, "*/")) {
-          inBlockComment = false;
-          index += 2;
-        } else {
-          index++;
-        }
-        continue;
-      }
-      if (quoteDelimiter != '\0') {
-        char current = text.charAt(index);
-        if (escaped) {
-          escaped = false;
-        } else if (current == '\\') {
-          escaped = true;
-        } else if (current == quoteDelimiter) {
-          quoteDelimiter = '\0';
-        }
-        index++;
-        continue;
-      }
-
-      if (!directive && startsWith(text, index, "@*")) {
-        index = skipDelimitedBlock(text, index + 2, "*@");
-        continue;
-      }
-      if (startsWith(text, index, "/*")) {
-        inBlockComment = true;
-        index += 2;
-        continue;
-      }
-      if (startsWith(text, index, "//")) {
-        inLineComment = true;
-        index += 2;
-        continue;
-      }
-      if (text.charAt(index) == '#') {
-        inLineComment = true;
-        index++;
-        continue;
-      }
-      if (text.charAt(index) == '\'' || text.charAt(index) == '"') {
-        quoteDelimiter = text.charAt(index);
-        escaped = false;
-        index++;
-        continue;
-      }
-
-      if (directive) {
-        boolean startsAtWordBoundary = index == 0
-          || (!Character.isLetterOrDigit(text.charAt(index - 1)) && text.charAt(index - 1) != '_');
-
-        int conditionalEndLength = startsAtWordBoundary
-          ? matchedPrefixLength(PHP_DIRECTIVE_CONDITIONAL_END_PATTERN, text, index)
-          : 0;
-        if (conditionalEndLength > 0) {
-          applyTextConditionalClosings(1);
-          index += conditionalEndLength;
-          continue;
-        }
-
-        int conditionalStartLength = startsAtWordBoundary
-          ? matchedPrefixLength(PHP_DIRECTIVE_CONDITIONAL_START_PATTERN, text, index)
-          : 0;
-        if (conditionalStartLength > 0) {
-          textConditionalDepth++;
-          if (isBraceDelimitedPhpConditional(text, index + conditionalStartLength)) {
-            openBraceBasedConditional();
-          }
-          index += conditionalStartLength;
-          continue;
-        }
-      } else {
-        int twigConditionalEndLength = matchedPrefixLength(TWIG_CONDITIONAL_END_PATTERN, text, index);
-        if (twigConditionalEndLength > 0) {
-          applyTextConditionalClosings(1);
-          index = skipDelimitedBlock(text, index + twigConditionalEndLength, "%}");
-          continue;
-        }
-
-        int twigConditionalStartLength = matchedPrefixLength(TWIG_CONDITIONAL_START_PATTERN, text, index);
-        if (twigConditionalStartLength > 0) {
-          textConditionalDepth++;
-          index = skipDelimitedBlock(text, index + twigConditionalStartLength, "%}");
-          continue;
-        }
-
-        int conditionalStartLength = matchedPrefixLength(RAZOR_BLOCK_START_PATTERN, text, index);
-        if (conditionalStartLength == 0) {
-          conditionalStartLength = matchedPrefixLength(RAZOR_BRANCH_START_PATTERN, text, index);
-        }
-        if (conditionalStartLength > 0) {
-          textConditionalDepth++;
-          openBraceBasedConditional();
-          index += conditionalStartLength;
-          continue;
-        }
-
-        int skippedTemplateBlock = skipTemplateBlock(text, index);
-        if (skippedTemplateBlock > index) {
-          index = skippedTemplateBlock;
-          continue;
-        }
-      }
-
-      if (startsWith(text, index, "}}") || startsWith(text, index, "%}") || startsWith(text, index, "#}")) {
-        index += 2;
-        continue;
-      }
-      if (text.charAt(index) == '{') {
-        if (pendingConditionalBranchOpenings > 0) {
-          pendingConditionalBranchOpenings--;
-        } else if (braceBasedTextConditionalDepth > 0) {
-          nestedTextBlockDepth++;
-        }
-        index++;
-        continue;
-      }
-      if (text.charAt(index) == '}') {
-        if (nestedTextBlockDepth > 0) {
-          nestedTextBlockDepth--;
-        } else if (braceBasedTextConditionalDepth > 0) {
-          if (isConditionalContinuation(text, index)) {
-            pendingConditionalBranchOpenings++;
-          } else {
-            braceBasedTextConditionalDepth--;
-            applyTextConditionalClosings(1);
-            if (braceBasedTextConditionalDepth == 0) {
-              clearBraceTracking();
-            }
-          }
-        }
-        index++;
-        continue;
-      }
-      index++;
+      state.index++;
     }
 
     if (textConditionalDepth == 0) {
       clearBraceTracking();
     }
+  }
+
+  /**
+   * Consumes the next character when the scan is already inside a comment or quoted string.
+   *
+   * @param text the fragment being scanned
+   * @param state the mutable scan state
+   * @return {@code true} when the current position was consumed
+   */
+  private static boolean consumeProtectedCharacter(String text, FragmentScanState state) {
+    if (state.inLineComment) {
+      if (isLineBreak(text.charAt(state.index))) {
+        state.inLineComment = false;
+      }
+      state.index++;
+      return true;
+    }
+    if (state.inBlockComment) {
+      if (startsWith(text, state.index, "*/")) {
+        state.inBlockComment = false;
+        state.index += 2;
+      } else {
+        state.index++;
+      }
+      return true;
+    }
+    if (state.quoteDelimiter != '\0') {
+      char current = text.charAt(state.index);
+      if (state.escaped) {
+        state.escaped = false;
+      } else if (current == '\\') {
+        state.escaped = true;
+      } else if (current == state.quoteDelimiter) {
+        state.quoteDelimiter = '\0';
+      }
+      state.index++;
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Starts scanning a comment or quoted string at the current position when one begins here.
+   *
+   * @param text the fragment being scanned
+   * @param directive whether the fragment comes from a directive node
+   * @param state the mutable scan state
+   * @return {@code true} when a comment or string opener was consumed
+   */
+  private static boolean consumeCommentOrStringStart(String text, boolean directive, FragmentScanState state) {
+    if (!directive && startsWith(text, state.index, "@*")) {
+      state.index = skipDelimitedBlock(text, state.index + 2, "*@");
+      return true;
+    }
+    if (startsWith(text, state.index, "/*")) {
+      state.inBlockComment = true;
+      state.index += 2;
+      return true;
+    }
+    if (startsWith(text, state.index, "//")) {
+      state.inLineComment = true;
+      state.index += 2;
+      return true;
+    }
+    if (text.charAt(state.index) == '#') {
+      state.inLineComment = true;
+      state.index++;
+      return true;
+    }
+    if (text.charAt(state.index) == '\'' || text.charAt(state.index) == '"') {
+      state.quoteDelimiter = text.charAt(state.index);
+      state.escaped = false;
+      state.index++;
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Consumes a conditional start or end token at the current position when one begins here.
+   *
+   * @param text the fragment being scanned
+   * @param directive whether the fragment comes from a directive node
+   * @param state the mutable scan state
+   * @return {@code true} when a conditional token was consumed
+   */
+  private boolean consumeConditionalToken(String text, boolean directive, FragmentScanState state) {
+    return directive
+      ? consumePhpDirectiveConditional(text, state)
+      : consumeTemplateConditional(text, state);
+  }
+
+  /**
+   * Consumes a PHP directive conditional token at the current position when one begins here.
+   *
+   * @param text the fragment being scanned
+   * @param state the mutable scan state
+   * @return {@code true} when a PHP directive conditional token was consumed
+   */
+  private boolean consumePhpDirectiveConditional(String text, FragmentScanState state) {
+    boolean startsAtWordBoundary = state.index == 0
+      || (!Character.isLetterOrDigit(text.charAt(state.index - 1)) && text.charAt(state.index - 1) != '_');
+
+    int conditionalEndLength = startsAtWordBoundary
+      ? matchedPrefixLength(PHP_DIRECTIVE_CONDITIONAL_END_PATTERN, text, state.index)
+      : 0;
+    if (conditionalEndLength > 0) {
+      applyTextConditionalClosings(1);
+      state.index += conditionalEndLength;
+      return true;
+    }
+
+    int conditionalStartLength = startsAtWordBoundary
+      ? matchedPrefixLength(PHP_DIRECTIVE_CONDITIONAL_START_PATTERN, text, state.index)
+      : 0;
+    if (conditionalStartLength > 0) {
+      textConditionalDepth++;
+      if (isBraceDelimitedPhpConditional(text, state.index + conditionalStartLength)) {
+        openBraceBasedConditional();
+      }
+      state.index += conditionalStartLength;
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Consumes a Twig, Razor, or template-delimited token at the current position when one begins here.
+   *
+   * @param text the fragment being scanned
+   * @param state the mutable scan state
+   * @return {@code true} when a template conditional token was consumed
+   */
+  private boolean consumeTemplateConditional(String text, FragmentScanState state) {
+    int twigConditionalEndLength = matchedPrefixLength(TWIG_CONDITIONAL_END_PATTERN, text, state.index);
+    if (twigConditionalEndLength > 0) {
+      applyTextConditionalClosings(1);
+      state.index = skipDelimitedBlock(text, state.index + twigConditionalEndLength, "%}");
+      return true;
+    }
+
+    int twigConditionalStartLength = matchedPrefixLength(TWIG_CONDITIONAL_START_PATTERN, text, state.index);
+    if (twigConditionalStartLength > 0) {
+      textConditionalDepth++;
+      state.index = skipDelimitedBlock(text, state.index + twigConditionalStartLength, "%}");
+      return true;
+    }
+
+    int conditionalStartLength = matchedPrefixLength(RAZOR_BLOCK_START_PATTERN, text, state.index);
+    if (conditionalStartLength == 0) {
+      conditionalStartLength = matchedPrefixLength(RAZOR_BRANCH_START_PATTERN, text, state.index);
+    }
+    if (conditionalStartLength > 0) {
+      textConditionalDepth++;
+      openBraceBasedConditional();
+      state.index += conditionalStartLength;
+      return true;
+    }
+
+    int skippedTemplateBlock = skipTemplateBlock(text, state.index);
+    if (skippedTemplateBlock > state.index) {
+      state.index = skippedTemplateBlock;
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Consumes structural delimiters and brace bookkeeping at the current position when needed.
+   *
+   * @param text the fragment being scanned
+   * @param state the mutable scan state
+   * @return {@code true} when a structural token was consumed
+   */
+  private boolean consumeStructuralToken(String text, FragmentScanState state) {
+    if (startsWith(text, state.index, "}}") || startsWith(text, state.index, "%}") || startsWith(text, state.index, "#}")) {
+      state.index += 2;
+      return true;
+    }
+    if (text.charAt(state.index) == '{') {
+      if (pendingConditionalBranchOpenings > 0) {
+        pendingConditionalBranchOpenings--;
+      } else if (braceBasedTextConditionalDepth > 0) {
+        nestedTextBlockDepth++;
+      }
+      state.index++;
+      return true;
+    }
+    if (text.charAt(state.index) == '}') {
+      if (nestedTextBlockDepth > 0) {
+        nestedTextBlockDepth--;
+      } else if (braceBasedTextConditionalDepth > 0) {
+        if (isConditionalContinuation(text, state.index)) {
+          pendingConditionalBranchOpenings++;
+        } else {
+          braceBasedTextConditionalDepth--;
+          applyTextConditionalClosings(1);
+          if (braceBasedTextConditionalDepth == 0) {
+            clearBraceTracking();
+          }
+        }
+      }
+      state.index++;
+      return true;
+    }
+    return false;
   }
 
   /**
@@ -533,6 +599,15 @@ public final class TemplateConditionalScopeTracker {
   private static boolean startsWith(String text, int index, String token) {
     return index + token.length() <= text.length()
       && text.regionMatches(index, token, 0, token.length());
+  }
+
+  private static final class FragmentScanState {
+
+    private int index;
+    private boolean inLineComment;
+    private boolean inBlockComment;
+    private boolean escaped;
+    private char quoteDelimiter = '\0';
   }
 
   private static boolean isLineBreak(char character) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -130,9 +130,9 @@ public final class TemplateConditionalScopeTracker {
       boolean fullCode = directive || isScanningConditionalHeader();
       boolean hashComments = fullCode;
       boolean slashComments = fullCode || scriptDepth > 0;
-      boolean strings = fullCode || scriptDepth > 0 || styleDepth > 0 || nestedTextBlockDepth > 0;
+      boolean stringsAndBlockComments = fullCode || scriptDepth > 0 || styleDepth > 0 || nestedTextBlockDepth > 0;
       if (consumeProtectedCharacter(text, state)
-        || consumeCommentOrStringStart(text, directive, hashComments, slashComments, strings, state)
+        || consumeCommentOrStringStart(text, directive, hashComments, slashComments, stringsAndBlockComments, state)
         || consumeConditionalHeaderCharacter(text, state)
         || consumeConditionalToken(text, directive, state)
         || consumeStructuralToken(text, state)) {
@@ -192,18 +192,18 @@ public final class TemplateConditionalScopeTracker {
    * @param directive whether the fragment comes from a directive node
    * @param hashComments whether {@code #} starts a line comment here (full code only)
    * @param slashComments whether {@code //} starts a line comment here (full code and script bodies)
-   * @param strings whether quoted strings and block comments are active here (code, script, style and nested code blocks)
+   * @param stringsAndBlockComments whether quoted strings and block comments are active here (code, script, style and nested code blocks)
    * @param state the mutable scan state
    * @return {@code true} when a comment or string opener was consumed
    */
-  private static boolean consumeCommentOrStringStart(String text, boolean directive, boolean hashComments, boolean slashComments, boolean strings, FragmentScanState state) {
+  private static boolean consumeCommentOrStringStart(String text, boolean directive, boolean hashComments, boolean slashComments, boolean stringsAndBlockComments, FragmentScanState state) {
     char current = text.charAt(state.index);
     // Razor comment: only in template markup, may wrap structural braces
     if (!directive && startsWith(text, state.index, "@*")) {
       state.index = skipDelimitedBlock(text, state.index + 2, "*@");
       return true;
     }
-    if (strings && startsWith(text, state.index, "/*")) {
+    if (stringsAndBlockComments && startsWith(text, state.index, "/*")) {
       state.inBlockComment = true;
       state.index += 2;
       return true;
@@ -218,7 +218,7 @@ public final class TemplateConditionalScopeTracker {
       state.index++;
       return true;
     }
-    if (strings && (current == '\'' || current == '"' || current == '`')) {
+    if (stringsAndBlockComments && (current == '\'' || current == '"' || current == '`')) {
       state.quoteDelimiter = current;
       state.escaped = false;
       state.index++;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -44,27 +44,31 @@ public final class TemplateConditionalScopeTracker {
 
   private static final Pattern RAZOR_BLOCK_START_PATTERN = Pattern.compile("@(if|switch)\\s*\\(", Pattern.CASE_INSENSITIVE);
   private static final Pattern RAZOR_BRANCH_START_PATTERN = Pattern.compile("@(case|default)\\s*[({]", Pattern.CASE_INSENSITIVE);
+  private static final Pattern PHP_DIRECTIVE_CONDITIONAL_START_PATTERN = Pattern.compile("(if|foreach|for)\\b", Pattern.CASE_INSENSITIVE);
   private static final Pattern TWIG_CONDITIONAL_START_PATTERN = Pattern.compile("\\{%[-\\s]*(if|for)\\b", Pattern.CASE_INSENSITIVE);
-  private static final Pattern PHP_CONDITIONAL_START_PATTERN = Pattern.compile("<\\?(?:php)?\\s*(if|foreach|for)\\b", Pattern.CASE_INSENSITIVE);
-
   private static final Pattern TWIG_CONDITIONAL_END_PATTERN = Pattern.compile("\\{%[-\\s]*(endif|endfor)\\b", Pattern.CASE_INSENSITIVE);
-  private static final Pattern PHP_CONDITIONAL_END_PATTERN = Pattern.compile("<\\?(?:php)?\\s*(endif|endforeach|endfor)\\b", Pattern.CASE_INSENSITIVE);
+  private static final Pattern PHP_DIRECTIVE_CONDITIONAL_END_PATTERN = Pattern.compile("(endif|endforeach|endfor)\\b", Pattern.CASE_INSENSITIVE);
 
   private int textConditionalDepth;
+  private int braceBasedTextConditionalDepth;
+  private int pendingConditionalBranchOpenings;
+  private int nestedTextBlockDepth;
   private int tagConditionalDepth;
 
   public void reset() {
     textConditionalDepth = 0;
+    braceBasedTextConditionalDepth = 0;
+    pendingConditionalBranchOpenings = 0;
+    nestedTextBlockDepth = 0;
     tagConditionalDepth = 0;
   }
 
   public void visitText(TextNode textNode) {
-    updateTextConditionalDepth(textNode.getCode(), textNode.getCode());
+    scanFragment(textNode.getCode(), false);
   }
 
   public void visitDirective(DirectiveNode directiveNode) {
-    String code = directiveNode.getCode();
-    updateTextConditionalDepth(code, unwrapDirective(code));
+    scanFragment(unwrapDirective(directiveNode.getCode()), true);
   }
 
   public void startElement(TagNode node) {
@@ -87,55 +91,194 @@ public final class TemplateConditionalScopeTracker {
     return textConditionalDepth > 0 || tagConditionalDepth > 0;
   }
 
-  private void updateTextConditionalDepth(String conditionalText, String braceText) {
-    int conditionalStarts = incrementTextConditionalDepthForStarts(conditionalText);
-    decrementTextConditionalDepthForExplicitEnds(conditionalText);
-    applyStructuralClosingBraces(conditionalText, braceText, conditionalStarts);
-  }
+  /**
+   * Scans a text or directive fragment and keeps the open conditional scopes in sync
+   * with structural braces, explicit template endings, and branch continuations.
+   *
+   * @param text the fragment to scan
+   * @param directive whether the fragment comes from a directive node
+   */
+  private void scanFragment(String text, boolean directive) {
+    boolean inLineComment = false;
+    boolean inBlockComment = false;
+    boolean escaped = false;
+    char quoteDelimiter = '\0';
 
-  private int incrementTextConditionalDepthForStarts(String conditionalText) {
-    int starts = countConditionalStarts(conditionalText);
-    textConditionalDepth += starts;
-    return starts;
-  }
+    for (int index = 0; index < text.length(); ) {
+      if (inLineComment) {
+        if (isLineBreak(text.charAt(index))) {
+          inLineComment = false;
+        }
+        index++;
+        continue;
+      }
+      if (inBlockComment) {
+        if (startsWith(text, index, "*/")) {
+          inBlockComment = false;
+          index += 2;
+        } else {
+          index++;
+        }
+        continue;
+      }
+      if (quoteDelimiter != '\0') {
+        char current = text.charAt(index);
+        if (escaped) {
+          escaped = false;
+        } else if (current == '\\') {
+          escaped = true;
+        } else if (current == quoteDelimiter) {
+          quoteDelimiter = '\0';
+        }
+        index++;
+        continue;
+      }
 
-  private void decrementTextConditionalDepthForExplicitEnds(String conditionalText) {
-    applyTextConditionalClosings(countConditionalEnds(conditionalText));
-  }
+      if (!directive && startsWith(text, index, "@*")) {
+        index = skipDelimitedBlock(text, index + 2, "*@");
+        continue;
+      }
+      if (startsWith(text, index, "/*")) {
+        inBlockComment = true;
+        index += 2;
+        continue;
+      }
+      if (startsWith(text, index, "//")) {
+        inLineComment = true;
+        index += 2;
+        continue;
+      }
+      if (text.charAt(index) == '#') {
+        inLineComment = true;
+        index++;
+        continue;
+      }
+      if (text.charAt(index) == '\'' || text.charAt(index) == '"') {
+        quoteDelimiter = text.charAt(index);
+        escaped = false;
+        index++;
+        continue;
+      }
 
-  private void applyStructuralClosingBraces(String conditionalText, String braceText, int conditionalStarts) {
-    applyTextConditionalClosings(countStructuralClosings(conditionalText, braceText, conditionalStarts));
-  }
+      if (directive) {
+        boolean startsAtWordBoundary = index == 0
+          || (!Character.isLetterOrDigit(text.charAt(index - 1)) && text.charAt(index - 1) != '_');
 
-  private int countStructuralClosings(String conditionalText, String braceText, int conditionalStarts) {
-    if (!hasOpenTextConditional() || !braceText.contains("}")) {
-      return 0;
+        int conditionalEndLength = startsAtWordBoundary
+          ? matchedPrefixLength(PHP_DIRECTIVE_CONDITIONAL_END_PATTERN, text, index)
+          : 0;
+        if (conditionalEndLength > 0) {
+          applyTextConditionalClosings(1);
+          index += conditionalEndLength;
+          continue;
+        }
+
+        int conditionalStartLength = startsAtWordBoundary
+          ? matchedPrefixLength(PHP_DIRECTIVE_CONDITIONAL_START_PATTERN, text, index)
+          : 0;
+        if (conditionalStartLength > 0) {
+          textConditionalDepth++;
+          if (isBraceDelimitedPhpConditional(text, index + conditionalStartLength)) {
+            openBraceBasedConditional();
+          }
+          index += conditionalStartLength;
+          continue;
+        }
+      } else {
+        int twigConditionalEndLength = matchedPrefixLength(TWIG_CONDITIONAL_END_PATTERN, text, index);
+        if (twigConditionalEndLength > 0) {
+          applyTextConditionalClosings(1);
+          index = skipDelimitedBlock(text, index + twigConditionalEndLength, "%}");
+          continue;
+        }
+
+        int twigConditionalStartLength = matchedPrefixLength(TWIG_CONDITIONAL_START_PATTERN, text, index);
+        if (twigConditionalStartLength > 0) {
+          textConditionalDepth++;
+          index = skipDelimitedBlock(text, index + twigConditionalStartLength, "%}");
+          continue;
+        }
+
+        int conditionalStartLength = matchedPrefixLength(RAZOR_BLOCK_START_PATTERN, text, index);
+        if (conditionalStartLength == 0) {
+          conditionalStartLength = matchedPrefixLength(RAZOR_BRANCH_START_PATTERN, text, index);
+        }
+        if (conditionalStartLength > 0) {
+          textConditionalDepth++;
+          openBraceBasedConditional();
+          index += conditionalStartLength;
+          continue;
+        }
+
+        int skippedTemplateBlock = skipTemplateBlock(text, index);
+        if (skippedTemplateBlock > index) {
+          index = skippedTemplateBlock;
+          continue;
+        }
+      }
+
+      if (startsWith(text, index, "}}") || startsWith(text, index, "%}") || startsWith(text, index, "#}")) {
+        index += 2;
+        continue;
+      }
+      if (text.charAt(index) == '{') {
+        if (pendingConditionalBranchOpenings > 0) {
+          pendingConditionalBranchOpenings--;
+        } else if (braceBasedTextConditionalDepth > 0) {
+          nestedTextBlockDepth++;
+        }
+        index++;
+        continue;
+      }
+      if (text.charAt(index) == '}') {
+        if (nestedTextBlockDepth > 0) {
+          nestedTextBlockDepth--;
+        } else if (braceBasedTextConditionalDepth > 0) {
+          if (isConditionalContinuation(text, index)) {
+            pendingConditionalBranchOpenings++;
+          } else {
+            braceBasedTextConditionalDepth--;
+            applyTextConditionalClosings(1);
+            if (braceBasedTextConditionalDepth == 0) {
+              clearBraceTracking();
+            }
+          }
+        }
+        index++;
+        continue;
+      }
+      index++;
     }
 
-    String trimmed = braceText.trim();
-    boolean continuation = isConditionalContinuation(trimmed);
-    int structuralClosings = opensAndClosesInSameFragment(conditionalText, conditionalStarts)
-      ? StructuralClosingBraceCounter.count(trimmed)
-      : LeadingClosingBraceCounter.count(trimmed);
-
-    if (continuation && structuralClosings > 0) {
-      return structuralClosings - 1;
+    if (textConditionalDepth == 0) {
+      clearBraceTracking();
     }
-    return structuralClosings;
   }
 
-  private boolean hasOpenTextConditional() {
-    return textConditionalDepth > 0;
-  }
-
-  private static boolean opensAndClosesInSameFragment(String conditionalText, int conditionalStarts) {
-    return conditionalStarts > 0 && !conditionalText.contains("{%");
+  /**
+   * Marks a brace-delimited conditional as open and waits for its branch opening brace.
+   */
+  private void openBraceBasedConditional() {
+    braceBasedTextConditionalDepth++;
+    pendingConditionalBranchOpenings++;
   }
 
   private void applyTextConditionalClosings(int closingCount) {
     if (closingCount > 0) {
       textConditionalDepth = Math.max(0, textConditionalDepth - closingCount);
+      if (textConditionalDepth == 0) {
+        clearBraceTracking();
+      }
     }
+  }
+
+  /**
+   * Clears the brace-related state once no brace-delimited conditional remains open.
+   */
+  private void clearBraceTracking() {
+    braceBasedTextConditionalDepth = 0;
+    pendingConditionalBranchOpenings = 0;
+    nestedTextBlockDepth = 0;
   }
 
   private static boolean isJstlConditionalTag(TagNode node) {
@@ -157,27 +300,6 @@ public final class TemplateConditionalScopeTracker {
     return false;
   }
 
-  private static int countMatches(Pattern pattern, String text) {
-    Matcher matcher = pattern.matcher(text);
-    int matches = 0;
-    while (matcher.find()) {
-      matches++;
-    }
-    return matches;
-  }
-
-  private static int countConditionalStarts(String conditionalText) {
-    return countMatches(RAZOR_BLOCK_START_PATTERN, conditionalText)
-      + countMatches(RAZOR_BRANCH_START_PATTERN, conditionalText)
-      + countMatches(TWIG_CONDITIONAL_START_PATTERN, conditionalText)
-      + countMatches(PHP_CONDITIONAL_START_PATTERN, conditionalText);
-  }
-
-  private static int countConditionalEnds(String conditionalText) {
-    return countMatches(TWIG_CONDITIONAL_END_PATTERN, conditionalText)
-      + countMatches(PHP_CONDITIONAL_END_PATTERN, conditionalText);
-  }
-
   private static String unwrapDirective(String code) {
     String trimmed = code.trim();
     if (!trimmed.startsWith("<?") || !trimmed.endsWith("?>")) {
@@ -190,13 +312,15 @@ public final class TemplateConditionalScopeTracker {
       : unwrapped;
   }
 
-  private static boolean isConditionalContinuation(String text) {
-    int index = skipLeadingTrivia(text, 0);
-    if (!startsWithSingleClosingBrace(text, index)) {
-      return false;
-    }
-
-    index = skipLeadingTrivia(text, index + 1);
+  /**
+   * Checks whether a closing brace at the provided index is followed by an else-like continuation.
+   *
+   * @param text the scanned fragment
+   * @param closingBraceIndex the index of the closing brace to inspect
+   * @return {@code true} when the brace continues the current conditional chain
+   */
+  private static boolean isConditionalContinuation(String text, int closingBraceIndex) {
+    int index = skipLeadingTrivia(text, closingBraceIndex + 1);
     if (index < text.length() && text.charAt(index) == '@') {
       index++;
     }
@@ -221,15 +345,98 @@ public final class TemplateConditionalScopeTracker {
       && isWordBoundary(text, index + keyword.length());
   }
 
+  /**
+   * Returns the length of a pattern matched exactly at the provided index.
+   *
+   * @param pattern the pattern to test
+   * @param text the scanned fragment
+   * @param index the current scan index
+   * @return the matched length, or {@code 0} when no match starts at {@code index}
+   */
+  private static int matchedPrefixLength(Pattern pattern, String text, int index) {
+    Matcher matcher = pattern.matcher(text);
+    matcher.region(index, text.length());
+    return matcher.lookingAt() ? matcher.end() - index : 0;
+  }
+
+  /**
+   * Determines whether a PHP conditional uses structural braces rather than alternative syntax.
+   *
+   * @param text the unwrapped PHP directive body
+   * @param index the index immediately after the conditional keyword
+   * @return {@code true} when the first structural token after the header is an opening brace
+   */
+  private static boolean isBraceDelimitedPhpConditional(String text, int index) {
+    boolean inLineComment = false;
+    boolean inBlockComment = false;
+    boolean escaped = false;
+    char quoteDelimiter = '\0';
+
+    for (int current = index; current < text.length(); ) {
+      if (inLineComment) {
+        if (isLineBreak(text.charAt(current))) {
+          inLineComment = false;
+        }
+        current++;
+        continue;
+      }
+      if (inBlockComment) {
+        if (startsWith(text, current, "*/")) {
+          inBlockComment = false;
+          current += 2;
+        } else {
+          current++;
+        }
+        continue;
+      }
+      if (quoteDelimiter != '\0') {
+        char character = text.charAt(current);
+        if (escaped) {
+          escaped = false;
+        } else if (character == '\\') {
+          escaped = true;
+        } else if (character == quoteDelimiter) {
+          quoteDelimiter = '\0';
+        }
+        current++;
+        continue;
+      }
+
+      if (startsWith(text, current, "/*")) {
+        inBlockComment = true;
+        current += 2;
+        continue;
+      }
+      if (startsWith(text, current, "//")) {
+        inLineComment = true;
+        current += 2;
+        continue;
+      }
+      if (text.charAt(current) == '#') {
+        inLineComment = true;
+        current++;
+        continue;
+      }
+      if (text.charAt(current) == '\'' || text.charAt(current) == '"') {
+        quoteDelimiter = text.charAt(current);
+        escaped = false;
+        current++;
+        continue;
+      }
+      if (text.charAt(current) == '{') {
+        return true;
+      }
+      if (text.charAt(current) == ':' || text.charAt(current) == ';') {
+        return false;
+      }
+      current++;
+    }
+    return false;
+  }
+
   private static boolean isWordBoundary(String text, int index) {
     return index >= text.length()
       || (!Character.isLetterOrDigit(text.charAt(index)) && text.charAt(index) != '_');
-  }
-
-  private static boolean startsWithSingleClosingBrace(String text, int index) {
-    return index < text.length()
-      && text.charAt(index) == '}'
-      && !(index + 1 < text.length() && text.charAt(index + 1) == '}');
   }
 
   private static int skipLeadingTrivia(String text, int index) {
@@ -287,233 +494,45 @@ public final class TemplateConditionalScopeTracker {
     return text.length();
   }
 
+  /**
+   * Skips a template block such as {@code {{ ... }}}, {@code {% ... %}}, or {@code {# ... #}}.
+   *
+   * @param text the scanned fragment
+   * @param index the current scan index
+   * @return the index after the skipped block, or the original index when no block starts there
+   */
+  private static int skipTemplateBlock(String text, int index) {
+    if (startsWith(text, index, "{{")) {
+      return skipDelimitedBlock(text, index + 2, "}}");
+    }
+    if (startsWith(text, index, "{%")) {
+      return skipDelimitedBlock(text, index + 2, "%}");
+    }
+    if (startsWith(text, index, "{#")) {
+      return skipDelimitedBlock(text, index + 2, "#}");
+    }
+    return index;
+  }
+
+  /**
+   * Skips characters until the matching closing delimiter is found.
+   *
+   * @param text the scanned fragment
+   * @param startIndex the index immediately after the opening delimiter
+   * @param closingDelimiter the delimiter that ends the skipped block
+   * @return the index immediately after the closing delimiter, or {@code text.length()} when it is missing
+   */
+  private static int skipDelimitedBlock(String text, int startIndex, String closingDelimiter) {
+    int closingIndex = text.indexOf(closingDelimiter, startIndex);
+    if (closingIndex < 0) {
+      return text.length();
+    }
+    return closingIndex + closingDelimiter.length();
+  }
+
   private static boolean startsWith(String text, int index, String token) {
     return index + token.length() <= text.length()
       && text.regionMatches(index, token, 0, token.length());
-  }
-
-  private static final class LeadingClosingBraceCounter {
-
-    private final String text;
-    private int index;
-
-    private LeadingClosingBraceCounter(String text) {
-      this.text = text;
-    }
-
-    private static int count(String text) {
-      return new LeadingClosingBraceCounter(text).count();
-    }
-
-    private int count() {
-      int closingBraces = 0;
-      while (hasMoreCharacters()) {
-        skipWhitespaceAndComments();
-        if (!hasMoreCharacters() || startsWithDoubleClosingBrace() || currentChar() != '}') {
-          return closingBraces;
-        }
-        closingBraces++;
-        index++;
-      }
-      return closingBraces;
-    }
-
-    private void skipWhitespaceAndComments() {
-      boolean advanced = true;
-      while (advanced && hasMoreCharacters()) {
-        advanced = skipWhitespace() || skipLineComment() || skipBlockComment();
-      }
-    }
-
-    private boolean skipWhitespace() {
-      int start = index;
-      while (hasMoreCharacters() && Character.isWhitespace(currentChar())) {
-        index++;
-      }
-      return index > start;
-    }
-
-    private boolean skipLineComment() {
-      if (!startsLineComment()) {
-        return false;
-      }
-      index += currentChar() == '#' ? 1 : 2;
-      while (hasMoreCharacters() && !isLineBreak(currentChar())) {
-        index++;
-      }
-      return true;
-    }
-
-    private boolean skipBlockComment() {
-      if (!startsBlockComment()) {
-        return false;
-      }
-      index += 2;
-      while (hasMoreCharacters() && !startsWith("*/")) {
-        index++;
-      }
-      if (startsWith("*/")) {
-        index += 2;
-      }
-      return true;
-    }
-
-    private boolean startsLineComment() {
-      return currentChar() == '#' || startsWith("//");
-    }
-
-    private boolean startsBlockComment() {
-      return startsWith("/*");
-    }
-
-    private boolean startsWithDoubleClosingBrace() {
-      return startsWith("}}");
-    }
-
-    private boolean startsWith(String token) {
-      return text.regionMatches(index, token, 0, token.length());
-    }
-
-    private boolean hasMoreCharacters() {
-      return index < text.length();
-    }
-
-    private char currentChar() {
-      return text.charAt(index);
-    }
-  }
-
-  private static final class StructuralClosingBraceCounter {
-
-    private final String text;
-    private int index;
-    private boolean inLineComment;
-    private boolean inBlockComment;
-    private boolean escaped;
-    private char quoteDelimiter;
-
-    private StructuralClosingBraceCounter(String text) {
-      this.text = text;
-    }
-
-    private static int count(String text) {
-      return new StructuralClosingBraceCounter(text).count();
-    }
-
-    private int count() {
-      int closingBraces = 0;
-      while (hasMoreCharacters()) {
-        closingBraces += scanCurrentCharacter();
-      }
-      return closingBraces;
-    }
-
-    private int scanCurrentCharacter() {
-      if (inLineComment) {
-        advanceLineComment();
-        return 0;
-      }
-      if (inBlockComment) {
-        advanceBlockComment();
-        return 0;
-      }
-      if (isInsideQuotedString()) {
-        advanceQuotedString();
-        return 0;
-      }
-      if (startsBlockComment()) {
-        inBlockComment = true;
-        index += 2;
-        return 0;
-      }
-      if (startsLineComment()) {
-        enterLineComment();
-        return 0;
-      }
-      if (startsQuotedString()) {
-        quoteDelimiter = currentChar();
-        escaped = false;
-        index++;
-        return 0;
-      }
-      if (startsWithDoubleClosingBrace()) {
-        index += 2;
-        return 0;
-      }
-      return consumeClosingBrace();
-    }
-
-    private void advanceLineComment() {
-      if (isLineBreak(currentChar())) {
-        inLineComment = false;
-      }
-      index++;
-    }
-
-    private void advanceBlockComment() {
-      if (startsWith("*/")) {
-        inBlockComment = false;
-        index += 2;
-      } else {
-        index++;
-      }
-    }
-
-    private void advanceQuotedString() {
-      char current = currentChar();
-      if (escaped) {
-        escaped = false;
-      } else if (current == '\\') {
-        escaped = true;
-      } else if (current == quoteDelimiter) {
-        quoteDelimiter = '\0';
-      }
-      index++;
-    }
-
-    private void enterLineComment() {
-      inLineComment = true;
-      index += currentChar() == '#' ? 1 : 2;
-    }
-
-    private boolean isInsideQuotedString() {
-      return quoteDelimiter != '\0';
-    }
-
-    private boolean startsBlockComment() {
-      return startsWith("/*");
-    }
-
-    private boolean startsLineComment() {
-      return currentChar() == '#' || startsWith("//");
-    }
-
-    private boolean startsQuotedString() {
-      char current = currentChar();
-      return current == '\'' || current == '"';
-    }
-
-    private boolean startsWithDoubleClosingBrace() {
-      return startsWith("}}");
-    }
-
-    private int consumeClosingBrace() {
-      int closingBraces = currentChar() == '}' ? 1 : 0;
-      index++;
-      return closingBraces;
-    }
-
-    private boolean startsWith(String token) {
-      return text.regionMatches(index, token, 0, token.length());
-    }
-
-    private boolean hasMoreCharacters() {
-      return index < text.length();
-    }
-
-    private char currentChar() {
-      return text.charAt(index);
-    }
   }
 
   private static boolean isLineBreak(char character) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -57,6 +57,7 @@ public final class TemplateConditionalScopeTracker {
   private int nestedTextBlockDepth;
   private int tagConditionalDepth;
   private boolean pendingBranchContinuation;
+  private int scriptOrStyleDepth;
 
   public void reset() {
     textConditionalDepth = 0;
@@ -67,6 +68,7 @@ public final class TemplateConditionalScopeTracker {
     nestedTextBlockDepth = 0;
     tagConditionalDepth = 0;
     pendingBranchContinuation = false;
+    scriptOrStyleDepth = 0;
   }
 
   public void visitText(TextNode textNode) {
@@ -83,11 +85,17 @@ public final class TemplateConditionalScopeTracker {
     if (isJstlConditionalTag(node)) {
       tagConditionalDepth++;
     }
+    if (isScriptOrStyle(node)) {
+      scriptOrStyleDepth++;
+    }
   }
 
   public void endElement(TagNode node) {
     if (isJstlConditionalTag(node) && tagConditionalDepth > 0) {
       tagConditionalDepth--;
+    }
+    if (isScriptOrStyle(node) && scriptOrStyleDepth > 0) {
+      scriptOrStyleDepth--;
     }
   }
 
@@ -112,8 +120,10 @@ public final class TemplateConditionalScopeTracker {
       resolvePendingBranchContinuation(text, state);
     }
     while (state.index < text.length()) {
+      boolean fullCode = directive || isScanningConditionalHeader();
+      boolean strings = fullCode || scriptOrStyleDepth > 0;
       if (consumeProtectedCharacter(text, state)
-        || consumeCommentOrStringStart(text, directive, isScanningConditionalHeader(), state)
+        || consumeCommentOrStringStart(text, directive, fullCode, strings, state)
         || consumeConditionalHeaderCharacter(text, state)
         || consumeConditionalToken(text, directive, state)
         || consumeStructuralToken(text, state)) {
@@ -171,36 +181,35 @@ public final class TemplateConditionalScopeTracker {
    *
    * @param text the fragment being scanned
    * @param directive whether the fragment comes from a directive node
-   * @param insideConditionalHeader whether the scan is inside a conditional header's parentheses
+   * @param lineComments whether {@code #} and {@code //} start line comments here (full code only)
+   * @param strings whether quoted strings and block comments are active here (code and script/style)
    * @param state the mutable scan state
    * @return {@code true} when a comment or string opener was consumed
    */
-  private static boolean consumeCommentOrStringStart(String text, boolean directive, boolean insideConditionalHeader, FragmentScanState state) {
+  private static boolean consumeCommentOrStringStart(String text, boolean directive, boolean lineComments, boolean strings, FragmentScanState state) {
+    char current = text.charAt(state.index);
+    // Razor comment: only in template markup, may wrap structural braces
     if (!directive && startsWith(text, state.index, "@*")) {
       state.index = skipDelimitedBlock(text, state.index + 2, "*@");
       return true;
     }
-    // Only code (directives, conditional headers) has comments and strings; plain markup text does not
-    if (!directive && !insideConditionalHeader) {
-      return false;
-    }
-    if (startsWith(text, state.index, "/*")) {
+    if (strings && startsWith(text, state.index, "/*")) {
       state.inBlockComment = true;
       state.index += 2;
       return true;
     }
-    if (startsWith(text, state.index, "//")) {
+    if (lineComments && startsWith(text, state.index, "//")) {
       state.inLineComment = true;
       state.index += 2;
       return true;
     }
-    if (text.charAt(state.index) == '#') {
+    if (lineComments && current == '#') {
       state.inLineComment = true;
       state.index++;
       return true;
     }
-    if (text.charAt(state.index) == '\'' || text.charAt(state.index) == '"') {
-      state.quoteDelimiter = text.charAt(state.index);
+    if (strings && (current == '\'' || current == '"' || current == '`')) {
+      state.quoteDelimiter = current;
       state.escaped = false;
       state.index++;
       return true;
@@ -529,6 +538,12 @@ public final class TemplateConditionalScopeTracker {
     return nodeName != null && JSTL_CONDITIONAL_TAGS.contains(nodeName.toLowerCase(Locale.ROOT));
   }
 
+  private static boolean isScriptOrStyle(TagNode node) {
+    String nodeName = node.getNodeName();
+    return nodeName != null
+      && ("script".equalsIgnoreCase(nodeName) || "style".equalsIgnoreCase(nodeName));
+  }
+
   private static boolean hasConditionalAttribute(TagNode node) {
     return hasAnyAttribute(node, VUE_CONDITIONAL_ATTRS)
       || hasAnyAttribute(node, ANGULAR_CONDITIONAL_ATTRS);
@@ -668,7 +683,7 @@ public final class TemplateConditionalScopeTracker {
     FragmentScanState state = new FragmentScanState(index);
     int parenthesisDepth = 0;
     while (state.index < text.length()) {
-      if (consumeProtectedCharacter(text, state) || consumeCommentOrStringStart(text, true, false, state)) {
+      if (consumeProtectedCharacter(text, state) || consumeCommentOrStringStart(text, true, true, true, state)) {
         continue;
       }
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -283,6 +283,13 @@ public final class TemplateConditionalScopeTracker {
    * @return {@code true} when a template conditional token was consumed
    */
   private boolean consumeTemplateConditional(String text, FragmentScanState state) {
+    char current = text.charAt(state.index);
+    // Every token handled here starts with '{' (Twig/template blocks) or '@' (Razor/Angular);
+    // skip the regex work (and its Matcher allocations) for every other character.
+    if (current != '{' && current != '@') {
+      return false;
+    }
+
     int twigConditionalEndLength = matchedPrefixLength(TWIG_CONDITIONAL_END_PATTERN, text, state.index);
     if (twigConditionalEndLength > 0) {
       applyTextConditionalClosings(1);

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -56,6 +56,7 @@ public final class TemplateConditionalScopeTracker {
   private int pendingConditionalHeaderParenthesisDepth;
   private int nestedTextBlockDepth;
   private int tagConditionalDepth;
+  private boolean pendingBranchContinuation;
 
   public void reset() {
     textConditionalDepth = 0;
@@ -65,6 +66,7 @@ public final class TemplateConditionalScopeTracker {
     pendingConditionalHeaderParenthesisDepth = 0;
     nestedTextBlockDepth = 0;
     tagConditionalDepth = 0;
+    pendingBranchContinuation = false;
   }
 
   public void visitText(TextNode textNode) {
@@ -72,10 +74,12 @@ public final class TemplateConditionalScopeTracker {
   }
 
   public void visitDirective(DirectiveNode directiveNode) {
+    flushPendingBranchContinuation();
     scanFragment(unwrapDirective(directiveNode.getCode()), true);
   }
 
   public void startElement(TagNode node) {
+    flushPendingBranchContinuation();
     if (isJstlConditionalTag(node)) {
       tagConditionalDepth++;
     }
@@ -104,6 +108,9 @@ public final class TemplateConditionalScopeTracker {
    */
   private void scanFragment(String text, boolean directive) {
     FragmentScanState state = new FragmentScanState();
+    if (!directive) {
+      resolvePendingBranchContinuation(text, state);
+    }
     while (state.index < text.length()) {
       if (consumeProtectedCharacter(text, state)
         || consumeCommentOrStringStart(text, directive, isScanningConditionalHeader(), state)
@@ -354,10 +361,57 @@ public final class TemplateConditionalScopeTracker {
       nestedTextBlockDepth--;
     } else if (continueBraceBasedConditional(text, state)) {
       return;
-    } else {
+    } else if (!deferBranchContinuation(text, state)) {
       closeBraceBasedConditional();
     }
     state.index++;
+  }
+
+  /**
+   * Defers the close decision when a branch-closing brace is followed only by trivia to the end of
+   * the fragment, so an {@code else} opening the next fragment can still continue the chain.
+   *
+   * @param text the fragment being scanned
+   * @param state the mutable scan state, positioned on the closing brace
+   * @return {@code true} when the close was deferred to the next fragment
+   */
+  private boolean deferBranchContinuation(String text, FragmentScanState state) {
+    if (braceBasedTextConditionalDepth == 0 || skipLeadingTrivia(text, state.index + 1) < text.length()) {
+      return false;
+    }
+    pendingBranchContinuation = true;
+    return true;
+  }
+
+  /**
+   * Resolves a deferred close at the start of the next fragment: continues the chain when it begins
+   * with an {@code else} branch, otherwise applies the pending close.
+   *
+   * @param text the fragment being scanned
+   * @param state the mutable scan state
+   */
+  private void resolvePendingBranchContinuation(String text, FragmentScanState state) {
+    if (!pendingBranchContinuation) {
+      return;
+    }
+    pendingBranchContinuation = false;
+    int continuationIndex = conditionalContinuationEndIndex(text, -1);
+    if (continuationIndex >= 0) {
+      pendingConditionalBranchOpenings++;
+      state.index = continuationIndex;
+    } else {
+      closeBraceBasedConditional();
+    }
+  }
+
+  /**
+   * Applies a deferred close when the next event is not a continuing {@code else} branch.
+   */
+  private void flushPendingBranchContinuation() {
+    if (pendingBranchContinuation) {
+      pendingBranchContinuation = false;
+      closeBraceBasedConditional();
+    }
   }
 
   /**
@@ -653,6 +707,9 @@ public final class TemplateConditionalScopeTracker {
   private static int skipComment(String text, int index) {
     if (index >= text.length()) {
       return index;
+    }
+    if (startsWith(text, index, "@*")) {
+      return skipDelimitedBlock(text, index + 2, "*@");
     }
     if (text.charAt(index) == '#') {
       return skipLineComment(text, index + 1);

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -130,7 +130,7 @@ public final class TemplateConditionalScopeTracker {
       boolean fullCode = directive || isScanningConditionalHeader();
       boolean hashComments = fullCode;
       boolean slashComments = fullCode || scriptDepth > 0;
-      boolean strings = fullCode || scriptDepth > 0 || styleDepth > 0;
+      boolean strings = fullCode || scriptDepth > 0 || styleDepth > 0 || nestedTextBlockDepth > 0;
       if (consumeProtectedCharacter(text, state)
         || consumeCommentOrStringStart(text, directive, hashComments, slashComments, strings, state)
         || consumeConditionalHeaderCharacter(text, state)
@@ -192,7 +192,7 @@ public final class TemplateConditionalScopeTracker {
    * @param directive whether the fragment comes from a directive node
    * @param hashComments whether {@code #} starts a line comment here (full code only)
    * @param slashComments whether {@code //} starts a line comment here (full code and script bodies)
-   * @param strings whether quoted strings and block comments are active here (code, script and style)
+   * @param strings whether quoted strings and block comments are active here (code, script, style and nested code blocks)
    * @param state the mutable scan state
    * @return {@code true} when a comment or string opener was consumed
    */

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -288,37 +288,84 @@ public final class TemplateConditionalScopeTracker {
    * @return {@code true} when a structural token was consumed
    */
   private boolean consumeStructuralToken(String text, FragmentScanState state) {
+    if (consumeTemplateBlockClosingDelimiter(text, state)) {
+      return true;
+    }
+    return switch (text.charAt(state.index)) {
+      case '{' -> consumeOpeningBrace(state);
+      case '}' -> consumeClosingBrace(text, state);
+      default -> false;
+    };
+  }
+
+  /**
+   * Consumes a template closing delimiter such as {@code }} or {@code %}}.
+   *
+   * @param text the fragment being scanned
+   * @param state the mutable scan state
+   * @return {@code true} when a closing delimiter was consumed
+   */
+  private static boolean consumeTemplateBlockClosingDelimiter(String text, FragmentScanState state) {
     if (startsWith(text, state.index, "}}") || startsWith(text, state.index, "%}") || startsWith(text, state.index, "#}")) {
       state.index += 2;
       return true;
     }
-    if (text.charAt(state.index) == '{') {
-      if (pendingConditionalBranchOpenings > 0) {
-        pendingConditionalBranchOpenings--;
-      } else if (braceBasedTextConditionalDepth > 0) {
-        nestedTextBlockDepth++;
-      }
-      state.index++;
-      return true;
-    }
-    if (text.charAt(state.index) == '}') {
-      if (nestedTextBlockDepth > 0) {
-        nestedTextBlockDepth--;
-      } else if (braceBasedTextConditionalDepth > 0) {
-        if (isConditionalContinuation(text, state.index)) {
-          pendingConditionalBranchOpenings++;
-        } else {
-          braceBasedTextConditionalDepth--;
-          applyTextConditionalClosings(1);
-          if (braceBasedTextConditionalDepth == 0) {
-            clearBraceTracking();
-          }
-        }
-      }
-      state.index++;
-      return true;
-    }
     return false;
+  }
+
+  /**
+   * Consumes an opening brace and updates the conditional nesting state.
+   *
+   * @param state the mutable scan state
+   * @return always {@code true}
+   */
+  private boolean consumeOpeningBrace(FragmentScanState state) {
+    if (pendingConditionalBranchOpenings > 0) {
+      pendingConditionalBranchOpenings--;
+    } else if (braceBasedTextConditionalDepth > 0) {
+      nestedTextBlockDepth++;
+    }
+    state.index++;
+    return true;
+  }
+
+  /**
+   * Consumes a closing brace and updates the conditional nesting state.
+   *
+   * @param text the fragment being scanned
+   * @param state the mutable scan state
+   * @return always {@code true}
+   */
+  private boolean consumeClosingBrace(String text, FragmentScanState state) {
+    if (nestedTextBlockDepth > 0) {
+      nestedTextBlockDepth--;
+    } else {
+      closeBraceBasedConditional(text, state.index);
+    }
+    state.index++;
+    return true;
+  }
+
+  /**
+   * Closes a brace-delimited conditional when the current brace ends its active branch.
+   *
+   * @param text the fragment being scanned
+   * @param closingBraceIndex the index of the closing brace being processed
+   */
+  private void closeBraceBasedConditional(String text, int closingBraceIndex) {
+    if (braceBasedTextConditionalDepth == 0) {
+      return;
+    }
+    if (isConditionalContinuation(text, closingBraceIndex)) {
+      pendingConditionalBranchOpenings++;
+      return;
+    }
+
+    braceBasedTextConditionalDepth--;
+    applyTextConditionalClosings(1);
+    if (braceBasedTextConditionalDepth == 0) {
+      clearBraceTracking();
+    }
   }
 
   /**
@@ -422,7 +469,7 @@ public final class TemplateConditionalScopeTracker {
   private static int matchedPrefixLength(Pattern pattern, String text, int index) {
     Matcher matcher = pattern.matcher(text);
     matcher.region(index, text.length());
-    return matcher.lookingAt() ? matcher.end() - index : 0;
+    return matcher.lookingAt() ? (matcher.end() - index) : 0;
   }
 
   /**
@@ -433,69 +480,20 @@ public final class TemplateConditionalScopeTracker {
    * @return {@code true} when the first structural token after the header is an opening brace
    */
   private static boolean isBraceDelimitedPhpConditional(String text, int index) {
-    boolean inLineComment = false;
-    boolean inBlockComment = false;
-    boolean escaped = false;
-    char quoteDelimiter = '\0';
-
-    for (int current = index; current < text.length(); ) {
-      if (inLineComment) {
-        if (isLineBreak(text.charAt(current))) {
-          inLineComment = false;
-        }
-        current++;
-        continue;
-      }
-      if (inBlockComment) {
-        if (startsWith(text, current, "*/")) {
-          inBlockComment = false;
-          current += 2;
-        } else {
-          current++;
-        }
-        continue;
-      }
-      if (quoteDelimiter != '\0') {
-        char character = text.charAt(current);
-        if (escaped) {
-          escaped = false;
-        } else if (character == '\\') {
-          escaped = true;
-        } else if (character == quoteDelimiter) {
-          quoteDelimiter = '\0';
-        }
-        current++;
+    FragmentScanState state = new FragmentScanState(index);
+    while (state.index < text.length()) {
+      if (consumeProtectedCharacter(text, state) || consumeCommentOrStringStart(text, true, state)) {
         continue;
       }
 
-      if (startsWith(text, current, "/*")) {
-        inBlockComment = true;
-        current += 2;
-        continue;
-      }
-      if (startsWith(text, current, "//")) {
-        inLineComment = true;
-        current += 2;
-        continue;
-      }
-      if (text.charAt(current) == '#') {
-        inLineComment = true;
-        current++;
-        continue;
-      }
-      if (text.charAt(current) == '\'' || text.charAt(current) == '"') {
-        quoteDelimiter = text.charAt(current);
-        escaped = false;
-        current++;
-        continue;
-      }
-      if (text.charAt(current) == '{') {
+      char current = text.charAt(state.index);
+      if (current == '{') {
         return true;
       }
-      if (text.charAt(current) == ':' || text.charAt(current) == ';') {
+      if (current == ':' || current == ';') {
         return false;
       }
-      current++;
+      state.index++;
     }
     return false;
   }
@@ -608,6 +606,13 @@ public final class TemplateConditionalScopeTracker {
     private boolean inBlockComment;
     private boolean escaped;
     private char quoteDelimiter = '\0';
+
+    private FragmentScanState() {
+    }
+
+    private FragmentScanState(int index) {
+      this.index = index;
+    }
   }
 
   private static boolean isLineBreak(char character) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -298,7 +298,10 @@ public final class TemplateConditionalScopeTracker {
     }
     return switch (text.charAt(state.index)) {
       case '{' -> consumeOpeningBrace(state);
-      case '}' -> consumeClosingBrace(text, state);
+      case '}' -> {
+        consumeClosingBrace(text, state);
+        yield true;
+      }
       default -> false;
     };
   }
@@ -340,18 +343,16 @@ public final class TemplateConditionalScopeTracker {
    *
    * @param text the fragment being scanned
    * @param state the mutable scan state
-   * @return always {@code true}
    */
-  private boolean consumeClosingBrace(String text, FragmentScanState state) {
+  private void consumeClosingBrace(String text, FragmentScanState state) {
     if (nestedTextBlockDepth > 0) {
       nestedTextBlockDepth--;
     } else if (continueBraceBasedConditional(text, state)) {
-      return true;
+      return;
     } else {
       closeBraceBasedConditional();
     }
     state.index++;
-    return true;
   }
 
   /**

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -196,7 +196,8 @@ public final class TemplateConditionalScopeTracker {
    * @param state the mutable scan state
    * @return {@code true} when a comment or string opener was consumed
    */
-  private static boolean consumeCommentOrStringStart(String text, boolean directive, boolean hashComments, boolean slashComments, boolean stringsAndBlockComments, FragmentScanState state) {
+  private static boolean consumeCommentOrStringStart(String text, boolean directive, boolean hashComments,
+    boolean slashComments, boolean stringsAndBlockComments, FragmentScanState state) {
     char current = text.charAt(state.index);
     // Razor comment: only in template markup, may wrap structural braces
     if (!directive && startsWith(text, state.index, "@*")) {

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
@@ -62,6 +62,31 @@ class TemplateConditionalScopeTrackerTest {
     assertThat(isConditionalAtLine(nodes, "div", 6)).isFalse();
   }
 
+  /**
+   * Keeps Razor if/else branches conditional when nested C# blocks close before the else branch.
+   */
+  @Test
+  void tracks_razor_conditionals_across_nested_csharp_blocks() {
+    List<Node> nodes = parse("""
+      @if (Model.HasData && Model.HasValidRows)
+      {
+        using (Html.BeginForm("ConfirmImportAllValidTrainingRecords", "TrainingImport", null, FormMethod.Post, new { onsubmit = "renderOverlay(this.action); return false;" }))
+        {
+          <button id="submit-valid-training-records" type="submit">Import</button>
+        }
+      }
+      else
+      {
+        <button id="submit-valid-training-records" type="submit" disabled="disabled">Import</button>
+      }
+      <div id="footer">Footer</div>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "button", 5)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "button", 10)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 12)).isFalse();
+  }
+
   @Test
   void tracks_jstl_conditional_tags() {
     List<Node> nodes = parse("""

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
@@ -47,6 +47,22 @@ class TemplateConditionalScopeTrackerTest {
   }
 
   @Test
+  void tracks_php_else_if_branches_without_leaking_past_the_chain() {
+    List<Node> nodes = parse("""
+      <?php if (random_int(0, 2) == 0) { ?>
+        <div id="choice">First</div>
+      <?php } else if (random_int(0, 1)) { ?>
+        <div id="choice">Second</div>
+      <?php } ?>
+      <div id="footer">Footer</div>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 2)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 4)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 6)).isFalse();
+  }
+
+  @Test
   void tracks_angular_brace_based_conditionals() {
     List<Node> nodes = parse("""
       @if (gridOptions) {
@@ -85,6 +101,25 @@ class TemplateConditionalScopeTrackerTest {
     assertThat(isConditionalAtLine(nodes, "button", 5)).isTrue();
     assertThat(isConditionalAtLine(nodes, "button", 10)).isTrue();
     assertThat(isConditionalAtLine(nodes, "div", 12)).isFalse();
+  }
+
+  @Test
+  void tracks_razor_conditionals_when_condition_contains_braces() {
+    List<Node> nodes = parse("""
+      @if (Model.Items.Any(item => new { Value = item }.Value != null))
+      {
+        <div id="choice">First</div>
+      }
+      else
+      {
+        <div id="choice">Second</div>
+      }
+      <div id="footer">Footer</div>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 3)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 7)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 9)).isFalse();
   }
 
   @Test

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
@@ -157,6 +157,18 @@ class NoDuplicateIDCheckTest {
   }
 
   @Test
+  void razorConditionalBlocksWithNestedCSharpString() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+        new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksNestedCSharpString.cshtml"),
+        new NoDuplicateIDCheck());
+
+    // A brace inside a C# string in a nested code block must not close the branch early
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+        .next().atLine(18).withMessage("Duplicate id \"footer\" found. First occurrence was on line 17.")
+        .noMore();
+  }
+
+  @Test
   void razorConditionalBlocksWithBracesInCondition() {
     HtmlSourceCode sourceCode = TestHelper.scan(
         new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksConditionBraces.cshtml"),

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
@@ -144,6 +144,30 @@ class NoDuplicateIDCheckTest {
   }
 
   @Test
+  void razorConditionalBlocksWithStyleSelector() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+        new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksStyleBlock.cshtml"),
+        new NoDuplicateIDCheck());
+
+    // A CSS id selector inside a branch must not be read as a code comment; its braces stay balanced
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+        .next().atLine(21).withMessage("Duplicate id \"wrapper\" found. First occurrence was on line 20.")
+        .noMore();
+  }
+
+  @Test
+  void razorConditionalBlocksWithApostropheInText() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+        new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksTextApostrophe.cshtml"),
+        new NoDuplicateIDCheck());
+
+    // An apostrophe in branch text must not open a string that swallows the closing brace
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+        .next().atLine(15).withMessage("Duplicate id \"dup\" found. First occurrence was on line 14.")
+        .noMore();
+  }
+
+  @Test
   void twigConditionalBlocks() {
     HtmlSourceCode sourceCode = TestHelper.scan(
         new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksTwig.html"),

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
@@ -192,6 +192,19 @@ class NoDuplicateIDCheckTest {
   }
 
   @Test
+  void razorConditionalBlocksWithElseIf() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+        new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksRazorElseIf.cshtml"),
+        new NoDuplicateIDCheck());
+
+    // IDs across @if/else if/else branches are mutually exclusive, even when the else if condition
+    // contains braces; only the outside duplicate is flagged
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+        .next().atLine(20).withMessage("Duplicate id \"footer\" found. First occurrence was on line 19.")
+        .noMore();
+  }
+
+  @Test
   void razorConditionalBlocksWithMalformedElseIf() {
     HtmlSourceCode sourceCode = TestHelper.scan(
         new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksMalformedElseIf.cshtml"),

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
@@ -93,6 +93,30 @@ class NoDuplicateIDCheckTest {
   }
 
   @Test
+  void razorSwitchBlocks() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+        new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksRazorSwitch.cshtml"),
+        new NoDuplicateIDCheck());
+
+    // Razor @switch uses plain case:/default: labels; ids across cases are mutually exclusive
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+        .next().atLine(20).withMessage("Duplicate id \"footer\" found. First occurrence was on line 19.")
+        .noMore();
+  }
+
+  @Test
+  void angularSwitchWithBraceInCaseLabel() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+        new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksAngularCaseBrace.cshtml"),
+        new NoDuplicateIDCheck());
+
+    // A brace inside an Angular @case label must not close the @switch early
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+        .next().atLine(19).withMessage("Duplicate id \"footer\" found. First occurrence was on line 18.")
+        .noMore();
+  }
+
+  @Test
   void angularConditionalBlocks() {
     HtmlSourceCode sourceCode = TestHelper.scan(
         new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksAngular.html"),

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
@@ -168,6 +168,30 @@ class NoDuplicateIDCheckTest {
   }
 
   @Test
+  void razorConditionalBlocksWithRazorCommentBeforeElse() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+        new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksRazorComment.cshtml"),
+        new NoDuplicateIDCheck());
+
+    // A Razor comment between the closing brace and else must not break the branch chain
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+        .next().atLine(19).withMessage("Duplicate id \"wrapper\" found. First occurrence was on line 18.")
+        .noMore();
+  }
+
+  @Test
+  void razorConditionalBlocksWithHtmlCommentBeforeElse() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+        new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksHtmlComment.cshtml"),
+        new NoDuplicateIDCheck());
+
+    // An HTML comment splits the text node; the else opening the next fragment must still continue the chain
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+        .next().atLine(18).withMessage("Duplicate id \"wrapper\" found. First occurrence was on line 17.")
+        .noMore();
+  }
+
+  @Test
   void twigConditionalBlocks() {
     HtmlSourceCode sourceCode = TestHelper.scan(
         new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksTwig.html"),

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
@@ -205,6 +205,42 @@ class NoDuplicateIDCheckTest {
   }
 
   @Test
+  void razorConditionalBlocksWithScriptTemplateLiteral() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+        new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksScriptTemplateLiteral.cshtml"),
+        new NoDuplicateIDCheck());
+
+    // A brace inside a backtick template literal in a script body must not close the conditional
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+        .next().atLine(19).withMessage("Duplicate id \"footer\" found. First occurrence was on line 18.")
+        .noMore();
+  }
+
+  @Test
+  void razorConditionalBlocksWithScriptString() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+        new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksScriptString.cshtml"),
+        new NoDuplicateIDCheck());
+
+    // A brace inside a quoted string in a script body must not close the conditional
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+        .next().atLine(19).withMessage("Duplicate id \"footer\" found. First occurrence was on line 18.")
+        .noMore();
+  }
+
+  @Test
+  void razorConditionalBlocksWithStyleString() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+        new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksStyleString.cshtml"),
+        new NoDuplicateIDCheck());
+
+    // A brace inside a quoted string in a style body must not close the conditional
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+        .next().atLine(19).withMessage("Duplicate id \"footer\" found. First occurrence was on line 18.")
+        .noMore();
+  }
+
+  @Test
   void razorConditionalBlocksWithMalformedElseIf() {
     HtmlSourceCode sourceCode = TestHelper.scan(
         new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksMalformedElseIf.cshtml"),

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
@@ -107,6 +107,20 @@ class NoDuplicateIDCheckTest {
         .noMore();
   }
 
+  /**
+   * Ignores duplicate ids across Razor if/else branches when one branch contains nested C# blocks.
+   */
+  @Test
+  void razorConditionalBlocksWithNestedCSharpBlocks() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+        new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksNested.cshtml"),
+        new NoDuplicateIDCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+        .next().atLine(18).withMessage("Duplicate id \"wrapper\" found. First occurrence was on line 17.")
+        .noMore();
+  }
+
   @Test
   void twigConditionalBlocks() {
     HtmlSourceCode sourceCode = TestHelper.scan(

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
@@ -69,6 +69,17 @@ class NoDuplicateIDCheckTest {
   }
 
   @Test
+  void phpConditionalBlocksWithElseIf() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+        new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksElseIf.phtml"),
+        new NoDuplicateIDCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+        .next().atLine(14).withMessage("Duplicate id \"footer\" found. First occurrence was on line 13.")
+        .noMore();
+  }
+
+  @Test
   void vueConditionalBlocks() {
     HtmlSourceCode sourceCode = TestHelper.scan(
         new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocks.vue"),
@@ -118,6 +129,17 @@ class NoDuplicateIDCheckTest {
 
     checkMessagesVerifier.verify(sourceCode.getIssues())
         .next().atLine(18).withMessage("Duplicate id \"wrapper\" found. First occurrence was on line 17.")
+        .noMore();
+  }
+
+  @Test
+  void razorConditionalBlocksWithBracesInCondition() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+        new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksConditionBraces.cshtml"),
+        new NoDuplicateIDCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+        .next().atLine(16).withMessage("Duplicate id \"wrapper\" found. First occurrence was on line 15.")
         .noMore();
   }
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
@@ -192,6 +192,18 @@ class NoDuplicateIDCheckTest {
   }
 
   @Test
+  void razorConditionalBlocksWithMalformedElseIf() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+        new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksMalformedElseIf.cshtml"),
+        new NoDuplicateIDCheck());
+
+    // A malformed else if without parentheses must not swallow the rest of the file
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+        .next().atLine(15).withMessage("Duplicate id \"dup\" found. First occurrence was on line 14.")
+        .noMore();
+  }
+
+  @Test
   void twigConditionalBlocks() {
     HtmlSourceCode sourceCode = TestHelper.scan(
         new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksTwig.html"),

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
@@ -253,6 +253,30 @@ class NoDuplicateIDCheckTest {
   }
 
   @Test
+  void razorConditionalBlocksWithScriptLineComment() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+        new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksScriptLineComment.cshtml"),
+        new NoDuplicateIDCheck());
+
+    // A brace inside a // line comment in a script body must not close the conditional
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+        .next().atLine(19).withMessage("Duplicate id \"footer\" found. First occurrence was on line 18.")
+        .noMore();
+  }
+
+  @Test
+  void razorConditionalBlocksWithStyleUrl() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+        new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksStyleUrl.cshtml"),
+        new NoDuplicateIDCheck());
+
+    // // is not a comment in CSS: the slashes in a url() must not be treated as a line comment
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+        .next().atLine(19).withMessage("Duplicate id \"footer\" found. First occurrence was on line 18.")
+        .noMore();
+  }
+
+  @Test
   void razorConditionalBlocksWithStyleString() {
     HtmlSourceCode sourceCode = TestHelper.scan(
         new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksStyleString.cshtml"),

--- a/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksAngularCaseBrace.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksAngularCaseBrace.cshtml
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+@switch (token)
+{
+    @case ('}')
+    {
+        <div id="badge">A</div>
+    }
+    @default
+    {
+        <div id="badge">B</div>
+    }
+}
+
+<!-- Non-compliant: Duplicate IDs outside conditionals -->
+<div id="footer">One</div>
+<div id="footer">Two</div>
+
+</body>
+</html>

--- a/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksConditionBraces.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksConditionBraces.cshtml
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+@if (Model.Items.Any(item => new { Value = item }.Value != null))
+{
+    <div id="choice">First</div>
+}
+else
+{
+    <div id="choice">Second</div>
+}
+
+<!-- Non-compliant: Duplicate IDs outside conditionals -->
+<div id="wrapper">Content 1</div>
+<div id="wrapper">Content 2</div>
+
+</body>
+</html>

--- a/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksElseIf.phtml
+++ b/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksElseIf.phtml
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+<!-- Compliant: IDs in mutually exclusive PHP if/else if branches -->
+<?php if (random_int(0, 2) == 0) { ?>
+    <div id="summary">First</div>
+<?php } else if (random_int(0, 1)) { ?>
+    <div id="summary">Second</div>
+<?php } ?>
+
+<!-- Non-compliant: Duplicate IDs outside conditionals -->
+<div id="footer">Footer 1</div>
+<div id="footer">Footer 2</div>
+
+</body>
+</html>

--- a/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksHtmlComment.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksHtmlComment.cshtml
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+@if (showA)
+{
+    <div id="panel">A</div>
+}
+<!-- fallback -->
+else
+{
+    <div id="panel">B</div>
+}
+
+<div id="panel">C</div>
+
+<div id="wrapper">One</div>
+<div id="wrapper">Two</div>
+
+</body>
+</html>

--- a/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksMalformedElseIf.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksMalformedElseIf.cshtml
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+@if (a)
+{
+    <div id="x">A</div>
+}
+else if
+{
+    <div id="y">B</div>
+}
+
+<div id="dup">One</div>
+<div id="dup">Two</div>
+
+</body>
+</html>

--- a/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksNested.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksNested.cshtml
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+@if (Model.HasData && Model.HasValidRows)
+{
+  using (Html.BeginForm("ConfirmImportAllValidTrainingRecords", "TrainingImport", null, FormMethod.Post, new { onsubmit = "renderOverlay(this.action); return false;" }))
+  {
+    <button id="submit-valid-training-records" type="submit">Import</button>
+  }
+}
+else
+{
+  <button id="submit-valid-training-records" type="submit" disabled="disabled">Import</button>
+}
+
+<div id="wrapper">Content 1</div>
+<div id="wrapper">Content 2</div>
+
+</body>
+</html>

--- a/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksNestedCSharpString.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksNestedCSharpString.cshtml
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+@if (show)
+{
+    @{
+        var payload = "}";
+    }
+    <div id="widget">A</div>
+}
+else
+{
+    <div id="widget">B</div>
+}
+
+<div id="footer">One</div>
+<div id="footer">Two</div>
+
+</body>
+</html>

--- a/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksRazorComment.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksRazorComment.cshtml
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+@if (showA)
+{
+    <div id="panel">A</div>
+}
+@* fallback *@
+else
+{
+    <div id="panel">B</div>
+}
+
+<div id="panel">C</div>
+
+<!-- Non-compliant: Duplicate IDs outside conditionals -->
+<div id="wrapper">One</div>
+<div id="wrapper">Two</div>
+
+</body>
+</html>

--- a/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksRazorElseIf.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksRazorElseIf.cshtml
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+@if (type == 0)
+{
+    <div id="status">First</div>
+}
+else if (items.Any(i => new { Id = i }.Id == 1))
+{
+    <div id="status">Second</div>
+}
+else
+{
+    <div id="status">Third</div>
+}
+
+<!-- Non-compliant: Duplicate IDs outside conditionals -->
+<div id="footer">Footer 1</div>
+<div id="footer">Footer 2</div>
+
+</body>
+</html>

--- a/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksRazorSwitch.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksRazorSwitch.cshtml
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+@switch (value)
+{
+    case 1:
+        <p id="msg">The value is 1!</p>
+        break;
+    case 1337:
+        <p id="msg">Your number is 1337!</p>
+        break;
+    default:
+        <p id="msg">Your number wasn't 1 or 1337.</p>
+        break;
+}
+
+<!-- Non-compliant: Duplicate IDs outside conditionals -->
+<div id="footer">One</div>
+<div id="footer">Two</div>
+
+</body>
+</html>

--- a/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksScriptLineComment.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksScriptLineComment.cshtml
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+@if (show)
+{
+    <script>
+        var x = 1; // closing }
+    </script>
+    <div id="widget">A</div>
+}
+else
+{
+    <div id="widget">B</div>
+}
+
+<!-- Non-compliant: Duplicate IDs outside conditionals -->
+<div id="footer">One</div>
+<div id="footer">Two</div>
+
+</body>
+</html>

--- a/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksScriptString.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksScriptString.cshtml
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+@if (show)
+{
+    <script>
+        var closing = "}";
+    </script>
+    <div id="widget">A</div>
+}
+else
+{
+    <div id="widget">B</div>
+}
+
+<!-- Non-compliant: Duplicate IDs outside conditionals -->
+<div id="footer">One</div>
+<div id="footer">Two</div>
+
+</body>
+</html>

--- a/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksScriptTemplateLiteral.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksScriptTemplateLiteral.cshtml
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+@if (show)
+{
+    <script>
+        var closing = `}`;
+    </script>
+    <div id="widget">A</div>
+}
+else
+{
+    <div id="widget">B</div>
+}
+
+<!-- Non-compliant: Duplicate IDs outside conditionals -->
+<div id="footer">One</div>
+<div id="footer">Two</div>
+
+</body>
+</html>

--- a/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksStyleBlock.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksStyleBlock.cshtml
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+@if (showBanner)
+{
+    <style>
+        #banner {
+            color: red;
+        }
+    </style>
+    <div id="banner">First</div>
+}
+else
+{
+    <div id="banner">Second</div>
+}
+
+<!-- Non-compliant: Duplicate IDs outside conditionals -->
+<div id="wrapper">Content 1</div>
+<div id="wrapper">Content 2</div>
+
+</body>
+</html>

--- a/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksStyleString.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksStyleString.cshtml
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+@if (show)
+{
+    <style>
+        .marker::after { content: "}"; }
+    </style>
+    <div id="widget">A</div>
+}
+else
+{
+    <div id="widget">B</div>
+}
+
+<!-- Non-compliant: Duplicate IDs outside conditionals -->
+<div id="footer">One</div>
+<div id="footer">Two</div>
+
+</body>
+</html>

--- a/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksStyleUrl.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksStyleUrl.cshtml
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+@if (show)
+{
+    <style>
+        .a { background: url(http://example.com/img.png) }
+    </style>
+    <div id="widget">A</div>
+}
+else
+{
+    <div id="widget">B</div>
+}
+
+<!-- Non-compliant: Duplicate IDs outside conditionals -->
+<div id="footer">One</div>
+<div id="footer">Two</div>
+
+</body>
+</html>

--- a/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksTextApostrophe.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksTextApostrophe.cshtml
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+@if (showFirst)
+{
+    <div id="first">A</div>
+}
+else
+{
+    Don't stop
+}
+
+<div id="dup">One</div>
+<div id="dup">Two</div>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
Fixes a Razor-specific `S7930` false positive when duplicate IDs appear in mutually exclusive `@if/@else` branches and one branch contains nested C# braces. The conditional tracker now keeps the branch scope open across nested `using (...) { ... }` and anonymous-object blocks.

## Changes
- Track brace-delimited template conditionals with nested structural depth so nested C# blocks do not close Razor and PHP branches early
- Add a low-level tracker regression for nested Razor `@if/@else` branches with inner C# blocks
- Add an `S7930` Razor regression file that still reports the real duplicate outside the conditional

## Functional Validation
Artifact:[SONARHTML-411-fv.zip](https://github.com/user-attachments/files/30113755/SONARHTML-411-fv.zip)

Once the file is attached to the PR description, unzip and run:
    ./run.sh

Expected output:
```text
******************* MASTER *******************
Analyzing "conditionalBlocksNested.cshtml"...
Results:
    - Rule "S7930" -> L.14
    - Rule "S7930" -> L.18

****** Branch "fix/sonarhtml-411-nested-razor-branches" (81f2148ea085fe5149d888a3f33161fc7562cee4) ******
Analyzing "conditionalBlocksNested.cshtml"...
Results:
    - Rule "S7930" -> L.18
```


