### PR TITLE
SONARHTML-444 Consolidate duplicated binding-attribute and string-literal helpers

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtils.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtils.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonar.plugins.html.api.Thymeleaf;
+import org.sonar.plugins.html.node.Attribute;
 import org.sonar.plugins.html.node.TagNode;
 
 import static org.sonar.plugins.html.api.HtmlConstants.isInteractiveElement;
@@ -123,6 +124,15 @@ public class AccessibilityUtils {
 
   private static boolean isQuote(char character) {
     return character == '\'' || character == '"' || character == '`';
+  }
+
+  /**
+   * Returns whether {@code attribute} was matched under a framework binding form
+   * (Angular {@code [x]}/{@code [attr.x]}, Vue {@code :x}/{@code v-bind:x}/{@code :[x]})
+   * rather than under its plain {@code canonicalName}.
+   */
+  public static boolean isBindingForm(Attribute attribute, String canonicalName) {
+    return !canonicalName.equalsIgnoreCase(attribute.getName());
   }
 
   public static boolean isFocusableElement(TagNode element) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/ControlGroup.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/ControlGroup.java
@@ -162,7 +162,7 @@ public class ControlGroup {
     if (typeAttr == null || typeAttr.getName().equalsIgnoreCase("type")) {
       return false;
     }
-    return !isStaticStringLiteral(typeAttr.getValue());
+    return AccessibilityUtils.unwrapStaticStringLiteral(typeAttr.getValue()) == null;
   }
 
   // Returns the resolved type value via getProperty, which covers static attributes
@@ -181,21 +181,13 @@ public class ControlGroup {
       return value;
     }
     // Bound attribute: unwrap JS string literal (e.g. "'checkbox'" → "checkbox")
-    if (isStaticStringLiteral(value)) {
-      String inner = value.substring(1, value.length() - 1).trim();
-      return inner.isEmpty() ? null : inner;
+    String literal = AccessibilityUtils.unwrapStaticStringLiteral(value);
+    if (literal == null) {
+      // Dynamic expression → unknown
+      return null;
     }
-    // Dynamic expression → unknown
-    return null;
-  }
-
-  private static boolean isStaticStringLiteral(@CheckForNull String value) {
-    if (value == null || value.length() < 2) {
-      return false;
-    }
-    char first = value.charAt(0);
-    char last = value.charAt(value.length() - 1);
-    return (first == '\'' && last == '\'') || (first == '"' && last == '"');
+    String inner = literal.trim();
+    return inner.isEmpty() ? null : inner;
   }
 
   private ControlGroup() {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ImgRedundantAltCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ImgRedundantAltCheck.java
@@ -25,6 +25,7 @@ import java.util.Locale;
 import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 
+import static org.sonar.plugins.html.api.accessibility.AccessibilityUtils.isBindingForm;
 import static org.sonar.plugins.html.api.accessibility.AccessibilityUtils.isHiddenFromScreenReader;
 import static org.sonar.plugins.html.api.accessibility.AccessibilityUtils.unwrapStaticStringLiteral;
 
@@ -62,7 +63,7 @@ public class ImgRedundantAltCheck extends AbstractPageCheck {
   @CheckForNull
   private static String resolveAltValue(Attribute altAttribute) {
     String value = altAttribute.getValue();
-    if ("alt".equalsIgnoreCase(altAttribute.getName())) {
+    if (!isBindingForm(altAttribute, "alt")) {
       return value;
     }
     // Bound attribute (Angular [alt]/[attr.alt], Vue :alt/v-bind:alt): only a

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheck.java
@@ -115,15 +115,11 @@ public class LabelHasAssociatedControlCheck extends AbstractPageCheck {
   // Property lookup that accepts Angular/Vue binding forms even with empty value — the binding name itself is the hint.
   private static boolean hasPropertyHint(TagNode node, String propertyName) {
     Attribute property = node.getProperty(propertyName);
-    return property != null && (isBindingForm(property, propertyName) || !Thymeleaf.isEmptyValue(property.getValue()));
+    return property != null && (AccessibilityUtils.isBindingForm(property, propertyName) || !Thymeleaf.isEmptyValue(property.getValue()));
   }
 
   private static boolean hasAttributeHint(TagNode node, String attributeName) {
     return !Thymeleaf.isEmptyValue(node.getAttribute(attributeName));
-  }
-
-  private static boolean isBindingForm(Attribute attribute, String canonicalName) {
-    return !canonicalName.equalsIgnoreCase(attribute.getName());
   }
 
   private static boolean isLabel(TagNode node) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoNoninteractiveTabIndexCheck.java
@@ -19,6 +19,7 @@ package org.sonar.plugins.html.checks.accessibility;
 import static org.sonar.plugins.html.api.HtmlConstants.INTERACTIVE_ROLES;
 import static org.sonar.plugins.html.api.HtmlConstants.hasKnownHTMLTag;
 import static org.sonar.plugins.html.api.HtmlConstants.isInteractiveElement;
+import static org.sonar.plugins.html.api.accessibility.AccessibilityUtils.unwrapStaticStringLiteral;
 
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
@@ -79,21 +80,12 @@ public class NoNoninteractiveTabIndexCheck extends AbstractPageCheck {
     }
 
     // Bound role values are only trusted when they are explicit string literals.
-    if (!isStaticStringLiteral(roleValue)) {
+    String literal = unwrapStaticStringLiteral(roleValue);
+    if (literal == null) {
       return null;
     }
 
-    var normalizedRole = roleValue.substring(1, roleValue.length() - 1).trim();
+    var normalizedRole = literal.trim();
     return normalizedRole.isEmpty() ? null : normalizedRole;
-  }
-
-  private static boolean isStaticStringLiteral(String value) {
-    if (value.length() < 2) {
-      return false;
-    }
-
-    char first = value.charAt(0);
-    char last = value.charAt(value.length() - 1);
-    return (first == '\'' && last == '\'') || (first == '"' && last == '"');
   }
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheck.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.api.Helpers;
+import org.sonar.plugins.html.api.accessibility.AccessibilityUtils;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
 import org.sonar.plugins.html.node.Attribute;
 import org.sonar.plugins.html.node.Node;
@@ -204,7 +205,7 @@ public class InputWithoutLabelCheck extends AbstractPageCheck {
     if (property == null) {
       return Set.of();
     }
-    if (isBindingForm(property, "aria-labelledby")) {
+    if (AccessibilityUtils.isBindingForm(property, "aria-labelledby")) {
       return null;
     }
     String trimmed = trimmedOrNull(property.getValue());
@@ -254,7 +255,7 @@ public class InputWithoutLabelCheck extends AbstractPageCheck {
 
   @CheckForNull
   private String resolveStaticAttribute(Attribute attribute, String canonicalName) {
-    if (isBindingForm(attribute, canonicalName)) {
+    if (AccessibilityUtils.isBindingForm(attribute, canonicalName)) {
       return null;
     }
     return staticOrNull(attribute.getValue());
@@ -278,10 +279,6 @@ public class InputWithoutLabelCheck extends AbstractPageCheck {
     return Helpers.containsDynamicValue(value, getHtmlSourceCode());
   }
 
-  private static boolean isBindingForm(Attribute attribute, String canonicalName) {
-    return !canonicalName.equalsIgnoreCase(attribute.getName());
-  }
-
   private static boolean hasAnyControlIdHint(TagNode node) {
     return node.hasProperty(ID) || node.hasAttribute(ASP_FOR);
   }
@@ -294,7 +291,7 @@ public class InputWithoutLabelCheck extends AbstractPageCheck {
   @CheckForNull
   private static String staticPropertyValue(TagNode node, String propertyName) {
     Attribute property = node.getProperty(propertyName);
-    if (property == null || isBindingForm(property, propertyName)) {
+    if (property == null || AccessibilityUtils.isBindingForm(property, propertyName)) {
       return null;
     }
     return trimmedOrNull(property.getValue());


### PR DESCRIPTION
## What

Pure refactor, no rule behavior change intended. Consolidates two pieces of
logic that were copy-pasted across several accessibility checks onto the
shared `AccessibilityUtils`.

## Why

Raised by Erwan during review of #774 (SONARHTML-438): `AccessibilityUtils.unwrapStaticStringLiteral`
added there was actually the 4th copy of "strip quotes off a bound value"
logic in the codebase, and a second duplication — "does this attribute's
actual name differ from the canonical one, i.e. is it a binding form" — also
existed in multiple checks.

## Changes

**String-literal unwrap** — two remaining private copies (naive first/last-char
quote match, no escape or template-literal handling) migrated onto the
shared, more robust `AccessibilityUtils.unwrapStaticStringLiteral`:
- `ControlGroup.resolveType`/`hasDynamicTypeBinding` (resolves bound `input[type]`)
- `NoNoninteractiveTabIndexCheck.resolveStaticRole` (resolves bound `role`)

Both drop their private `isStaticStringLiteral`. The extra `.trim()` +
empty→null step is kept after unwrapping so existing behavior (e.g.
`[type]="''"` → `null`, not `""`) is preserved.

**Binding-form check** — added `AccessibilityUtils.isBindingForm(Attribute, String canonicalName)`
and migrated the identical private helper (`!canonicalName.equalsIgnoreCase(attribute.getName())`)
plus one inlined instance onto it:
- `InputWithoutLabelCheck` (3 call sites)
- `LabelHasAssociatedControlCheck` (1 call site)
- `ImgRedundantAltCheck.resolveAltValue` (was inlined as `"alt".equalsIgnoreCase(...)`)

## Out of scope

A few structurally-similar but semantically-distinct quote/name checks were
left untouched — different domains or deliberately different semantics:
`Thymeleaf.isQuotedLiteral`, `FormMethodAttributeCheck`'s inline checks,
`ContentSecurityPolicyCheck.stripSingleQuotes`, `InputWithoutLabelCheck.looseTypeValue`.

## Testing

No test assertions changed. Ran the full suites for every migrated check
(`ValidAutocompleteCheckTest`, `NoNoninteractiveTabIndexCheckTest`,
`InputWithoutLabelCheckTest`, `LabelHasAssociatedControlCheckTest`,
`ImgRedundantAltCheckTest`, `AccessibilityUtilsTest`) plus the full
`sonar-html-plugin` module — all green.

Note: the shared helper is slightly *more* permissive than the old private
copies in two untested edge cases (literals with whitespace outside the
quotes, and non-interpolated backtick literals) — a safe widening, not a
behavior regression.