### PR TITLE
SONARHTML-407 Sync RSPEC before 3.30 release

### DIFF
--- a/sonarpedia.json
+++ b/sonarpedia.json
@@ -3,7 +3,7 @@
   "languages": [
     "HTML"
   ],
-  "latest-update": "2026-07-14T12:31:42.630722Z",
+  "latest-update": "2026-07-29T12:45:42.119380Z",
   "options": {
     "no-language-in-filenames": true,
     "preserve-filenames": true


### PR DESCRIPTION
## Summary
Refresh the generated SonarHTML RSPEC metadata before the 3.30 release. The current `rspec` master state is already reflected in the rule resources, so the sync only updates the SonarPedia timestamp.

## Changes
- Regenerate SonarHTML rule resources from `rspec` `master`
- Refresh `sonarpedia.json` to record the latest RSPEC sync date

:warning::warning: This is not ready for review :warning::warning:
