### PR TITLE
SONARHTML-412 Add regression test for S7930 Razor code-block preamble FP

### DIFF
--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
@@ -241,6 +241,19 @@ class NoDuplicateIDCheckTest {
   }
 
   @Test
+  void razorConditionalBlocksWithCodeBlockPreamble() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+        new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksRazorPreamble.cshtml"),
+        new NoDuplicateIDCheck());
+
+    // A top-level @{ ... } code block containing a C# if must not consume the conditional depth of the
+    // following @if/else if chain; ids across those branches stay mutually exclusive
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+        .next().atLine(27).withMessage("Duplicate id \"footer\" found. First occurrence was on line 26.")
+        .noMore();
+  }
+
+  @Test
   void razorConditionalBlocksWithScriptTemplateLiteral() {
     HtmlSourceCode sourceCode = TestHelper.scan(
         new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksScriptTemplateLiteral.cshtml"),

--- a/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksRazorPreamble.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksRazorPreamble.cshtml
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+@{
+    string headerType = null;
+    if (Model.Type == "home-search")
+    {
+        headerType = "home";
+    }
+}
+@if (Model.Type == "search" ||
+    Model.Type == "home-search")
+{
+    <bgl-visual-header id="home_vhead"></bgl-visual-header>
+}
+else if (Model.Type == "inspiration")
+{
+    <bgl-visual-header id="home_vhead"></bgl-visual-header>
+}
+else if (Model.Type == "home")
+{
+    <bgl-visual-header id="home_vhead"></bgl-visual-header>
+}
+
+<div id="footer">One</div>
+<div id="footer">Two</div>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds a regression test for the `S7930` (NoDuplicateID) false positive described in SONARHTML-412: a Razor `@if / else if` chain preceded by a top-level `@{ ... }` code block (itself containing a C# `if`) reported duplicate ids on the mutually-exclusive branches.

The underlying bug was already fixed on `master` by the SONARHTML-411 rework (#744), which reworked `TemplateConditionalScopeTracker`. That PR did not, however, include a test for this specific shape, so the fix was unguarded and could silently regress. This change closes that gap.

## What this adds

- `conditionalBlocksRazorPreamble.cshtml` — the SONARHTML-412 repro: a top-level `@{ ... }` preamble followed by an `@if / else if / else if` chain reusing `id="home_vhead"`, plus a genuine duplicate `id="footer"` outside any conditional.
- `razorConditionalBlocksWithCodeBlockPreamble` — asserts only the real outside duplicate is flagged; the three branch ids are not.

## Validation

- Passes on current `master`.
- Verified as a real guard: swapping in the pre-fix `TemplateConditionalScopeTracker` makes the test fail (the branch false positives reappear).

No production code changes — test-only.
