### PR TITLE
SONARHTML-438 Fix S6851 FP: false positives on unresolved alt bindings

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtils.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtils.java
@@ -17,6 +17,7 @@
 package org.sonar.plugins.html.api.accessibility;
 
 import java.util.Set;
+import javax.annotation.CheckForNull;
 import org.sonar.plugins.html.api.Thymeleaf;
 import org.sonar.plugins.html.node.TagNode;
 
@@ -66,6 +67,26 @@ public class AccessibilityUtils {
 
     var ariaDisabledAttr = element.getAttribute("aria-disabled");
     return "true".equalsIgnoreCase(ariaDisabledAttr);
+  }
+
+  /**
+   * Unwraps a JavaScript string literal used as a framework binding value
+   * (Angular {@code [x]="'foo'"}, Vue {@code :x="'foo'"}), returning the inner
+   * text. Returns {@code null} when {@code value} is not a single- or
+   * double-quoted string literal — i.e. it's a dynamic expression that cannot
+   * be statically resolved.
+   */
+  @CheckForNull
+  public static String unwrapStaticStringLiteral(@CheckForNull String value) {
+    if (value == null || value.length() < 2) {
+      return null;
+    }
+    char first = value.charAt(0);
+    char last = value.charAt(value.length() - 1);
+    if ((first == '\'' && last == '\'') || (first == '"' && last == '"')) {
+      return value.substring(1, value.length() - 1);
+    }
+    return null;
   }
 
   public static boolean isFocusableElement(TagNode element) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtils.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtils.java
@@ -18,6 +18,7 @@ package org.sonar.plugins.html.api.accessibility;
 
 import java.util.Set;
 import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
 import org.sonar.plugins.html.api.Thymeleaf;
 import org.sonar.plugins.html.node.TagNode;
 
@@ -70,23 +71,69 @@ public class AccessibilityUtils {
   }
 
   /**
-   * Unwraps a JavaScript string literal used as a framework binding value
-   * (Angular {@code [x]="'foo'"}, Vue {@code :x="'foo'"}), returning the inner
-   * text. Returns {@code null} when {@code value} is not a single- or
-   * double-quoted string literal — i.e. it's a dynamic expression that cannot
-   * be statically resolved.
+   * Unwraps a binding expression that is a single static string literal, e.g.
+   * {@code "'image of a sunrise'"} to {@code "image of a sunrise"}, and returns {@code null} for
+   * anything whose value is not resolvable at analysis time: identifiers and property accesses
+   * ({@code data.imageAlt}), concatenations ({@code 'a' + imageVar + 'b'}), method calls,
+   * ternaries, and interpolated template literals ({@code `photo of ${name}`}).
+   *
+   * <p>Whitespace around the expression is ignored, and a quote escaped with a backslash does not
+   * terminate the literal. The unwrapped text is returned as written, with escape sequences left
+   * intact. Parentheses are deliberately not unwrapped, so {@code ('a sunrise')} stays unresolved:
+   * nobody parenthesizes a bare literal in a template, and not resolving it only ever costs a
+   * missed issue, never a false positive.
+   *
+   * <p>HTML entities are not decoded, so an entity-encoded literal such as
+   * {@code &#39;sunrise&#39;} is not recognized as one.
    */
   @CheckForNull
-  public static String unwrapStaticStringLiteral(@CheckForNull String value) {
-    if (value == null || value.length() < 2) {
+  public static String unwrapStaticStringLiteral(@Nullable String value) {
+    if (value == null) {
       return null;
     }
-    char first = value.charAt(0);
-    char last = value.charAt(value.length() - 1);
-    if ((first == '\'' && last == '\'') || (first == '"' && last == '"')) {
-      return value.substring(1, value.length() - 1);
+
+    String expression = value.trim();
+    if (expression.length() < 2) {
+      return null;
     }
+
+    char quote = expression.charAt(0);
+    if (!isQuote(quote)) {
+      return null;
+    }
+
+    int index = 1;
+    while (index < expression.length()) {
+      char currentCharacter = expression.charAt(index);
+      if (currentCharacter == '\\') {
+        // Skip the escaped character. A trailing backslash runs past the end and leaves the
+        // literal unterminated, which the exit below reports as unresolved.
+        index += 2;
+      } else if (quote == '`' && isInterpolationStart(expression, index)) {
+        // A template literal such as `photo of ${name}` embeds a value, so it is not static.
+        return null;
+      } else if (currentCharacter == quote) {
+        // A genuine literal closes at the very last character. Anything following the closing
+        // quote is an operator, a member access, or a second literal, none of which resolve
+        // statically (e.g. "'a' + imageVar", "'a'.trim()", "'a''b'").
+        return index == expression.length() - 1 ? expression.substring(1, index) : null;
+      } else {
+        index++;
+      }
+    }
+
+    // The opening quote is never closed.
     return null;
+  }
+
+  private static boolean isInterpolationStart(String expression, int index) {
+    return expression.charAt(index) == '$'
+      && index + 1 < expression.length()
+      && expression.charAt(index + 1) == '{';
+  }
+
+  private static boolean isQuote(char character) {
+    return character == '\'' || character == '"' || character == '`';
   }
 
   public static boolean isFocusableElement(TagNode element) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtils.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtils.java
@@ -72,19 +72,11 @@ public class AccessibilityUtils {
 
   /**
    * Unwraps a binding expression that is a single static string literal, e.g.
-   * {@code "'image of a sunrise'"} to {@code "image of a sunrise"}, and returns {@code null} for
-   * anything whose value is not resolvable at analysis time: identifiers and property accesses
-   * ({@code data.imageAlt}), concatenations ({@code 'a' + imageVar + 'b'}), method calls,
-   * ternaries, and interpolated template literals ({@code `photo of ${name}`}).
-   *
-   * <p>Whitespace around the expression is ignored, and a quote escaped with a backslash does not
-   * terminate the literal. The unwrapped text is returned as written, with escape sequences left
-   * intact. Parentheses are deliberately not unwrapped, so {@code ('a sunrise')} stays unresolved:
-   * nobody parenthesizes a bare literal in a template, and not resolving it only ever costs a
-   * missed issue, never a false positive.
-   *
-   * <p>HTML entities are not decoded, so an entity-encoded literal such as
-   * {@code &#39;sunrise&#39;} is not recognized as one.
+   * {@code "'image of a sunrise'"} to {@code "image of a sunrise"}, keeping escape sequences as
+   * written. Returns {@code null} when the value is not statically resolvable: identifiers,
+   * concatenations, calls, ternaries and interpolated template literals. Parenthesized literals
+   * ({@code ('a sunrise')}) are deliberately left unresolved — templates do not write them, and
+   * missing one costs a false negative, never a false positive.
    */
   @CheckForNull
   public static String unwrapStaticStringLiteral(@Nullable String value) {
@@ -106,16 +98,13 @@ public class AccessibilityUtils {
     while (index < expression.length()) {
       char currentCharacter = expression.charAt(index);
       if (currentCharacter == '\\') {
-        // Skip the escaped character. A trailing backslash runs past the end and leaves the
-        // literal unterminated, which the exit below reports as unresolved.
+        // Skip the escaped character; running past the end leaves the literal unterminated.
         index += 2;
       } else if (quote == '`' && isInterpolationStart(expression, index)) {
-        // A template literal such as `photo of ${name}` embeds a value, so it is not static.
         return null;
       } else if (currentCharacter == quote) {
-        // A genuine literal closes at the very last character. Anything following the closing
-        // quote is an operator, a member access, or a second literal, none of which resolve
-        // statically (e.g. "'a' + imageVar", "'a'.trim()", "'a''b'").
+        // Anything after the closing quote — an operator, a member access, a second literal —
+        // means the expression is more than this one literal.
         return index == expression.length() - 1 ? expression.substring(1, index) : null;
       } else {
         index++;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ImgRedundantAltCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ImgRedundantAltCheck.java
@@ -18,12 +18,15 @@ package org.sonar.plugins.html.checks.accessibility;
 
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
+import org.sonar.plugins.html.node.Attribute;
 import org.sonar.plugins.html.node.TagNode;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
+import javax.annotation.CheckForNull;
 
 import static org.sonar.plugins.html.api.accessibility.AccessibilityUtils.isHiddenFromScreenReader;
+import static org.sonar.plugins.html.api.accessibility.AccessibilityUtils.unwrapStaticStringLiteral;
 
 @Rule(key = "S6851")
 public class ImgRedundantAltCheck extends AbstractPageCheck {
@@ -37,7 +40,12 @@ public class ImgRedundantAltCheck extends AbstractPageCheck {
       return;
     }
 
-    var alt = element.getPropertyValue("alt");
+    Attribute altAttribute = element.getProperty("alt");
+    if (altAttribute == null) {
+      return;
+    }
+
+    String alt = resolveAltValue(altAttribute);
     if (alt == null) {
       return;
     }
@@ -49,6 +57,18 @@ public class ImgRedundantAltCheck extends AbstractPageCheck {
       var message = String.format(MESSAGE_TEMPLATE, punctuation, quotedWords);
       createViolation(element.getStartLinePosition(), message);
     }
+  }
+
+  @CheckForNull
+  private static String resolveAltValue(Attribute altAttribute) {
+    String value = altAttribute.getValue();
+    if ("alt".equalsIgnoreCase(altAttribute.getName())) {
+      return value;
+    }
+    // Bound attribute (Angular [alt]/[attr.alt], Vue :alt/v-bind:alt): only a
+    // statically resolvable string literal can be inspected; any other
+    // expression is unresolved at analysis time and must be skipped.
+    return unwrapStaticStringLiteral(value);
   }
 
   private static boolean isImg(TagNode element) {

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtilsTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtilsTest.java
@@ -1,0 +1,106 @@
+/*
+ * SonarQube HTML
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.html.api.accessibility;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.sonar.plugins.html.api.accessibility.AccessibilityUtils.unwrapStaticStringLiteral;
+
+class AccessibilityUtilsTest {
+
+  @ParameterizedTest
+  @MethodSource("staticStringLiterals")
+  void unwrapsStaticStringLiterals(String value, String expected) {
+    assertThat(unwrapStaticStringLiteral(value)).isEqualTo(expected);
+  }
+
+  private static Stream<Arguments> staticStringLiterals() {
+    return Stream.of(
+      Arguments.of("'image of a sunrise'", "image of a sunrise"),
+      Arguments.of("\"image of a sunrise\"", "image of a sunrise"),
+      Arguments.of("`image of a sunrise`", "image of a sunrise"),
+      // whitespace around the whole expression is not part of the value
+      Arguments.of("  'a sunrise'  ", "a sunrise"),
+      // an escaped quote does not terminate the literal, and escapes survive unwrapping
+      Arguments.of("'it\\'s a sunrise'", "it\\'s a sunrise"),
+      Arguments.of("\"say \\\"hi\\\"\"", "say \\\"hi\\\""),
+      // the literal ends on an escaped backslash, not on an escaped quote
+      Arguments.of("'a path C:\\\\'", "a path C:\\\\"),
+      // the opposite quote character is ordinary text
+      Arguments.of("'say \"hi\"'", "say \"hi\""),
+      // a template literal without interpolation is still static
+      Arguments.of("`say 'hi'`", "say 'hi'"));
+  }
+
+  @Test
+  void unwrapsEmptyLiteral() {
+    assertThat(unwrapStaticStringLiteral("''")).isEmpty();
+    assertThat(unwrapStaticStringLiteral("\"\"")).isEmpty();
+  }
+
+  @Test
+  void keepsWhitespaceInsideTheLiteral() {
+    assertThat(unwrapStaticStringLiteral("' a sunrise '")).isEqualTo(" a sunrise ");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+    // identifiers, property accesses and calls
+    "data.imageAlt",
+    "IMAGE_ALT",
+    "imageSrc()",
+    "blok().image?.alt ?? ''",
+    "flavour.image_alt || flavour.name",
+    // concatenations that merely start and end with a matching quote
+    "'a' + imageVar + 'b'",
+    "'image' + suffix + 'text'",
+    "'a' + 'b'",
+    "'a''b'",
+    "('a') + ('b')",
+    // parentheses are deliberately not unwrapped, so even a parenthesized literal stays unresolved
+    "('a sunrise')",
+    "(( 'a sunrise' ))",
+    // a literal that is only part of the expression
+    "'a photo'.toUpperCase()",
+    "translate('a photo')",
+    "condition ? 'a photo' : 'a picture'",
+    // interpolated template literals are resolved at runtime
+    "`photo of ${name}`",
+    // unterminated literals
+    "'a sunrise",
+    "'a sunrise\\",
+    "'",
+    "`photo of $",
+    // no literal at all
+    "",
+    "   ",
+  })
+  void returnsNullForExpressionsThatAreNotStaticLiterals(String value) {
+    assertThat(unwrapStaticStringLiteral(value)).isNull();
+  }
+
+  @Test
+  void returnsNullForNull() {
+    assertThat(unwrapStaticStringLiteral(null)).isNull();
+  }
+}

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ImgRedundantAltCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ImgRedundantAltCheckTest.java
@@ -43,4 +43,23 @@ class ImgRedundantAltCheckTest {
       .next().atLine(4)
       .noMore();
   }
+
+  @Test
+  void boundAlt() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/ImgRedundantAltCheck/bound-alt.html"),
+      new ImgRedundantAltCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(2).withMessage(
+        "Remove redundant word \"image\" from the \"alt\" attribute of your \"img\" tag.")
+      .next().atLine(3).withMessage(
+        "Remove redundant word \"photo\" from the \"alt\" attribute of your \"img\" tag.")
+      .next().atLine(4).withMessage(
+        "Remove redundant word \"picture\" from the \"alt\" attribute of your \"img\" tag.")
+      .next().atLine(5)
+      .next().atLine(6)
+      .next().atLine(7)
+      .noMore();
+  }
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ImgRedundantAltCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ImgRedundantAltCheckTest.java
@@ -60,6 +60,12 @@ class ImgRedundantAltCheckTest {
       .next().atLine(5)
       .next().atLine(6)
       .next().atLine(7)
+      .next().atLine(28).withMessage(
+        "Remove redundant word \"photo\" from the \"alt\" attribute of your \"img\" tag.")
+      .next().atLine(29).withMessage(
+        "Remove redundant word \"image\" from the \"alt\" attribute of your \"img\" tag.")
+      .next().atLine(30).withMessage(
+        "Remove redundant word \"photo\" from the \"alt\" attribute of your \"img\" tag.")
       .noMore();
   }
 }

--- a/sonar-html-plugin/src/test/resources/checks/ImgRedundantAltCheck/bound-alt.html
+++ b/sonar-html-plugin/src/test/resources/checks/ImgRedundantAltCheck/bound-alt.html
@@ -1,0 +1,21 @@
+<!-- Bound to a statically resolvable string literal containing a redundant word: Noncompliant -->
+<img [alt]="'image of a sunrise'" /> <!-- Noncompliant -->
+<img [attr.alt]="'photo of a cat'" /> <!-- Noncompliant -->
+<img attr.alt="'picture of a dog'" /> <!-- Noncompliant -->
+<img :alt="'image of a cat'" /> <!-- Noncompliant -->
+<img v-bind:alt="'photo of a dog'" /> <!-- Noncompliant -->
+<img :[alt]="'picture of a turtle'" /> <!-- Noncompliant -->
+
+<!-- Bound to a string literal without redundant words: Compliant -->
+<img [alt]="'a sunrise'" />
+<img :alt="'a cat'" />
+
+<!-- Unresolved identifiers/expressions containing redundant substrings: Compliant -->
+<img [src]="data.imageSrc" [alt]="data.imageAlt" />
+<img [src]="imageSrc()" [alt]="blok().image?.alt ?? ''" />
+<img :src="flavour.image" :alt="flavour.image_alt || flavour.name" />
+<img :src="imageProps.row.imageUrl" :alt="imageProps.row.name" />
+<img :src="imageSrc" :alt="IMAGE_ALT" />
+
+<!-- Bound alt on a hidden image: still Compliant -->
+<img :alt="'photo of a cat'" aria-hidden="true" />

--- a/sonar-html-plugin/src/test/resources/checks/ImgRedundantAltCheck/bound-alt.html
+++ b/sonar-html-plugin/src/test/resources/checks/ImgRedundantAltCheck/bound-alt.html
@@ -19,3 +19,22 @@
 
 <!-- Bound alt on a hidden image: still Compliant -->
 <img :alt="'photo of a cat'" aria-hidden="true" />
+
+<!-- Concatenation merely starting and ending with a matching quote is not a literal: Compliant -->
+<img [alt]="'a' + imageVar + 'b'" />
+<img :alt="'image' + suffix + 'text'" />
+
+<!-- Padding and escaped quotes do not prevent resolution: Noncompliant -->
+<img [alt]="  'photo of a cat'  " /> <!-- Noncompliant -->
+<img [alt]="'it\'s an image of a cat'" /> <!-- Noncompliant -->
+<img :alt="`photo of a dog`" /> <!-- Noncompliant -->
+
+<!-- Expressions that merely contain a literal stay unresolved: Compliant -->
+<img :alt="`photo of ${animal}`" />
+<img [alt]="'a photo'.toUpperCase()" />
+<img [alt]="translate('a picture')" />
+<img [alt]="showAlt ? 'an image' : 'a photo'" />
+<img [alt]="'an image" />
+
+<!-- Parentheses are not unwrapped, so a parenthesized literal stays unresolved: Compliant -->
+<img [alt]="('picture of a dog')" />


### PR DESCRIPTION
## What

`Web:S6851` (`ImgRedundantAltCheck`) flagged `img` `alt` attributes bound via
Angular (`[alt]`, `[attr.alt]`) or Vue (`:alt`, `v-bind:alt`) syntax whenever
the *binding expression* happened to contain "image", "photo", or "picture" —
even though the actual rendered text is unknown at analysis time.

```html
<img [src]="data.imageSrc" [alt]="data.imageAlt">   <!-- was FP -->
<img :src="imageSrc" :alt="IMAGE_ALT">              <!-- was FP -->
```

## Why

Customer feedback surfaced 7 grouped reports (11 occurrences across 5
projects) of this exact pattern, and the local ruling corpora contain ~42
similar dynamic `alt` binding lines across 37 files.

`TagNode.getProperty("alt")` already resolves all the Angular/Vue binding
forms to find the attribute, but the check was calling `getPropertyValue`
and scanning whatever came back — including raw JS/TS expressions — as if it
were literal alt text.

## Fix

- `ImgRedundantAltCheck` now looks at the original attribute name returned
by `getProperty("alt")`:
  - Plain `alt="..."` — unchanged behavior.
  - A binding form (`[alt]`, `[attr.alt]`, `attr.alt`, `:alt`, `v-bind:alt`,
`:[alt]`) — only inspected when the value is a statically resolvable JS
string literal (`[alt]="'image of a sunrise'"`); any other expression is
treated as unresolved and skipped.
- Added `AccessibilityUtils.unwrapStaticStringLiteral`, lifting the
string-literal-unwrap logic that already existed privately in
`ControlGroup` (used for `input[type]` bindings) so it's shared rather than
duplicated a third time. (`ControlGroup` itself is left untouched — no
behavior change there, out of scope for this fix.)

## Testing

- New fixture `ImgRedundantAltCheck/bound-alt.html` covers every supported
Angular/Vue binding form with both a noncompliant string literal and an
unresolved expression, plus the existing `static/aria-hidden` cases.
- New `boundAlt()` test in `ImgRedundantAltCheckTest`.
- Existing `test()` (plain `alt=` cases) is unchanged and still passes.
- Full `sonar-html-plugin` test module passes.