### PR TITLE
CLP-212: Migrate scanner test fixtures

### DIFF
--- a/sonar-html-plugin/pom.xml
+++ b/sonar-html-plugin/pom.xml
@@ -86,18 +86,6 @@
     </dependency>
     <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
-      <artifactId>sonar-plugin-api-impl</artifactId>
-      <version>${sonarqube.api.impl.version}</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-testing-harness</artifactId>
       <version>${sonarqube.api.impl.version}</version>
       <scope>test</scope>

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/HtmlPluginTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/HtmlPluginTest.java
@@ -16,11 +16,11 @@
  */
 package org.sonar.plugins.html;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.Plugin;
 import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
-import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.utils.Version;
 import org.sonar.plugins.html.core.AnalysisWarningsWrapper;
 import org.sonar.plugins.html.core.Html;
@@ -32,12 +32,11 @@ import org.sonar.plugins.html.rules.SonarWayProfile;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-
 class HtmlPluginTest {
 
   @Test
   void webPluginTester() {
-    Plugin.Context context = new Plugin.Context(SonarRuntimeImpl.forSonarQube(Version.create(7, 9), SonarQubeSide.SERVER, SonarEdition.COMMUNITY));
+    Plugin.Context context = new Plugin.Context(TestSonarRuntime.forSonarQube(Version.create(7, 9), SonarQubeSide.SERVER, SonarEdition.COMMUNITY));
 
     new HtmlPlugin().define(context);
     assertThat(context.getExtensions())

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlFileExtensionsTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlFileExtensionsTest.java
@@ -18,8 +18,8 @@ package org.sonar.plugins.html.core;
 
 import java.util.Set;
 import org.junit.jupiter.api.Test;
-import org.sonar.api.config.internal.MapSettings;
 import org.sonar.plugins.html.api.HtmlConstants;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlSensorTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlSensorTest.java
@@ -16,6 +16,9 @@
  */
 package org.sonar.plugins.html.core;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -34,19 +37,11 @@ import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.SonarRuntime;
 import org.sonar.api.batch.fs.InputFile;
-import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
-import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import org.sonar.api.batch.rule.ActiveRules;
 import org.sonar.api.batch.rule.CheckFactory;
-import org.sonar.scanner.plugin.api.impl.fs.DefaultInputFile;
-import org.sonar.scanner.plugin.api.impl.rule.DefaultActiveRules;
-import org.sonar.scanner.plugin.api.impl.rule.NewActiveRule;
 import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.batch.sensor.highlighting.TypeOfText;
-import org.sonar.scanner.plugin.api.impl.sensor.DefaultSensorDescriptor;
 import org.sonar.api.batch.sensor.issue.IssueResolution;
-import org.sonar.scanner.plugin.api.impl.sensor.issue.DefaultNoSonarFilter;
-import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.measures.CoreMetrics;
 import org.sonar.api.measures.FileLinesContext;
 import org.sonar.api.measures.FileLinesContextFactory;
@@ -58,6 +53,11 @@ import org.sonar.api.utils.Version;
 import org.sonar.plugins.html.api.HtmlConstants;
 import org.sonar.plugins.html.checks.sonar.AllowedLangAttributeCheck;
 import org.sonar.plugins.html.rules.HtmlRulesDefinition;
+import org.sonar.scanner.plugin.api.impl.fs.DefaultInputFile;
+import org.sonar.scanner.plugin.api.impl.rule.DefaultActiveRules;
+import org.sonar.scanner.plugin.api.impl.rule.NewActiveRule;
+import org.sonar.scanner.plugin.api.impl.sensor.DefaultSensorDescriptor;
+import org.sonar.scanner.plugin.api.impl.sensor.issue.DefaultNoSonarFilter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -77,7 +77,7 @@ class HtmlSensorTest {
 
   @BeforeEach
   void setUp() {
-    final SonarRuntime sonarRuntime = SonarRuntimeImpl.forSonarQube(Version.create(8, 9), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY);
+    final SonarRuntime sonarRuntime = TestSonarRuntime.forSonarQube(Version.create(8, 9), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY);
     HtmlRulesDefinition rulesDefinition = new HtmlRulesDefinition(sonarRuntime);
     RulesDefinition.Context context = new RulesDefinition.Context();
     rulesDefinition.define(context);
@@ -147,7 +147,7 @@ class HtmlSensorTest {
 
   @Test
   void sonarlint() throws IOException {
-    tester.setRuntime(SonarRuntimeImpl.forSonarLint(Version.create(6, 7)));
+    tester.setRuntime(TestSonarRuntime.forSonarLint(Version.create(6, 7)));
     DefaultInputFile inputFile = createInputFile(TEST_DIR, "user-properties.jsp");
     tester.fileSystem().add(inputFile);
     sensor.execute(tester);
@@ -159,7 +159,7 @@ class HtmlSensorTest {
 
   @Test
   void sonar_resolve_is_saved_at_minimum_supported_runtime() {
-    tester.setRuntime(SonarRuntimeImpl.forSonarQube(Version.create(13, 5), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY));
+    tester.setRuntime(TestSonarRuntime.forSonarQube(Version.create(13, 5), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY));
     DefaultInputFile inputFile = createInputFile("sonar-resolve.html", String.join("\n",
       "<div>",
       "<!-- sonar-resolve [fp] Web:S5256 \"reason\" -->",
@@ -178,7 +178,7 @@ class HtmlSensorTest {
 
   @Test
   void sonar_resolve_is_ignored_before_supported_runtime() {
-    tester.setRuntime(SonarRuntimeImpl.forSonarQube(Version.create(13, 4), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY));
+    tester.setRuntime(TestSonarRuntime.forSonarQube(Version.create(13, 4), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY));
     DefaultInputFile inputFile = createInputFile("sonar-resolve.html", String.join("\n",
       "<div>",
       "<!-- sonar-resolve Web:S5256 \"reason\" -->",
@@ -192,7 +192,7 @@ class HtmlSensorTest {
 
   @Test
   void sonar_resolve_is_ignored_in_sonarlint() {
-    tester.setRuntime(SonarRuntimeImpl.forSonarLint(Version.create(13, 6)));
+    tester.setRuntime(TestSonarRuntime.forSonarLint(Version.create(13, 6)));
     DefaultInputFile inputFile = createInputFile("sonar-resolve.html", String.join("\n",
       "<div>",
       "<!-- sonar-resolve Web:S5256 \"reason\" -->",
@@ -206,7 +206,7 @@ class HtmlSensorTest {
 
   @Test
   void unreadable_file() {
-    tester.setRuntime(SonarRuntimeImpl.forSonarLint(Version.create(6, 7)));
+    tester.setRuntime(TestSonarRuntime.forSonarLint(Version.create(6, 7)));
     DefaultInputFile inputFile = new TestInputFileBuilder("key", "user-properties.jsp")
       .setModuleBaseDir(TEST_DIR)
       .setLanguage(HtmlConstants.LANGUAGE_KEY)
@@ -232,7 +232,7 @@ class HtmlSensorTest {
   @Test
   void test_descriptor_sonarlint() {
     DefaultSensorDescriptor sensorDescriptor = new DefaultSensorDescriptor();
-    SonarRuntime sonarRuntime = SonarRuntimeImpl.forSonarLint(Version.create(6, 5));
+    SonarRuntime sonarRuntime = TestSonarRuntime.forSonarLint(Version.create(6, 5));
     new HtmlSensor(sonarRuntime, null, null, new CheckFactory(new DefaultActiveRules(Collections.emptyList())),
       new AnalysisWarningsWrapper()).describe(sensorDescriptor);
     assertThat(sensorDescriptor.name()).isEqualTo("HTML");
@@ -249,7 +249,7 @@ class HtmlSensorTest {
         return this;
       }
     };
-    SonarRuntime sonarRuntime = SonarRuntimeImpl.forSonarQube(Version.create(9, 3), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY);
+    SonarRuntime sonarRuntime = TestSonarRuntime.forSonarQube(Version.create(9, 3), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY);
     new HtmlSensor(sonarRuntime, null, null, new CheckFactory(new DefaultActiveRules(Collections.emptyList())),
       new AnalysisWarningsWrapper()).describe(sensorDescriptor);
     assertThat(sensorDescriptor.name()).isEqualTo("HTML");
@@ -260,7 +260,7 @@ class HtmlSensorTest {
 
   @Test
   void php_file_should_not_have_metrics() {
-    tester.setRuntime(SonarRuntimeImpl.forSonarQube(Version.create(7, 9), SonarQubeSide.SERVER, SonarEdition.COMMUNITY));
+    tester.setRuntime(TestSonarRuntime.forSonarQube(Version.create(7, 9), SonarQubeSide.SERVER, SonarEdition.COMMUNITY));
     DefaultInputFile inputFile = new TestInputFileBuilder("key", "foo.php")
       .setModuleBaseDir(TEST_DIR).setContents("""
         <html>

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlTest.java
@@ -17,8 +17,8 @@
 package org.sonar.plugins.html.core;
 
 import org.junit.jupiter.api.Test;
-import org.sonar.api.config.internal.MapSettings;
 import org.sonar.plugins.html.api.HtmlConstants;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/JspTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/JspTest.java
@@ -17,8 +17,8 @@
 package org.sonar.plugins.html.core;
 
 import org.junit.jupiter.api.Test;
-import org.sonar.api.config.internal.MapSettings;
 import org.sonar.plugins.html.api.HtmlConstants;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/CheckClassesTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/CheckClassesTest.java
@@ -16,11 +16,11 @@
  */
 package org.sonar.plugins.html.rules;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.SonarRuntime;
-import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.utils.Version;
 
@@ -40,7 +40,7 @@ class CheckClassesTest {
         .isNotNull();
     }
 
-    SonarRuntime sonarRuntime = SonarRuntimeImpl.forSonarQube(Version.create(8, 9), SonarQubeSide.SERVER, SonarEdition.COMMUNITY);
+    SonarRuntime sonarRuntime = TestSonarRuntime.forSonarQube(Version.create(8, 9), SonarQubeSide.SERVER, SonarEdition.COMMUNITY);
     HtmlRulesDefinition rulesDefinition = new HtmlRulesDefinition(sonarRuntime);
     RulesDefinition.Context context = new RulesDefinition.Context();
     rulesDefinition.define(context);

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/HtmlRulesDefinitionTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/rules/HtmlRulesDefinitionTest.java
@@ -16,6 +16,7 @@
  */
 package org.sonar.plugins.html.rules;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -23,7 +24,6 @@ import org.junit.jupiter.api.Test;
 import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.SonarRuntime;
-import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.rules.RuleType;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.utils.Version;
@@ -34,7 +34,7 @@ class HtmlRulesDefinitionTest {
 
   @Test
   void test() {
-    SonarRuntime sonarRuntime = SonarRuntimeImpl.forSonarQube(Version.create(8, 9), SonarQubeSide.SERVER, SonarEdition.COMMUNITY);
+    SonarRuntime sonarRuntime = TestSonarRuntime.forSonarQube(Version.create(8, 9), SonarQubeSide.SERVER, SonarEdition.COMMUNITY);
     HtmlRulesDefinition rulesDefinition = new HtmlRulesDefinition(sonarRuntime);
     RulesDefinition.Context context = new RulesDefinition.Context();
     rulesDefinition.define(context);

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/visitor/SonarResolveScannerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/visitor/SonarResolveScannerTest.java
@@ -16,6 +16,9 @@
  */
 package org.sonar.plugins.html.visitor;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
@@ -32,10 +35,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.batch.fs.InputFile;
-import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
-import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.issue.IssueResolution;
-import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.rule.RuleKey;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.api.utils.Version;
@@ -257,7 +257,7 @@ class SonarResolveScannerTest {
 
   private static SensorContextTester newSensorContext() {
     return SensorContextTester.create(Paths.get("."))
-      .setRuntime(SonarRuntimeImpl.forSonarQube(Version.create(13, 6), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY));
+      .setRuntime(TestSonarRuntime.forSonarQube(Version.create(13, 6), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY));
   }
 
   private static void assertResolution(IssueResolution issueResolution, String ruleKey, String comment, int line) {


### PR DESCRIPTION
## Summary

- remove the SonarQube `sonar-plugin-api-impl` dependency
- migrate moved scanner implementation imports and use `TestSonarRuntime`
- keep scanner-engine 13.4.1 fixtures as the direct test dependencies

## Dependency changes

Before: tests resolved both `org.sonarsource.sonarqube:sonar-plugin-api-impl` and the scanner fixture artifacts.

After: tests use `plugin-api-scanner-impl` and `sensor-test-fixtures` at `13.4.1.4007`; the resolved Maven graph contains no `sonar-plugin-api-impl`.

`sonar-plugin-api-test-fixtures` is retained for its logging helpers.

## Validation

- `mvn -q test`
- Maven dependency-tree check for `org.sonarsource.sonarqube:sonar-plugin-api-impl` (no matches)
- `git diff --check`
