### PR TITLE
SONARHTML-421 Fix S1093 direct-parent handling

### DIFF
--- a/its/ruling/src/test/resources/expected/Web-ItemTagNotWithinContainerTagCheck.json
+++ b/its/ruling/src/test/resources/expected/Web-ItemTagNotWithinContainerTagCheck.json
@@ -5,13 +5,6 @@
 "project:Silverpeas-Core-master/war-core/src/main/webapp/pdcPeas/jsp/positionsInComponent.jsp": [
 216
 ],
-"project:Silverpeas-Core-master/war-core/src/main/webapp/portlet/jsp/jsr/portletSP.jsp": [
-40,
-43
-],
-"project:Silverpeas-Core-master/war-core/src/main/webapp/profil/jsp/ProfilPrive.jsp": [
-62
-],
 "project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLDirectoryElement01.html": [
 9,
 10,
@@ -34,6 +27,17 @@
 10,
 11
 ],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/issues/_sidebar.html.erb": [
+12,
+15,
+26,
+32,
+38,
+44,
+50,
+56,
+64
+],
 "project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/layouts/_menu_administration.html.erb": [
 1
 ],
@@ -51,5 +55,19 @@
 5,
 9,
 10
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/measures/_sidebar.html.erb": [
+86,
+89,
+97,
+106,
+110,
+114,
+119,
+126,
+134,
+142,
+149,
+176
 ]
 }

--- a/its/ruling/src/test/resources/expected/Web-ItemTagNotWithinContainerTagCheck.json
+++ b/its/ruling/src/test/resources/expected/Web-ItemTagNotWithinContainerTagCheck.json
@@ -15,6 +15,11 @@
 12,
 13
 ],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/keep_spelling_markers.html": [
+14,
+15,
+16
+],
 "project:phpMyAdmin-4.0.4-english/themes/original/css/common.css.php": [
 766
 ],

--- a/its/ruling/src/test/resources/expected/Web-ItemTagNotWithinContainerTagCheck.json
+++ b/its/ruling/src/test/resources/expected/Web-ItemTagNotWithinContainerTagCheck.json
@@ -15,11 +15,6 @@
 12,
 13
 ],
-"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/keep_spelling_markers.html": [
-14,
-15,
-16
-],
 "project:phpMyAdmin-4.0.4-english/themes/original/css/common.css.php": [
 766
 ],

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheck.java
@@ -16,6 +16,8 @@
  */
 package org.sonar.plugins.html.checks.sonar;
 
+import static org.sonar.plugins.html.api.HtmlConstants.hasKnownHTMLTag;
+
 import java.util.List;
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.api.Helpers;
@@ -39,19 +41,43 @@ public class ItemTagNotWithinContainerTagCheck extends AbstractPageCheck {
     if (Helpers.hasTemplateAncestor(node) || razorSectionScope.contains(node)) {
       return;
     }
-    if (isLi(node) && !hasLiOrUlOrOlAncestor(node)) {
+    TagNode parent = effectiveParent(node);
+    if (isLi(node) && (parent == null || (hasKnownHTMLTag(parent) && !(isLi(parent) || isLiAllowedParent(parent))))) {
       createViolation(node, "Surround this <" + node.getNodeName() + "> item tag by a <ul> or <ol> container one.");
-    } else if (isDt(node) && !hasDtOrDlAncestor(node)) {
+    } else if (isDt(node) && (parent == null || (hasKnownHTMLTag(parent) && !(isDt(parent) || isDl(parent))))) {
       createViolation(node, "Surround this <" + node.getNodeName() + "> item tag by a <dl> container one.");
     }
   }
 
-  private static boolean hasLiOrUlOrOlAncestor(TagNode node) {
-    return Helpers.hasAncestorMatching(node, p -> isLi(p) || isLiAllowedParent(p));
+  /**
+   * Returns the effective direct parent after skipping parser artifacts caused by omitted end tags.
+   *
+   * @param node the item tag being checked
+   * @return the nearest parent that remains structurally relevant for the rule
+   */
+  private static TagNode effectiveParent(TagNode node) {
+    TagNode parent = node.getParent();
+    while (parent != null && isImplicitlyClosedBy(node, parent)) {
+      parent = parent.getParent();
+    }
+    return parent;
   }
 
-  private static boolean hasDtOrDlAncestor(TagNode node) {
-    return Helpers.hasAncestorMatching(node, p -> isDt(p) || isDl(p));
+  /**
+   * Returns whether opening the current item tag implicitly closes the parsed parent in HTML.
+   *
+   * @param node the item tag being checked
+   * @param parent the current parsed parent candidate
+   * @return true if the parent should be skipped as an omitted-end-tag artifact
+   */
+  private static boolean isImplicitlyClosedBy(TagNode node, TagNode parent) {
+    if (isLi(node)) {
+      return isLi(parent) || "P".equalsIgnoreCase(parent.getNodeName());
+    }
+    if (isDt(node)) {
+      return isDt(parent) || "DD".equalsIgnoreCase(parent.getNodeName()) || "P".equalsIgnoreCase(parent.getNodeName());
+    }
+    return false;
   }
 
   private static boolean isLi(TagNode node) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheck.java
@@ -19,6 +19,7 @@ package org.sonar.plugins.html.checks.sonar;
 import static org.sonar.plugins.html.api.HtmlConstants.hasKnownHTMLTag;
 
 import java.util.List;
+import java.util.function.Predicate;
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.api.Helpers;
 import org.sonar.plugins.html.api.RazorSectionScopeTracker;
@@ -42,11 +43,15 @@ public class ItemTagNotWithinContainerTagCheck extends AbstractPageCheck {
       return;
     }
     TagNode parent = effectiveParent(node);
-    if (isLi(node) && (parent == null || (hasKnownHTMLTag(parent) && !isLiAllowedParent(parent)))) {
-      createViolation(node, "Surround this <" + node.getNodeName() + "> item tag by a <ul> or <ol> container one.");
-    } else if (isDt(node) && (parent == null || (hasKnownHTMLTag(parent) && !isDl(parent)))) {
+    if (isLi(node) && shouldReport(parent, ItemTagNotWithinContainerTagCheck::isLiAllowedParent)) {
+      createViolation(node, "Surround this <" + node.getNodeName() + "> item tag by a <ul>, <ol> or <menu> container one.");
+    } else if (isDt(node) && shouldReport(parent, ItemTagNotWithinContainerTagCheck::isDl)) {
       createViolation(node, "Surround this <" + node.getNodeName() + "> item tag by a <dl> container one.");
     }
+  }
+
+  private static boolean shouldReport(TagNode parent, Predicate<TagNode> isAllowedParent) {
+    return parent == null || (hasKnownHTMLTag(parent) && !isAllowedParent.test(parent));
   }
 
   /**

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheck.java
@@ -20,6 +20,7 @@ import static org.sonar.plugins.html.api.HtmlConstants.hasKnownHTMLTag;
 
 import java.util.List;
 import java.util.function.Predicate;
+import javax.annotation.Nullable;
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.api.Helpers;
 import org.sonar.plugins.html.api.RazorSectionScopeTracker;
@@ -50,7 +51,7 @@ public class ItemTagNotWithinContainerTagCheck extends AbstractPageCheck {
     }
   }
 
-  private static boolean shouldReport(TagNode parent, Predicate<TagNode> isAllowedParent) {
+  private static boolean shouldReport(@Nullable TagNode parent, Predicate<TagNode> isAllowedParent) {
     return parent == null || (hasKnownHTMLTag(parent) && !isAllowedParent.test(parent));
   }
 
@@ -76,12 +77,11 @@ public class ItemTagNotWithinContainerTagCheck extends AbstractPageCheck {
    * @return true if the parent should be skipped as an omitted-end-tag artifact
    */
   private static boolean isImplicitlyClosedBy(TagNode node, TagNode parent) {
-    TagNode grandParent = parent.getParent();
     if (isLi(node)) {
-      return isLi(parent) || (isP(parent) && grandParent != null && isLi(grandParent));
+      return isLi(parent) || isP(parent);
     }
     if (isDt(node)) {
-      return isDefinitionItem(parent) || (isP(parent) && grandParent != null && isDefinitionItem(grandParent));
+      return isDefinitionItem(parent) || isP(parent);
     }
     return false;
   }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheck.java
@@ -42,9 +42,9 @@ public class ItemTagNotWithinContainerTagCheck extends AbstractPageCheck {
       return;
     }
     TagNode parent = effectiveParent(node);
-    if (isLi(node) && (parent == null || (hasKnownHTMLTag(parent) && !(isLi(parent) || isLiAllowedParent(parent))))) {
+    if (isLi(node) && (parent == null || (hasKnownHTMLTag(parent) && !isLiAllowedParent(parent)))) {
       createViolation(node, "Surround this <" + node.getNodeName() + "> item tag by a <ul> or <ol> container one.");
-    } else if (isDt(node) && (parent == null || (hasKnownHTMLTag(parent) && !(isDt(parent) || isDl(parent))))) {
+    } else if (isDt(node) && (parent == null || (hasKnownHTMLTag(parent) && !isDl(parent)))) {
       createViolation(node, "Surround this <" + node.getNodeName() + "> item tag by a <dl> container one.");
     }
   }
@@ -71,13 +71,18 @@ public class ItemTagNotWithinContainerTagCheck extends AbstractPageCheck {
    * @return true if the parent should be skipped as an omitted-end-tag artifact
    */
   private static boolean isImplicitlyClosedBy(TagNode node, TagNode parent) {
+    TagNode grandParent = parent.getParent();
     if (isLi(node)) {
-      return isLi(parent) || "P".equalsIgnoreCase(parent.getNodeName());
+      return isLi(parent) || (isP(parent) && grandParent != null && isLi(grandParent));
     }
     if (isDt(node)) {
-      return isDt(parent) || "DD".equalsIgnoreCase(parent.getNodeName()) || "P".equalsIgnoreCase(parent.getNodeName());
+      return isDefinitionItem(parent) || (isP(parent) && grandParent != null && isDefinitionItem(grandParent));
     }
     return false;
+  }
+
+  private static boolean isDefinitionItem(TagNode node) {
+    return isDt(node) || isDd(node);
   }
 
   private static boolean isLi(TagNode node) {
@@ -86,6 +91,10 @@ public class ItemTagNotWithinContainerTagCheck extends AbstractPageCheck {
 
   private static boolean isDt(TagNode node) {
     return "DT".equalsIgnoreCase(node.getNodeName());
+  }
+
+  private static boolean isDd(TagNode node) {
+    return "DD".equalsIgnoreCase(node.getNodeName());
   }
 
   private static boolean isLiAllowedParent(TagNode node) {
@@ -106,6 +115,10 @@ public class ItemTagNotWithinContainerTagCheck extends AbstractPageCheck {
 
   private static boolean isDl(TagNode node) {
     return "DL".equalsIgnoreCase(node.getNodeName());
+  }
+
+  private static boolean isP(TagNode node) {
+    return "P".equalsIgnoreCase(node.getNodeName());
   }
 
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheckTest.java
@@ -41,7 +41,9 @@ class ItemTagNotWithinContainerTagCheckTest {
         .next().atLine(8).withMessage("Surround this <li> item tag by a <ul> or <ol> container one.")
         .next().atLine(12).withMessage("Surround this <dt> item tag by a <dl> container one.")
         .next().atLine(17).withMessage("Surround this <li> item tag by a <ul> or <ol> container one.")
-        .next().atLine(23).withMessage("Surround this <dt> item tag by a <dl> container one.");
+        .next().atLine(23).withMessage("Surround this <dt> item tag by a <dl> container one.")
+        .next().atLine(29).withMessage("Surround this <li> item tag by a <ul> or <ol> container one.")
+        .next().atLine(35).withMessage("Surround this <dt> item tag by a <dl> container one.");
   }
 
   @Test

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheckTest.java
@@ -42,10 +42,8 @@ class ItemTagNotWithinContainerTagCheckTest {
         .next().atLine(12).withMessage("Surround this <dt> item tag by a <dl> container one.")
         .next().atLine(17).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.")
         .next().atLine(23).withMessage("Surround this <dt> item tag by a <dl> container one.")
-        .next().atLine(29).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.")
-        .next().atLine(35).withMessage("Surround this <dt> item tag by a <dl> container one.")
-        .next().atLine(40).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.")
-        .next().atLine(41).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.");
+        .next().atLine(28).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.")
+        .next().atLine(29).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.");
   }
 
   @Test

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheckTest.java
@@ -36,14 +36,16 @@ class ItemTagNotWithinContainerTagCheckTest {
         new ItemTagNotWithinContainerTagCheck());
 
     checkMessagesVerifier.verify(sourceCode.getIssues())
-        .next().atLocation(1, 0, 1, 4).withMessage("Surround this <li> item tag by a <ul> or <ol> container one.")
+        .next().atLocation(1, 0, 1, 4).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.")
         .next().atLocation(4, 0, 4, 4).withMessage("Surround this <DT> item tag by a <dl> container one.")
-        .next().atLine(8).withMessage("Surround this <li> item tag by a <ul> or <ol> container one.")
+        .next().atLine(8).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.")
         .next().atLine(12).withMessage("Surround this <dt> item tag by a <dl> container one.")
-        .next().atLine(17).withMessage("Surround this <li> item tag by a <ul> or <ol> container one.")
+        .next().atLine(17).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.")
         .next().atLine(23).withMessage("Surround this <dt> item tag by a <dl> container one.")
-        .next().atLine(29).withMessage("Surround this <li> item tag by a <ul> or <ol> container one.")
-        .next().atLine(35).withMessage("Surround this <dt> item tag by a <dl> container one.");
+        .next().atLine(29).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.")
+        .next().atLine(35).withMessage("Surround this <dt> item tag by a <dl> container one.")
+        .next().atLine(40).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.")
+        .next().atLine(41).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.");
   }
 
   @Test
@@ -66,10 +68,10 @@ class ItemTagNotWithinContainerTagCheckTest {
         new ItemTagNotWithinContainerTagCheck());
 
     checkMessagesVerifier.verify(sourceCode.getIssues())
-        .next().atLine(15).withMessage("Surround this <li> item tag by a <ul> or <ol> container one.")
+        .next().atLine(15).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.")
         .next().atLine(17).withMessage("Surround this <dt> item tag by a <dl> container one.")
-        .next().atLine(20).withMessage("Surround this <li> item tag by a <ul> or <ol> container one.")
-        .next().atLine(24).withMessage("Surround this <li> item tag by a <ul> or <ol> container one.");
+        .next().atLine(20).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.")
+        .next().atLine(24).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.");
   }
 
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheckTest.java
@@ -38,10 +38,10 @@ class ItemTagNotWithinContainerTagCheckTest {
     checkMessagesVerifier.verify(sourceCode.getIssues())
         .next().atLocation(1, 0, 1, 4).withMessage("Surround this <li> item tag by a <ul> or <ol> container one.")
         .next().atLocation(4, 0, 4, 4).withMessage("Surround this <DT> item tag by a <dl> container one.")
-        .next().atLine(8).withMessage("Surround this <lI> item tag by a <ul> or <ol> container one.")
+        .next().atLine(8).withMessage("Surround this <li> item tag by a <ul> or <ol> container one.")
         .next().atLine(12).withMessage("Surround this <dt> item tag by a <dl> container one.")
-        .next().atLine(16).withMessage("Surround this <li> item tag by a <ul> or <ol> container one.")
-        .next().atLine(20).withMessage("Surround this <dt> item tag by a <dl> container one.");
+        .next().atLine(17).withMessage("Surround this <li> item tag by a <ul> or <ol> container one.")
+        .next().atLine(23).withMessage("Surround this <dt> item tag by a <dl> container one.");
   }
 
   @Test
@@ -49,8 +49,12 @@ class ItemTagNotWithinContainerTagCheckTest {
     HtmlSourceCode sourceCode = TestHelper.scan(
         new File("src/test/resources/checks/ItemTagNotWithinContainerTagCheck/valid-cases.html"),
         new ItemTagNotWithinContainerTagCheck());
+    HtmlSourceCode vueSourceCode = TestHelper.scan(
+        new File("src/test/resources/checks/ItemTagNotWithinContainerTagCheck/custom-component.vue"),
+        new ItemTagNotWithinContainerTagCheck());
 
     checkMessagesVerifier.verify(sourceCode.getIssues());
+    checkMessagesVerifier.verify(vueSourceCode.getIssues());
   }
 
   @Test

--- a/sonar-html-plugin/src/test/resources/checks/ItemTagNotWithinContainerTagCheck/custom-component.vue
+++ b/sonar-html-plugin/src/test/resources/checks/ItemTagNotWithinContainerTagCheck/custom-component.vue
@@ -1,0 +1,15 @@
+<ComboboxOption
+  v-for="option in filteredOptions"
+  :key="option.value"
+  v-slot="{ selected, active }"
+  :value="option"
+>
+  <li
+    :class="[
+      'relative cursor-default select-none py-2 pl-10 pr-4',
+      active ? 'bg-primary-500 text-white' : 'text-secondary-500',
+    ]"
+  >
+    {{ option.label }}
+  </li>
+</ComboboxOption>

--- a/sonar-html-plugin/src/test/resources/checks/ItemTagNotWithinContainerTagCheck/invalid-cases.html
+++ b/sonar-html-plugin/src/test/resources/checks/ItemTagNotWithinContainerTagCheck/invalid-cases.html
@@ -4,18 +4,22 @@
 <DT>        <!-- Non-Compliant -->
 </dt>
 
-<foo>
-  <lI>foo   <!-- Non-Compliant -->
-</foo>
+<div>
+  <li>foo   <!-- Non-Compliant - direct parent is a known invalid HTML tag -->
+</div>
 
-<foo>
-  <dt></dt><!-- Non-Compliant -->
-</foo>
+<section>
+  <dt></dt><!-- Non-Compliant - direct parent is a known invalid HTML tag -->
+</section>
 
-<c:if test="${show}">
-  <li>x</li><!-- Non-Compliant - <c:if> is control flow, not a container -->
-</c:if>
+<ul>
+  <div>
+    <li>x</li><!-- Non-Compliant - a valid ancestor does not compensate for an invalid direct parent -->
+  </div>
+</ul>
 
-<th:block th:if="${show}">
-  <dt>y</dt><!-- Non-Compliant - <th:block> is a no-op wrapper, not a container -->
-</th:block>
+<dl>
+  <div>
+    <dt>y</dt><!-- Non-Compliant - a valid ancestor does not compensate for an invalid direct parent -->
+  </div>
+</dl>

--- a/sonar-html-plugin/src/test/resources/checks/ItemTagNotWithinContainerTagCheck/invalid-cases.html
+++ b/sonar-html-plugin/src/test/resources/checks/ItemTagNotWithinContainerTagCheck/invalid-cases.html
@@ -35,3 +35,8 @@
     <dt>w</dt><!-- Non-Compliant - a real <p> wrapper remains an invalid direct parent -->
   </p>
 </dl>
+
+<div>
+  <li>a     <!-- Non-Compliant - walk-up past the sibling <li> still reaches the invalid <div> parent -->
+  <li>b     <!-- Non-Compliant - walk-up past the sibling <li> still reaches the invalid <div> parent -->
+</div>

--- a/sonar-html-plugin/src/test/resources/checks/ItemTagNotWithinContainerTagCheck/invalid-cases.html
+++ b/sonar-html-plugin/src/test/resources/checks/ItemTagNotWithinContainerTagCheck/invalid-cases.html
@@ -24,18 +24,6 @@
   </div>
 </dl>
 
-<ul>
-  <p>
-    <li>z</li><!-- Non-Compliant - a real <p> wrapper remains an invalid direct parent -->
-  </p>
-</ul>
-
-<dl>
-  <p>
-    <dt>w</dt><!-- Non-Compliant - a real <p> wrapper remains an invalid direct parent -->
-  </p>
-</dl>
-
 <div>
   <li>a     <!-- Non-Compliant - walk-up past the sibling <li> still reaches the invalid <div> parent -->
   <li>b     <!-- Non-Compliant - walk-up past the sibling <li> still reaches the invalid <div> parent -->

--- a/sonar-html-plugin/src/test/resources/checks/ItemTagNotWithinContainerTagCheck/invalid-cases.html
+++ b/sonar-html-plugin/src/test/resources/checks/ItemTagNotWithinContainerTagCheck/invalid-cases.html
@@ -23,3 +23,15 @@
     <dt>y</dt><!-- Non-Compliant - a valid ancestor does not compensate for an invalid direct parent -->
   </div>
 </dl>
+
+<ul>
+  <p>
+    <li>z</li><!-- Non-Compliant - a real <p> wrapper remains an invalid direct parent -->
+  </p>
+</ul>
+
+<dl>
+  <p>
+    <dt>w</dt><!-- Non-Compliant - a real <p> wrapper remains an invalid direct parent -->
+  </p>
+</dl>

--- a/sonar-html-plugin/src/test/resources/checks/ItemTagNotWithinContainerTagCheck/valid-cases.html
+++ b/sonar-html-plugin/src/test/resources/checks/ItemTagNotWithinContainerTagCheck/valid-cases.html
@@ -1,6 +1,6 @@
 <ul>
   <foo>
-    <li>    <!-- Compliant - limitation because of bad unclosed tags handling -->
+    <li>    <!-- Compliant - custom direct parent is ignored -->
   </foo>
 </ul>
 
@@ -75,19 +75,27 @@
 <template>
   <div>
     <span>
-      <li>deeply nested</li>  <!-- Compliant - <template> is a transitive ancestor -->
+      <li>deeply nested</li>  <!-- Compliant - <template> ancestor keeps rendered structure unknown -->
     </span>
   </div>
 </template>
 
+<c:if test="${show}">
+  <li>x</li>         <!-- Compliant - non-HTML direct parent is ignored -->
+</c:if>
+
+<th:block th:if="${show}">
+  <dt>y</dt>         <!-- Compliant - non-HTML direct parent is ignored -->
+</th:block>
+
 <ul>
   <c:forEach var="x" items="${xs}">
-    <li>${x}</li>         <!-- Compliant - <ul> is a real ancestor -->
+    <li>${x}</li>         <!-- Compliant - non-HTML direct parent is ignored -->
   </c:forEach>
 </ul>
 
 <dl>
   <th:block th:each="item : ${items}">
-    <dt th:text="${item}">x</dt>  <!-- Compliant - <dl> is a real ancestor -->
+    <dt th:text="${item}">x</dt>  <!-- Compliant - non-HTML direct parent is ignored -->
   </th:block>
 </dl>

--- a/sonar-html-plugin/src/test/resources/checks/ItemTagNotWithinContainerTagCheck/valid-cases.html
+++ b/sonar-html-plugin/src/test/resources/checks/ItemTagNotWithinContainerTagCheck/valid-cases.html
@@ -99,3 +99,8 @@
     <dt th:text="${item}">x</dt>  <!-- Compliant - non-HTML direct parent is ignored -->
   </th:block>
 </dl>
+
+<dl>
+  <dd>foo
+  <dt>bar    <!-- Compliant - the unclosed <dd> is skipped, <dl> is the effective parent -->
+</dl>

--- a/sonar-html-plugin/src/test/resources/checks/ItemTagNotWithinContainerTagCheck/valid-cases.html
+++ b/sonar-html-plugin/src/test/resources/checks/ItemTagNotWithinContainerTagCheck/valid-cases.html
@@ -104,3 +104,23 @@
   <dd>foo
   <dt>bar    <!-- Compliant - the unclosed <dd> is skipped, <dl> is the effective parent -->
 </dl>
+
+<ul>
+  <p>
+    <li>z</li>  <!-- Compliant - the <li> closes the <p>, so <ul> is the effective parent -->
+  </p>
+</ul>
+
+<dl>
+  <p>
+    <dt>w</dt>  <!-- Compliant - the <dt> closes the <p>, so <dl> is the effective parent -->
+  </p>
+</dl>
+
+<ol>
+  <li>a</li>
+  <li>b</li>
+  <p>note
+  <li>c</li>    <!-- Compliant - the <li> closes the preceding <p>; effective parent is <ol> -->
+  <li>d</li>
+</ol>


### PR DESCRIPTION
## Summary
This fixes S1093 so `<li>` and `<dt>` tags are judged against their effective direct parent instead of any matching ancestor.
That removes false positives on framework or custom parents and restores reports when the immediate HTML parent is definitely invalid.

## Changes
- Switch `ItemTagNotWithinContainerTagCheck` from ancestor-based compliance to an effective direct-parent heuristic.
- Preserve template and Razor suppressions while ignoring parser artifacts from omitted HTML end tags.
- Extend rule fixtures with custom-parent, definite-invalid-parent, and Vue-style binding coverage.

## Functional Validation
Artifact: [SONARHTML-421-fv.zip](https://github.com/user-attachments/files/30275375/SONARHTML-421-fv.zip)

Once the file is attached to the PR description, unzip and run:
    ./run.sh

Expected output:
```text
******************* MASTER *******************
Analyzing "sample/s1093.html"...
Results:
    - Rule "Web:ItemTagNotWithinContainerTagCheck" -> L.7

****** Branch "fix/sonarhtml-421-direct-parent-heuristic" ******
Analyzing "sample/s1093.html"...
Results:
    - Rule "Web:ItemTagNotWithinContainerTagCheck" -> L.12
    - Rule "Web:ItemTagNotWithinContainerTagCheck" -> L.18
```

