### PR TITLE
SONARHTML-436 Accept div groups in description lists

### DIFF
--- a/its/ruling/src/test/resources/expected/Web-ItemTagNotWithinContainerTagCheck.json
+++ b/its/ruling/src/test/resources/expected/Web-ItemTagNotWithinContainerTagCheck.json
@@ -5,6 +5,9 @@
 "project:Silverpeas-Core-master/war-core/src/main/webapp/pdcPeas/jsp/positionsInComponent.jsp": [
 216
 ],
+"project:Silverpeas-Core-master/war-core/src/main/webapp/portlet/jsp/jsr/portletSP.jsp": [
+109
+],
 "project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLDirectoryElement01.html": [
 9,
 10,

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheck.java
@@ -46,7 +46,7 @@ public class ItemTagNotWithinContainerTagCheck extends AbstractPageCheck {
     TagNode parent = effectiveParent(node);
     if (isLi(node) && shouldReport(parent, ItemTagNotWithinContainerTagCheck::isLiAllowedParent)) {
       createViolation(node, "Surround this <" + node.getNodeName() + "> item tag by a <ul>, <ol> or <menu> container one.");
-    } else if (isDt(node) && shouldReport(parent, ItemTagNotWithinContainerTagCheck::isDl)) {
+    } else if (isDt(node) && shouldReport(parent, ItemTagNotWithinContainerTagCheck::isDtAllowedParent)) {
       createViolation(node, "Surround this <" + node.getNodeName() + "> item tag by a <dl> container one.");
     }
   }
@@ -120,6 +120,26 @@ public class ItemTagNotWithinContainerTagCheck extends AbstractPageCheck {
 
   private static boolean isDl(TagNode node) {
     return "DL".equalsIgnoreCase(node.getNodeName());
+  }
+
+  /**
+   * Checks whether a node can directly contain a {@code dt} element.
+   *
+   * @param node the direct parent of the {@code dt} element
+   * @return true when the parent is a {@code dl} or a {@code div} directly inside a {@code dl}
+   */
+  private static boolean isDtAllowedParent(TagNode node) {
+    return isDl(node) || (isDiv(node) && node.getParent() != null && isDl(node.getParent()));
+  }
+
+  /**
+   * Checks whether a node is a {@code div} element.
+   *
+   * @param node the node to inspect
+   * @return true when the node is a {@code div} element
+   */
+  private static boolean isDiv(TagNode node) {
+    return "DIV".equalsIgnoreCase(node.getNodeName());
   }
 
   private static boolean isP(TagNode node) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheck.java
@@ -46,7 +46,7 @@ public class ItemTagNotWithinContainerTagCheck extends AbstractPageCheck {
     TagNode parent = effectiveParent(node);
     if (isLi(node) && shouldReport(parent, ItemTagNotWithinContainerTagCheck::isLiAllowedParent)) {
       createViolation(node, "Surround this <" + node.getNodeName() + "> item tag by a <ul>, <ol> or <menu> container one.");
-    } else if (isDt(node) && shouldReport(parent, ItemTagNotWithinContainerTagCheck::isDtAllowedParent)) {
+    } else if (isDefinitionItem(node) && shouldReport(parent, ItemTagNotWithinContainerTagCheck::isDefinitionItemAllowedParent)) {
       createViolation(node, "Surround this <" + node.getNodeName() + "> item tag by a <dl> container one.");
     }
   }
@@ -80,7 +80,7 @@ public class ItemTagNotWithinContainerTagCheck extends AbstractPageCheck {
     if (isLi(node)) {
       return isLi(parent) || isP(parent);
     }
-    if (isDt(node)) {
+    if (isDefinitionItem(node)) {
       return isDefinitionItem(parent) || isP(parent);
     }
     return false;
@@ -123,12 +123,12 @@ public class ItemTagNotWithinContainerTagCheck extends AbstractPageCheck {
   }
 
   /**
-   * Checks whether a node can directly contain a {@code dt} element.
+   * Checks whether a node can directly contain a definition item element.
    *
-   * @param node the direct parent of the {@code dt} element
+   * @param node the direct parent of the {@code dt} or {@code dd} element
    * @return true when the parent is a {@code dl} or a {@code div} directly inside a {@code dl}
    */
-  private static boolean isDtAllowedParent(TagNode node) {
+  private static boolean isDefinitionItemAllowedParent(TagNode node) {
     return isDl(node) || (isDiv(node) && node.getParent() != null && isDl(node.getParent()));
   }
 

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/ItemTagNotWithinContainerTagCheck.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/ItemTagNotWithinContainerTagCheck.html
@@ -1,19 +1,23 @@
 <h2>Why is this an issue?</h2>
-<p>The <code>&lt;dt&gt;</code> HTML element specifies a term in a description or definition list, and as such must be used inside a
-<code>&lt;dl&gt;</code> element, which represents a description list. Common uses for this element are to implement a glossary or to display
-metadata.</p>
+<p>The <code>&lt;dt&gt;</code> and <code>&lt;dd&gt;</code> HTML elements specify terms and descriptions in a description list. They must be used
+inside a <code>&lt;dl&gt;</code> element, either directly or in a <code>&lt;div&gt;</code> group that is a direct child of the
+<code>&lt;dl&gt;</code>. Common uses for description lists are to implement a glossary or to display metadata.</p>
 <p>The <code>&lt;li&gt;</code> HTML element is used to represent an item in a list. It must be contained in a parent element: an ordered list
 (<code>&lt;ol&gt;</code>), an unordered list (<code>&lt;ul&gt;</code>), or a menu (<code>&lt;menu&gt;</code>).</p>
-<p>Using a <code>&lt;li&gt;</code> or <code>&lt;dt&gt;</code> item tag outside of the aforementioned parent elements does not follow the HTML
-specification.</p>
+<p>Using a <code>&lt;li&gt;</code>, <code>&lt;dt&gt;</code>, or <code>&lt;dd&gt;</code> item tag outside of the aforementioned parent elements does
+not follow the HTML specification.</p>
 <pre data-diff-id="1" data-diff-type="noncompliant">
 &lt;li&gt;Apple&lt;/li&gt;          &lt;!-- Noncompliant --&gt;
 &lt;li&gt;Strawberry&lt;/li&gt;     &lt;!-- Noncompliant --&gt;
 
 &lt;dt&gt;Apple&lt;/dt&gt;          &lt;!-- Noncompliant --&gt;
 &lt;dt&gt;Strawberry&lt;/dt&gt;     &lt;!-- Noncompliant --&gt;
+
+&lt;dd&gt;A fruit&lt;/dd&gt;        &lt;!-- Noncompliant --&gt;
+&lt;dd&gt;A berry&lt;/dd&gt;        &lt;!-- Noncompliant --&gt;
 </pre>
-<p>To fix this issue, enclose <code>&lt;li&gt;</code> and <code>&lt;dt&gt;</code> with their respective allowed parent tags.</p>
+<p>To fix this issue, enclose <code>&lt;li&gt;</code>, <code>&lt;dt&gt;</code>, and <code>&lt;dd&gt;</code> with their respective allowed parent
+tags.</p>
 <pre data-diff-id="1" data-diff-type="compliant">
 &lt;ul&gt; &lt;!-- or &lt;ul&gt; or &lt;menu&gt; --&gt;
   &lt;li&gt;Apple&lt;/li&gt;
@@ -21,8 +25,14 @@ specification.</p>
 &lt;/ul&gt;
 
 &lt;dl&gt;
-  &lt;dt&gt;Apple&lt;/dt&gt;
-  &lt;dt&gt;Strawberry&lt;/dt&gt;
+  &lt;div&gt;
+    &lt;dt&gt;Apple&lt;/dt&gt;
+    &lt;dd&gt;A fruit&lt;/dd&gt;
+  &lt;/div&gt;
+  &lt;div&gt;
+    &lt;dt&gt;Strawberry&lt;/dt&gt;
+    &lt;dd&gt;A berry&lt;/dd&gt;
+  &lt;/div&gt;
 &lt;/dl&gt;
 </pre>
 <h2>Resources</h2>
@@ -30,6 +40,8 @@ specification.</p>
 <ul>
   <li>MDN web docs - <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li"><code>&lt;li&gt;</code>: The List Item element</a></li>
   <li>MDN web docs - <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dt"><code>&lt;dt&gt;</code>: The Description Term
+  element</a></li>
+  <li>MDN web docs - <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dd"><code>&lt;dd&gt;</code>: The Description Details
   element</a></li>
 </ul>
 

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/ItemTagNotWithinContainerTagCheck.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/ItemTagNotWithinContainerTagCheck.html
@@ -25,6 +25,13 @@ tags.</p>
 &lt;/ul&gt;
 
 &lt;dl&gt;
+  &lt;dt&gt;Apple&lt;/dt&gt;
+  &lt;dd&gt;A fruit&lt;/dd&gt;
+  &lt;dt&gt;Strawberry&lt;/dt&gt;
+  &lt;dd&gt;A berry&lt;/dd&gt;
+&lt;/dl&gt;
+
+&lt;dl&gt;
   &lt;div&gt;
     &lt;dt&gt;Apple&lt;/dt&gt;
     &lt;dd&gt;A fruit&lt;/dd&gt;

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheckTest.java
@@ -38,12 +38,16 @@ class ItemTagNotWithinContainerTagCheckTest {
     checkMessagesVerifier.verify(sourceCode.getIssues())
         .next().atLocation(1, 0, 1, 4).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.")
         .next().atLocation(4, 0, 4, 4).withMessage("Surround this <DT> item tag by a <dl> container one.")
-        .next().atLine(8).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.")
-        .next().atLine(12).withMessage("Surround this <dt> item tag by a <dl> container one.")
-        .next().atLine(17).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.")
-        .next().atLine(24).withMessage("Surround this <dt> item tag by a <dl> container one.")
-        .next().atLine(30).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.")
-        .next().atLine(31).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.");
+        .next().atLocation(7, 0, 7, 4).withMessage("Surround this <dd> item tag by a <dl> container one.")
+        .next().atLine(11).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.")
+        .next().atLine(15).withMessage("Surround this <dt> item tag by a <dl> container one.")
+        .next().atLine(20).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.")
+        .next().atLine(27).withMessage("Surround this <dt> item tag by a <dl> container one.")
+        .next().atLine(33).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.")
+        .next().atLine(34).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.")
+        .next().atLine(38).withMessage("Surround this <dt> item tag by a <dl> container one.")
+        .next().atLine(44).withMessage("Surround this <dt> item tag by a <dl> container one.")
+        .next().atLine(50).withMessage("Surround this <dd> item tag by a <dl> container one.");
   }
 
   @Test

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/ItemTagNotWithinContainerTagCheckTest.java
@@ -41,9 +41,9 @@ class ItemTagNotWithinContainerTagCheckTest {
         .next().atLine(8).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.")
         .next().atLine(12).withMessage("Surround this <dt> item tag by a <dl> container one.")
         .next().atLine(17).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.")
-        .next().atLine(23).withMessage("Surround this <dt> item tag by a <dl> container one.")
-        .next().atLine(28).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.")
-        .next().atLine(29).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.");
+        .next().atLine(24).withMessage("Surround this <dt> item tag by a <dl> container one.")
+        .next().atLine(30).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.")
+        .next().atLine(31).withMessage("Surround this <li> item tag by a <ul>, <ol> or <menu> container one.");
   }
 
   @Test

--- a/sonar-html-plugin/src/test/resources/checks/ItemTagNotWithinContainerTagCheck/invalid-cases.html
+++ b/sonar-html-plugin/src/test/resources/checks/ItemTagNotWithinContainerTagCheck/invalid-cases.html
@@ -30,3 +30,7 @@
   <li>a     <!-- Non-Compliant - walk-up past the sibling <li> still reaches the invalid <div> parent -->
   <li>b     <!-- Non-Compliant - walk-up past the sibling <li> still reaches the invalid <div> parent -->
 </div>
+
+<div>
+  <dt>term</dt><!-- Non-Compliant - a div outside any dl is not a valid parent -->
+</div>

--- a/sonar-html-plugin/src/test/resources/checks/ItemTagNotWithinContainerTagCheck/invalid-cases.html
+++ b/sonar-html-plugin/src/test/resources/checks/ItemTagNotWithinContainerTagCheck/invalid-cases.html
@@ -4,6 +4,9 @@
 <DT>        <!-- Non-Compliant -->
 </dt>
 
+<dd>        <!-- Non-Compliant -->
+</dd>
+
 <div>
   <li>foo   <!-- Non-Compliant - direct parent is a known invalid HTML tag -->
 </div>
@@ -34,3 +37,15 @@
 <div>
   <dt>term</dt><!-- Non-Compliant - a div outside any dl is not a valid parent -->
 </div>
+
+<dl>
+  <div>
+    <div>
+      <dt>z</dt><!-- Non-Compliant - the inner div is not a direct child of the dl -->
+    </div>
+  </div>
+</dl>
+
+<section>
+  <dd>definition</dd><!-- Non-Compliant - direct parent is a known invalid HTML tag -->
+</section>

--- a/sonar-html-plugin/src/test/resources/checks/ItemTagNotWithinContainerTagCheck/invalid-cases.html
+++ b/sonar-html-plugin/src/test/resources/checks/ItemTagNotWithinContainerTagCheck/invalid-cases.html
@@ -19,9 +19,11 @@
 </ul>
 
 <dl>
-  <div>
-    <dt>y</dt><!-- Non-Compliant - a valid ancestor does not compensate for an invalid direct parent -->
-  </div>
+  <section>
+    <div>
+      <dt>y</dt><!-- Non-Compliant - the div is not a direct child of the dl -->
+    </div>
+  </section>
 </dl>
 
 <div>

--- a/sonar-html-plugin/src/test/resources/checks/ItemTagNotWithinContainerTagCheck/valid-cases.html
+++ b/sonar-html-plugin/src/test/resources/checks/ItemTagNotWithinContainerTagCheck/valid-cases.html
@@ -23,6 +23,19 @@
   <dt></dt>
 </dl>
 
+<dl>
+  <div>
+    <dt>term</dt>
+    <dd>definition</dd>
+  </div>
+  <div>
+    <dt>another term</dt>
+    <dt>related term</dt>
+    <dd>another definition</dd>
+    <dd>related definition</dd>
+  </div>
+</dl>
+
 <ul>
   <ul>
     <li>foo

--- a/sonar-html-plugin/src/test/resources/checks/ItemTagNotWithinContainerTagCheck/valid-cases.html
+++ b/sonar-html-plugin/src/test/resources/checks/ItemTagNotWithinContainerTagCheck/valid-cases.html
@@ -21,6 +21,7 @@
 
 <dl>
   <dt></dt>
+  <dd></dd>
 </dl>
 
 <dl>
@@ -116,6 +117,11 @@
 <dl>
   <dd>foo
   <dt>bar    <!-- Compliant - the unclosed <dd> is skipped, <dl> is the effective parent -->
+</dl>
+
+<dl>
+  <dt>foo
+  <dd>bar    <!-- Compliant - the unclosed <dt> is skipped, <dl> is the effective parent -->
 </dl>
 
 <ul>


### PR DESCRIPTION
## Summary
S1093 now recognizes valid description-list groups whose `dt` elements are directly inside a `div` child of `dl`, avoiding false positives on valid markup.

## Changes
- Accept a `div` direct child of `dl` as an allowed parent for `dt`
- Keep nested `div` structures reported
- Cover single and multiple term/definition groups in the rule fixtures

## Functional Validation
Artifact: [SONARHTML-436-fv.zip](https://github.com/user-attachments/files/30976710/SONARHTML-436-fv.zip)

Once the file is attached to the PR description, unzip and run:
    ./run.sh

Expected output:
```text
******************* MASTER *******************
Analyzing "sample.html"...
Results:
    - Rule "Web:S1093" -> L.3
    - Rule "Web:S1093" -> L.8

****** Branch "fix/sonarhtml-436-accept-dl-div-groups" ******
Analyzing "sample.html"...
Results:
    - Rule "Web:S1093" -> L.8
```
