### PR TITLE
SONARHTML-441 Restrict S1082 to native HTML elements

### DIFF
--- a/its/ruling/src/test/resources/expected/Web-MouseEventWithoutKeyboardEquivalentCheck.json
+++ b/its/ruling/src/test/resources/expected/Web-MouseEventWithoutKeyboardEquivalentCheck.json
@@ -674,9 +674,6 @@
 108,
 130
 ],
-"project:voten/resources/assets/js/components/passport/PersonalAccessTokens.vue": [
-101
-],
 "project:voten/resources/assets/js/components/submission/GifSubmission.vue": [
 19
 ],

--- a/its/ruling/src/test/resources/expected/Web-MouseEventWithoutKeyboardEquivalentCheck.json
+++ b/its/ruling/src/test/resources/expected/Web-MouseEventWithoutKeyboardEquivalentCheck.json
@@ -564,11 +564,126 @@
 "project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/resource/_options.html.erb": [
 26
 ],
+"project:voten/resources/assets/js/components/AdminPanelSuggestedChannels.vue": [
+85
+],
+"project:voten/resources/assets/js/components/Announcement.vue": [
+11
+],
+"project:voten/resources/assets/js/components/BannedUser.vue": [
+13,
+18
+],
+"project:voten/resources/assets/js/components/BlockedDomain.vue": [
+12,
+18
+],
+"project:voten/resources/assets/js/components/BookmarkedChannel.vue": [
+25,
+33
+],
+"project:voten/resources/assets/js/components/BookmarkedUser.vue": [
+21,
+27
+],
+"project:voten/resources/assets/js/components/ChannelHeader.vue": [
+70,
+104
+],
+"project:voten/resources/assets/js/components/Comment.vue": [
+74,
+110,
+119
+],
+"project:voten/resources/assets/js/components/CommentForm.vue": [
+15,
+85
+],
+"project:voten/resources/assets/js/components/EmojiPicker.vue": [
+18,
+25,
+40
+],
 "project:voten/resources/assets/js/components/GifPlayer.vue": [
 22
 ],
+"project:voten/resources/assets/js/components/Home.vue": [
+24
+],
+"project:voten/resources/assets/js/components/Message.vue": [
+15
+],
+"project:voten/resources/assets/js/components/Messages.vue": [
+54,
+87,
+99,
+128,
+148,
+260
+],
+"project:voten/resources/assets/js/components/Moderator.vue": [
+17
+],
+"project:voten/resources/assets/js/components/NewSubmission.vue": [
+193,
+202,
+211
+],
+"project:voten/resources/assets/js/components/Notification.vue": [
+2
+],
+"project:voten/resources/assets/js/components/PhotoViewer.vue": [
+37
+],
+"project:voten/resources/assets/js/components/QuickChannelPicker.vue": [
+20
+],
+"project:voten/resources/assets/js/components/QuickEmojiPicker.vue": [
+18
+],
+"project:voten/resources/assets/js/components/QuickMentioner.vue": [
+20
+],
+"project:voten/resources/assets/js/components/ReportedComment.vue": [
+46,
+55,
+64
+],
+"project:voten/resources/assets/js/components/ReportedSubmission.vue": [
+43,
+49,
+55
+],
+"project:voten/resources/assets/js/components/Rule.vue": [
+10,
+14
+],
+"project:voten/resources/assets/js/components/Submission.vue": [
+161,
+173
+],
+"project:voten/resources/assets/js/components/UserHeader.vue": [
+127
+],
+"project:voten/resources/assets/js/components/auth/RightSidebar.vue": [
+9,
+41,
+50,
+52,
+106,
+108,
+130
+],
+"project:voten/resources/assets/js/components/passport/PersonalAccessTokens.vue": [
+101
+],
 "project:voten/resources/assets/js/components/submission/GifSubmission.vue": [
 19
+],
+"project:voten/resources/assets/js/components/submission/ImgSubmission.vue": [
+13,
+25,
+37
 ],
 "project:voten/resources/views/passport/index.blade.php": [
 26,

--- a/its/ruling/src/test/resources/expected/Web-MouseEventWithoutKeyboardEquivalentCheck.json
+++ b/its/ruling/src/test/resources/expected/Web-MouseEventWithoutKeyboardEquivalentCheck.json
@@ -3,41 +3,12 @@
 259,
 262
 ],
-"project:Silverpeas-Core-master/war-core/src/main/webapp/form/jsp/editor.jsp": [
-503,
-506
-],
-"project:Silverpeas-Core-master/war-core/src/main/webapp/jobDomainPeas/jsp/userCreate.jsp": [
-238
-],
 "project:Silverpeas-Core-master/war-core/src/main/webapp/jobDomainPeas/jsp/userImport.jsp": [
 201,
 209
 ],
-"project:Silverpeas-Core-master/war-core/src/main/webapp/pdcPeas/jsp/axisManager.jsp": [
-283,
-284
-],
-"project:Silverpeas-Core-master/war-core/src/main/webapp/pdcPeas/jsp/globalResult.jsp": [
-593
-],
-"project:Silverpeas-Core-master/war-core/src/main/webapp/pdcPeas/jsp/searchContext.jsp": [
-411,
-557
-],
-"project:Silverpeas-Core-master/war-core/src/main/webapp/pdcPeas/jsp/searchContextInComponent.jsp": [
-550,
-710
-],
-"project:Silverpeas-Core-master/war-core/src/main/webapp/pdcPeas/jsp/searchToSelect.jsp": [
-616,
-778
-],
 "project:Silverpeas-Core-master/war-core/src/main/webapp/portlet/jsp/admin/portletAdminBarre.jsp": [
 60
-],
-"project:Silverpeas-Core-master/war-core/src/main/webapp/sharing/jsp/ticketManager.jsp": [
-190
 ],
 "project:custom/S6842.html": [
 1,
@@ -46,138 +17,6 @@
 ],
 "project:custom/S6852.html": [
 1
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLInputElement01.html": [
-36
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLInputElement02.html": [
-36
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLInputElement03.html": [
-36
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLInputElement04.html": [
-36
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLInputElement05.html": [
-36
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLInputElement06.html": [
-36
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLInputElement07.html": [
-36
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLInputElement08.html": [
-36
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLInputElement09.html": [
-36
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLInputElement10.html": [
-36
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLInputElement11.html": [
-36
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLInputElement12.html": [
-36
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLInputElement13.html": [
-36
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLInputElement14.html": [
-36
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLInputElement15.html": [
-36
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLInputElement16.html": [
-36
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLInputElement17.html": [
-36
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLInputElement18.html": [
-36
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLInputElement19.html": [
-36
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLInputElement20.html": [
-36
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLInputElement21.html": [
-36
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLInputElement22.html": [
-36
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLInputElement01.xhtml": [
-38
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLInputElement02.xhtml": [
-38
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLInputElement03.xhtml": [
-38
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLInputElement04.xhtml": [
-38
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLInputElement05.xhtml": [
-38
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLInputElement06.xhtml": [
-38
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLInputElement07.xhtml": [
-38
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLInputElement08.xhtml": [
-38
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLInputElement09.xhtml": [
-38
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLInputElement10.xhtml": [
-38
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLInputElement11.xhtml": [
-38
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLInputElement12.xhtml": [
-38
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLInputElement13.xhtml": [
-38
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLInputElement14.xhtml": [
-38
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLInputElement15.xhtml": [
-38
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLInputElement16.xhtml": [
-38
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLInputElement17.xhtml": [
-38
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLInputElement18.xhtml": [
-38
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLInputElement19.xhtml": [
-38
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLInputElement20.xhtml": [
-38
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLInputElement21.xhtml": [
-38
-],
-"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLInputElement22.xhtml": [
-38
 ],
 "project:external_webkit-jb-mr1/PerformanceTests/XSSFilter/resources/target-for-large-post-many-inline-scripts-and-events.html": [
 8,
@@ -501,9 +340,6 @@
 1280,
 1284
 ],
-"project:external_webkit-jb-mr1/Source/JavaScriptCore/tests/mozilla/importList.html": [
-55
-],
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/animate-duration.html": [
 49,
 54,
@@ -514,13 +350,6 @@
 ],
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/computed-transform-value.html": [
 25
-],
-"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/nested-plug-ins.html": [
-26,
-29,
-34,
-37,
-40
 ],
 "project:external_webkit-jb-mr1/Source/WebCore/manual-tests/onclick_in_noncontent.html": [
 13
@@ -548,21 +377,6 @@
 257,
 269,
 273
-],
-"project:sonar-master/plugins/sonar-core-plugin/src/main/resources/org/sonar/plugins/core/widgets/complexity.html.erb": [
-81,
-87,
-93
-],
-"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/bulk_deletion/index.html.erb": [
-48
-],
-"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/cloud/index.html.erb": [
-34,
-37
-],
-"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/resource/_options.html.erb": [
-26
 ],
 "project:voten/resources/assets/js/components/AdminPanelSuggestedChannels.vue": [
 85

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/Aria.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/Aria.java
@@ -4149,8 +4149,10 @@ public class Aria {
         return AriaRole.DOCUMENT;
       case "button":
         return AriaRole.BUTTON;
-      case "datalist", "select":
+      case "datalist":
         return AriaRole.LISTBOX;
+      case "select":
+        return isListbox(element) ? AriaRole.LISTBOX : AriaRole.COMBOBOX;
       case "details":
         return AriaRole.GROUP;
       case "dialog":
@@ -4217,6 +4219,21 @@ public class Aria {
         return AriaRole.TEXTBOX;
       default:
         return null;
+    }
+  }
+
+  private static boolean isListbox(TagNode element) {
+    if (element.getAttribute("multiple") != null) {
+      return true;
+    }
+    var size = element.getAttribute("size");
+    if (size == null) {
+      return false;
+    }
+    try {
+      return Integer.parseInt(size) > 1;
+    } catch (NumberFormatException e) {
+      return false;
     }
   }
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
@@ -42,7 +42,8 @@ public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck 
   // combinations to five modifiers so malformed bindings are not mistaken for event handlers.
   private static final String EVENT_MODIFIERS = "(?:\\.[\\w-]{1,10}){0,5}";
   private static final Map<String, Pattern> EVENT_PATTERNS = new ConcurrentHashMap<>();
-  private static final Set<String> NATIVELY_ACTIVATABLE_ROLES = Set.of("textbox", "checkbox", "radio", "listbox");
+  private static final Set<String> NATIVELY_ACTIVATABLE_ROLES = Set.of(
+    "textbox", "checkbox", "radio", "combobox", "listbox");
 
   @RuleProperty(
     key = "whitelistedElements",

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
@@ -19,7 +19,9 @@ package org.sonar.plugins.html.checks.sonar;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.sonar.check.Rule;
@@ -36,25 +38,11 @@ public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck 
 
   private static final String DEFAULT_WHITELISTED_ELEMENTS = "";
 
-  // Angular 2+ allows key names for the onKeydown pseudo-event to prevent checking the key name manually
-  // This pseudo-event also allows key combinations
-  // Key names are limited to 10 charters and the combination of keys is realistic limited to 5
-  // Vue also supports key modifiers on @keydown (e.g. @keydown.enter, v-on:keydown.enter)
-  // Note: Vue's @keydown shorthand has the @ stripped by the parser, leaving bare "keydown.enter" as the attribute name
-  private static final Pattern KEY_DOWN_WITH_KEY_NAME = Pattern.compile(
-    "\\(keydown(\\.\\w{1,10}){1,5}\\)" +
-    "|keydown(\\.\\w{1,10}){1,5}" +
-    "|v-on:keydown(\\.\\w{1,10}){1,5}",
-    Pattern.CASE_INSENSITIVE);
-
-  // Angular 2+ allows key names for the onKeyup pseudo-event, similar to keydown
-  // Vue also supports key modifiers on @keyup (e.g. @keyup.enter, v-on:keyup.enter)
-  // Note: Vue's @keyup shorthand has the @ stripped by the parser, leaving bare "keyup.enter" as the attribute name
-  private static final Pattern KEY_UP_WITH_KEY_NAME = Pattern.compile(
-    "\\(keyup(\\.\\w{1,10}){1,5}\\)" +
-    "|keyup(\\.\\w{1,10}){1,5}" +
-    "|v-on:keyup(\\.\\w{1,10}){1,5}",
-    Pattern.CASE_INSENSITIVE);
+  // Angular pseudo-events and Vue modifiers. Key names are limited to 10 characters and realistic
+  // combinations to five modifiers so malformed bindings are not mistaken for event handlers.
+  private static final String EVENT_MODIFIERS = "(?:\\.[\\w-]{1,10}){0,5}";
+  private static final Map<String, Pattern> EVENT_PATTERNS = new ConcurrentHashMap<>();
+  private static final Set<String> NATIVELY_ACTIVATABLE_ROLES = Set.of("textbox", "checkbox", "radio", "listbox");
 
   @RuleProperty(
     key = "whitelistedElements",
@@ -93,6 +81,11 @@ public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck 
           roles = new String[]{
             role.toString()
           };
+
+          // Explicit ARIA roles still require keyboard handlers; only native controls provide them.
+          if (NATIVELY_ACTIVATABLE_ROLES.contains(role.toString())) {
+            return;
+          }
         }
       }
 
@@ -131,11 +124,11 @@ public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck 
   }
 
   private static boolean hasOnKeyDown(TagNode node) {
-    return hasEventHandlerAttribute(node, "KEYDOWN") || hasKeyDownWithKeyName(node);
+    return hasEventHandlerAttribute(node, "KEYDOWN");
   }
 
   private static boolean hasOnKeyUp(TagNode node) {
-    return hasEventHandlerAttribute(node, "KEYUP") || hasKeyUpWithKeyName(node);
+    return hasEventHandlerAttribute(node, "KEYUP");
   }
 
   private static boolean hasOnMouseover(TagNode node) {
@@ -158,12 +151,17 @@ public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck 
   private static boolean hasEventHandlerAttribute(TagNode node, String eventName) {
     return hasAttribute(node, "ON" + eventName)
       // Angular event binding attributes
-      || hasAttribute(node, "(" + eventName + ")")
       || hasAttribute(node, "ON-" + eventName)
       || hasAttribute(node, "NG-" + eventName)
-      // Vue long form v-on:eventname, plus the @eventname shorthand the parser strips to a bare name
-      || hasAttribute(node, "V-ON:" + eventName)
-      || hasAttribute(node, eventName);
+      || hasEventBinding(node, eventName);
+  }
+
+  private static boolean hasEventBinding(TagNode node, String eventName) {
+    Pattern pattern = EVENT_PATTERNS.computeIfAbsent(eventName, name -> Pattern.compile(
+      "\\(" + name + EVENT_MODIFIERS + "\\)"
+        + "|(?:v-on:)?" + name + EVENT_MODIFIERS,
+      Pattern.CASE_INSENSITIVE));
+    return node.getAttributes().stream().anyMatch(attribute -> pattern.matcher(attribute.getName()).matches());
   }
 
   private static boolean hasAttribute(TagNode node, String attributeName) {
@@ -198,14 +196,6 @@ public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck 
     }
     var normalizedNodeName = nodeName.toUpperCase(Locale.ROOT);
     return whitelistedElementsSet.contains(normalizedNodeName);
-  }
-
-  private static boolean hasKeyDownWithKeyName(TagNode node) {
-    return node.getAttributes().stream().anyMatch(a -> KEY_DOWN_WITH_KEY_NAME.matcher(a.getName()).matches());
-  }
-
-  private static boolean hasKeyUpWithKeyName(TagNode node) {
-    return node.getAttributes().stream().anyMatch(a -> KEY_UP_WITH_KEY_NAME.matcher(a.getName()).matches());
   }
 
   private static Set<String> parseWhitelistedElements(String whitelistedElements) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
@@ -17,23 +17,16 @@
 package org.sonar.plugins.html.checks.sonar;
 
 import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
-import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import org.sonar.check.Rule;
-import org.sonar.check.RuleProperty;
 import org.sonar.plugins.html.api.Helpers;
+import org.sonar.plugins.html.api.HtmlConstants;
 import org.sonar.plugins.html.api.accessibility.Aria;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
-import org.sonar.plugins.html.node.Node;
 import org.sonar.plugins.html.node.TagNode;
 
 @Rule(key = "MouseEventWithoutKeyboardEquivalentCheck")
 public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck {
-
-  private static final String DEFAULT_WHITELISTED_ELEMENTS = "lightning-button,lightning-button-icon,lightning-button-menu";
 
   // Angular 2+ allows key names for the onKeydown pseudo-event to prevent checking the key name manually
   // This pseudo-event also allows key combinations
@@ -55,22 +48,9 @@ public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck 
     "|v-on:keyup(\\.\\w{1,10}){1,5}",
     Pattern.CASE_INSENSITIVE);
 
-  @RuleProperty(
-    key = "whitelistedElements",
-    description = "Comma-separated list of custom elements to ignore when they expose an onClick attribute without keyboard event handlers.",
-    defaultValue = DEFAULT_WHITELISTED_ELEMENTS)
-  public String whitelistedElements = DEFAULT_WHITELISTED_ELEMENTS;
-
-  private Set<String> whitelistedElementsSet = Set.of();
-
-  @Override
-  public void startDocument(List<Node> nodes) {
-    whitelistedElementsSet = parseWhitelistedElements(whitelistedElements);
-  }
-
   @Override
   public void startElement(TagNode node) {
-    if (node.getLocalName().equals(node.getNodeName())) {
+    if (node.getLocalName().equals(node.getNodeName()) && HtmlConstants.hasKnownHTMLTag(node)) {
       String attribute = null;
 
       if (isException(node)) {
@@ -117,8 +97,8 @@ public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck 
     return "textbox".equalsIgnoreCase(role);
   }
 
-  private boolean isException(TagNode node) {
-    return isClickableButtonLikeElement(node) || ((isInput(node) || isButton(node) || isHyperlink(node) || isSummary(node)) && hasOnClick(node) && !hasButtonRole(node));
+  private static boolean isException(TagNode node) {
+    return (isInput(node) || isButton(node) || isHyperlink(node) || isSummary(node)) && hasOnClick(node) && !hasButtonRole(node);
   }
 
   private static boolean hasOnClick(TagNode node) {
@@ -194,15 +174,6 @@ public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck 
     return "SUMMARY".equalsIgnoreCase(node.getNodeName());
   }
 
-  private boolean isClickableButtonLikeElement(TagNode node) {
-    var nodeName = node.getNodeName();
-    if (nodeName == null) {
-      return false;
-    }
-    var normalizedNodeName = nodeName.toUpperCase(Locale.ROOT);
-    return whitelistedElementsSet.contains(normalizedNodeName);
-  }
-
   private static boolean hasKeyDownWithKeyName(TagNode node) {
     return node.getAttributes().stream().anyMatch(a -> KEY_DOWN_WITH_KEY_NAME.matcher(a.getName()).matches());
   }
@@ -211,14 +182,4 @@ public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck 
     return node.getAttributes().stream().anyMatch(a -> KEY_UP_WITH_KEY_NAME.matcher(a.getName()).matches());
   }
 
-  private static Set<String> parseWhitelistedElements(String whitelistedElements) {
-    if (whitelistedElements == null || whitelistedElements.isBlank()) {
-      return Set.of();
-    }
-    return Arrays.stream(whitelistedElements.split(","))
-      .map(String::trim)
-      .filter(element -> !element.isEmpty())
-      .map(element -> element.toUpperCase(Locale.ROOT))
-      .collect(Collectors.toSet());
-  }
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
@@ -58,7 +58,7 @@ public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck 
 
   @RuleProperty(
     key = "whitelistedElements",
-    description = "Comma-separated list of custom elements to ignore when they expose an onClick attribute without keyboard event handlers.",
+    description = "Comma-separated list of native HTML elements to ignore for all mouse-event keyboard-equivalence checks.",
     defaultValue = DEFAULT_WHITELISTED_ELEMENTS)
   public String whitelistedElements = DEFAULT_WHITELISTED_ELEMENTS;
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
@@ -17,16 +17,24 @@
 package org.sonar.plugins.html.checks.sonar;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.sonar.check.Rule;
+import org.sonar.check.RuleProperty;
 import org.sonar.plugins.html.api.Helpers;
 import org.sonar.plugins.html.api.HtmlConstants;
 import org.sonar.plugins.html.api.accessibility.Aria;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
+import org.sonar.plugins.html.node.Node;
 import org.sonar.plugins.html.node.TagNode;
 
 @Rule(key = "MouseEventWithoutKeyboardEquivalentCheck")
 public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck {
+
+  private static final String DEFAULT_WHITELISTED_ELEMENTS = "";
 
   // Angular 2+ allows key names for the onKeydown pseudo-event to prevent checking the key name manually
   // This pseudo-event also allows key combinations
@@ -47,6 +55,19 @@ public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck 
     "|keyup(\\.\\w{1,10}){1,5}" +
     "|v-on:keyup(\\.\\w{1,10}){1,5}",
     Pattern.CASE_INSENSITIVE);
+
+  @RuleProperty(
+    key = "whitelistedElements",
+    description = "Comma-separated list of custom elements to ignore when they expose an onClick attribute without keyboard event handlers.",
+    defaultValue = DEFAULT_WHITELISTED_ELEMENTS)
+  public String whitelistedElements = DEFAULT_WHITELISTED_ELEMENTS;
+
+  private Set<String> whitelistedElementsSet = Set.of();
+
+  @Override
+  public void startDocument(List<Node> nodes) {
+    whitelistedElementsSet = parseWhitelistedElements(whitelistedElements);
+  }
 
   @Override
   public void startElement(TagNode node) {
@@ -97,8 +118,8 @@ public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck 
     return "textbox".equalsIgnoreCase(role);
   }
 
-  private static boolean isException(TagNode node) {
-    return (isInput(node) || isButton(node) || isHyperlink(node) || isSummary(node)) && hasOnClick(node) && !hasButtonRole(node);
+  private boolean isException(TagNode node) {
+    return isClickableButtonLikeElement(node) || ((isInput(node) || isButton(node) || isHyperlink(node) || isSummary(node)) && hasOnClick(node) && !hasButtonRole(node));
   }
 
   private static boolean hasOnClick(TagNode node) {
@@ -110,13 +131,11 @@ public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck 
   }
 
   private static boolean hasOnKeyDown(TagNode node) {
-    // Vue's @keydown shorthand has @ stripped by the parser, leaving bare "keydown" attribute name
-    return hasEventHandlerAttribute(node, "KEYDOWN") || hasAttribute(node, "KEYDOWN") || hasKeyDownWithKeyName(node);
+    return hasEventHandlerAttribute(node, "KEYDOWN") || hasKeyDownWithKeyName(node);
   }
 
   private static boolean hasOnKeyUp(TagNode node) {
-    // Vue's @keyup shorthand has @ stripped by the parser, leaving bare "keyup" attribute name
-    return hasEventHandlerAttribute(node, "KEYUP") || hasAttribute(node, "KEYUP") || hasKeyUpWithKeyName(node);
+    return hasEventHandlerAttribute(node, "KEYUP") || hasKeyUpWithKeyName(node);
   }
 
   private static boolean hasOnMouseover(TagNode node) {
@@ -128,11 +147,8 @@ public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck 
   }
 
   private static boolean hasOnMouseout(TagNode node) {
-    return hasAttribute(node, "ONMOUSEOUT")
-      || hasAttribute(node, "(MOUSEOUT)")
-      || hasAttribute(node, "ON-MOUSEOUT")
-      // Angular 1 only has a 'NG-MOUSELEAVE' attribute, no 'NG-MOUSEOUT'
-      || hasAttribute(node, "NG-MOUSELEAVE");
+    // Angular 1 only has a 'NG-MOUSELEAVE' attribute, no 'NG-MOUSEOUT'
+    return hasEventHandlerAttribute(node, "MOUSEOUT") || hasAttribute(node, "NG-MOUSELEAVE");
   }
 
   private static boolean hasOnBlur(TagNode node) {
@@ -145,8 +161,9 @@ public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck 
       || hasAttribute(node, "(" + eventName + ")")
       || hasAttribute(node, "ON-" + eventName)
       || hasAttribute(node, "NG-" + eventName)
-      // Vue long form: v-on:eventname (shorthand @eventname has @ stripped by the parser)
-      || hasAttribute(node, "V-ON:" + eventName);
+      // Vue long form v-on:eventname, plus the @eventname shorthand the parser strips to a bare name
+      || hasAttribute(node, "V-ON:" + eventName)
+      || hasAttribute(node, eventName);
   }
 
   private static boolean hasAttribute(TagNode node, String attributeName) {
@@ -174,12 +191,32 @@ public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck 
     return "SUMMARY".equalsIgnoreCase(node.getNodeName());
   }
 
+  private boolean isClickableButtonLikeElement(TagNode node) {
+    var nodeName = node.getNodeName();
+    if (nodeName == null) {
+      return false;
+    }
+    var normalizedNodeName = nodeName.toUpperCase(Locale.ROOT);
+    return whitelistedElementsSet.contains(normalizedNodeName);
+  }
+
   private static boolean hasKeyDownWithKeyName(TagNode node) {
     return node.getAttributes().stream().anyMatch(a -> KEY_DOWN_WITH_KEY_NAME.matcher(a.getName()).matches());
   }
 
   private static boolean hasKeyUpWithKeyName(TagNode node) {
     return node.getAttributes().stream().anyMatch(a -> KEY_UP_WITH_KEY_NAME.matcher(a.getName()).matches());
+  }
+
+  private static Set<String> parseWhitelistedElements(String whitelistedElements) {
+    if (whitelistedElements == null || whitelistedElements.isBlank()) {
+      return Set.of();
+    }
+    return Arrays.stream(whitelistedElements.split(","))
+      .map(String::trim)
+      .filter(element -> !element.isEmpty())
+      .map(element -> element.toUpperCase(Locale.ROOT))
+      .collect(Collectors.toSet());
   }
 
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheck.java
@@ -50,7 +50,7 @@ public class MouseEventWithoutKeyboardEquivalentCheck extends AbstractPageCheck 
 
   @Override
   public void startElement(TagNode node) {
-    if (node.getLocalName().equals(node.getNodeName()) && HtmlConstants.hasKnownHTMLTag(node)) {
+    if (HtmlConstants.hasKnownHTMLTag(node)) {
       String attribute = null;
 
       if (isException(node)) {

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/MouseEventWithoutKeyboardEquivalentCheck.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/MouseEventWithoutKeyboardEquivalentCheck.html
@@ -1,12 +1,13 @@
 <h2>Why is this an issue?</h2>
 <p>Offering the same experience with the mouse and the keyboard allows users to pick their preferred device.</p>
 <p>Additionally, users of assistive technology will be able to browse the site even if they cannot use the mouse.</p>
-<p>This rule raises an issue when:</p>
+<p>This rule raises an issue when a native HTML element:</p>
 <ul>
-  <li>an HTML element with an <code>onClick</code> attribute doesn’t also have an <code>onKeyDown</code> or <code>onKeyUp</code> attribute.</li>
-  <li>an HTML element with an <code>onMouseover</code> attribute doesn’t also have an <code>onFocus</code> attribute.</li>
-  <li>an HTML element with an <code>onMouseout</code> attribute doesn’t also have an <code>onBlur</code> attribute.</li>
+  <li>has an <code>onClick</code> attribute but no <code>onKeyDown</code> or <code>onKeyUp</code> attribute.</li>
+  <li>has an <code>onMouseover</code> attribute but no <code>onFocus</code> attribute.</li>
+  <li>has an <code>onMouseout</code> attribute but no <code>onBlur</code> attribute.</li>
 </ul>
+<p>Components and custom elements are not checked because the analyzer cannot determine how they render or handle keyboard events.</p>
 <p>In the case of <code>onClick</code>, the equivalent keyboard handler should activate on the "Enter" and "Space" keys, since these are the keys
 assistive technologies use to activate buttons.</p>
 <p><code>onKeyPress</code> is also recognised as a keyboard equivalent for backward compatibility, but the event is <a
@@ -24,8 +25,9 @@ technology, and is activated by both Enter and Space without extra code:</p>
 <pre>
 &lt;button onClick="doSomething();"&gt;Do something&lt;/button&gt;      &lt;!-- Compliant --&gt;
 </pre>
-<p>If a custom element must remain non-interactive (e.g. a <code>&lt;div&gt;</code>), the equivalent keyboard handler must check the key so it only
-triggers on Enter or Space, and the element must expose <code>role="button"</code> and <code>tabindex="0"</code> so it is announced and reachable:</p>
+<p>If a native non-interactive element, such as a <code>&lt;div&gt;</code>, handles clicks, the equivalent keyboard handler must check the key so it
+only triggers on Enter or Space, and the element must expose <code>role="button"</code> and <code>tabindex="0"</code> so it is announced and
+reachable:</p>
 <pre>
 &lt;div role="button" tabindex="0" onClick="doSomething();"
      onKeyDown="if (event.key === 'Enter' || event.key === ' ') doSomething();"&gt;   &lt;!-- Compliant --&gt;
@@ -56,14 +58,6 @@ by Enter — an <code>&lt;a onClick&gt;</code> without <code>href</code> behaves
 page, prefer <code>&lt;button&gt;</code> over a bare <code>&lt;a&gt;</code>.</p>
 <p>An issue will still be raised for any element that carries <code>role="button"</code> (including <code>&lt;button role="button"&gt;</code>),
 because the explicit role overrides the implicit behaviour and the element is treated as a custom widget.</p>
-<h3>Custom button-like web components</h3>
-<p>Design systems often ship custom elements that behave like a <code>&lt;button&gt;</code> (e.g. <code>lightning-button</code>,
-<code>ion-button</code>, <code>clr-button</code>). Listing them in the <code>whitelistedElements</code> parameter suppresses the issue for those tag
-names:</p>
-<pre>
-whitelistedElements = lightning-button,lightning-button-icon,clr-button,ion-button
-</pre>
-<p>The default value covers the Salesforce Lightning <code>lightning-button*</code> family.</p>
 <h2>Resources</h2>
 <h3>Documentation</h3>
 <ul>

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/MouseEventWithoutKeyboardEquivalentCheck.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/MouseEventWithoutKeyboardEquivalentCheck.html
@@ -1,13 +1,17 @@
 <h2>Why is this an issue?</h2>
 <p>Offering the same experience with the mouse and the keyboard allows users to pick their preferred device.</p>
 <p>Additionally, users of assistive technology will be able to browse the site even if they cannot use the mouse.</p>
-<p>This rule raises an issue when a native HTML element:</p>
+<p>This rule raises an issue when an element recognized by the analyzer as native HTML:</p>
 <ul>
   <li>has an <code>onClick</code> attribute but no <code>onKeyDown</code> or <code>onKeyUp</code> attribute.</li>
   <li>has an <code>onMouseover</code> attribute but no <code>onFocus</code> attribute.</li>
   <li>has an <code>onMouseout</code> attribute but no <code>onBlur</code> attribute.</li>
 </ul>
-<p>Components and custom elements are not checked because the analyzer cannot determine how they render or handle keyboard events.</p>
+<p>The rule recognizes plain HTML attributes (such as <code>onClick</code>), Angular event bindings (such as <code>(click)</code>,
+<code>ng-click</code>, and <code>on-click</code>), and Vue bindings (such as <code>v-on:click</code> and <code>@click</code>). These bindings can
+include event modifiers such as <code>@click.prevent</code> and <code>@keydown.enter</code>.</p>
+<p>Only elements the analyzer recognizes as native HTML are checked. Components and custom elements are skipped because the analyzer cannot determine
+how they render or handle keyboard events.</p>
 <p>In the case of <code>onClick</code>, the equivalent keyboard handler should activate on the "Enter" and "Space" keys, since these are the keys
 assistive technologies use to activate buttons.</p>
 <p><code>onKeyPress</code> is also recognised as a keyboard equivalent for backward compatibility, but the event is <a
@@ -33,6 +37,11 @@ reachable:</p>
      onKeyDown="if (event.key === 'Enter' || event.key === ' ') doSomething();"&gt;   &lt;!-- Compliant --&gt;
 &lt;/div&gt;
 </pre>
+<p>The same applies to framework event bindings:</p>
+<pre>
+&lt;div (click)="doSomething()" (keydown.enter)="doSomething()" role="button" tabindex="0"&gt;&lt;/div&gt;
+&lt;div @click="doSomething()" @keydown.enter="doSomething()" role="button" tabindex="0"&gt;&lt;/div&gt;
+</pre>
 <p>For purely visual hover effects, prefer CSS over scripted mouse handlers — the <code>:hover</code> and <code>:focus-visible</code> pseudo-classes
 give mouse and keyboard parity without any JavaScript:</p>
 <pre>
@@ -53,11 +62,17 @@ the platform:</p>
   <li><code>&lt;a&gt;</code>,</li>
   <li><code>&lt;summary&gt;</code>.</li>
 </ul>
+<p>Native controls with an implicit <code>textbox</code>, <code>checkbox</code>, <code>radio</code>, or <code>listbox</code> role are also skipped.
+This includes text inputs, <code>&lt;textarea&gt;</code>, <code>&lt;input type="checkbox"&gt;</code>, <code>&lt;input type="radio"&gt;</code>, and
+<code>&lt;select&gt;</code>.</p>
 <p>Be aware that the anchor exception is broad: only an <code>&lt;a&gt;</code> with an <code>href</code> attribute is actually focusable and activated
 by Enter — an <code>&lt;a onClick&gt;</code> without <code>href</code> behaves like inert text from the keyboard. For button-like actions inside the
 page, prefer <code>&lt;button&gt;</code> over a bare <code>&lt;a&gt;</code>.</p>
 <p>An issue will still be raised for any element that carries <code>role="button"</code> (including <code>&lt;button role="button"&gt;</code>),
 because the explicit role overrides the implicit behaviour and the element is treated as a custom widget.</p>
+<h3>Ignoring specific native elements</h3>
+<p>The <code>whitelistedElements</code> parameter takes a comma-separated list of native HTML tag names to exclude from all checks by this rule. It is
+empty by default.</p>
 <h2>Resources</h2>
 <h3>Documentation</h3>
 <ul>

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/accessibility/AriaTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/accessibility/AriaTest.java
@@ -1,0 +1,47 @@
+/*
+ * SonarQube HTML
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.html.api.accessibility;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.plugins.html.node.Attribute;
+import org.sonar.plugins.html.node.TagNode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AriaTest {
+
+  @Test
+  void returnsComboboxForSingleSelect() {
+    assertThat(Aria.getImplicitRole(tag("select"))).isEqualTo(AriaRole.COMBOBOX);
+    assertThat(Aria.getImplicitRole(tag("select", "size", "1"))).isEqualTo(AriaRole.COMBOBOX);
+  }
+
+  @Test
+  void returnsListboxForMultiSelect() {
+    assertThat(Aria.getImplicitRole(tag("select", "multiple", ""))).isEqualTo(AriaRole.LISTBOX);
+    assertThat(Aria.getImplicitRole(tag("select", "size", "2"))).isEqualTo(AriaRole.LISTBOX);
+  }
+
+  private static TagNode tag(String name, String... attributeNameValuePairs) {
+    TagNode node = new TagNode();
+    node.setNodeName(name);
+    for (int i = 0; i < attributeNameValuePairs.length; i += 2) {
+      node.getAttributes().add(new Attribute(attributeNameValuePairs[i], attributeNameValuePairs[i + 1]));
+    }
+    return node;
+  }
+}

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheckTest.java
@@ -82,6 +82,22 @@ class MouseEventWithoutKeyboardEquivalentCheckTest {
       .next().atLine(1)
       .next().atLine(2)
       .next().atLine(3)
+      .next().atLine(7).withMessage("Add a 'onKeyDown|onKeyUp' attribute to this <div> tag.")
+      .next().atLine(9).withMessage("Add a 'onFocus' attribute to this <div> tag.")
+      .next().atLine(11).withMessage("Add a 'onBlur' attribute to this <div> tag.")
+      .noMore();
+  }
+
+  @Test
+  void whitelisted_native_elements_are_ignored() {
+    MouseEventWithoutKeyboardEquivalentCheck check = new MouseEventWithoutKeyboardEquivalentCheck();
+    check.whitelistedElements = "div";
+
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.whitelisted-elements.html"),
+      check);
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
       .noMore();
   }
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheckTest.java
@@ -59,6 +59,9 @@ class MouseEventWithoutKeyboardEquivalentCheckTest {
         // Vue.js - invalid key name combinations
         .next().atLine(106)
         .next().atLine(107)
+        .next().atLine(113)
+        .next().atLine(114)
+        .next().atLine(115)
     ;
   }
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/MouseEventWithoutKeyboardEquivalentCheckTest.java
@@ -63,29 +63,25 @@ class MouseEventWithoutKeyboardEquivalentCheckTest {
   }
 
   @Test
-  void custom_elements_without_whitelist_are_reported() {
+  void component_elements_are_ignored() {
     HtmlSourceCode sourceCode = TestHelper.scan(
-      new File("src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.whitelisted-elements.html"),
+      new File("src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.component-elements.html"),
       new MouseEventWithoutKeyboardEquivalentCheck());
 
     checkMessagesVerifier.verify(sourceCode.getIssues())
-      .next().atLine(2)
-      .next().atLine(3)
-      .next().atLine(4)
       .noMore();
   }
 
   @Test
-  void custom_elements_in_whitelist_are_ignored_and_defaults_can_be_overridden() {
-    var check = new MouseEventWithoutKeyboardEquivalentCheck();
-    check.whitelistedElements = " clr-button,ION-BUTTON ,";
+  void native_elements_without_keyboard_equivalents_are_reported() {
     HtmlSourceCode sourceCode = TestHelper.scan(
-      new File("src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.whitelisted-elements.html"),
-      check);
+      new File("src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.native-elements.html"),
+      new MouseEventWithoutKeyboardEquivalentCheck());
 
     checkMessagesVerifier.verify(sourceCode.getIssues())
       .next().atLine(1)
-      .next().atLine(4)
+      .next().atLine(2)
+      .next().atLine(3)
       .noMore();
   }
 }

--- a/sonar-html-plugin/src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.component-elements.html
+++ b/sonar-html-plugin/src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.component-elements.html
@@ -7,3 +7,4 @@
 <app-button (mouseout)="hideHint()">Hide hint</app-button>
 <app-button @mouseout="hideHint()">Hide hint</app-button>
 <my-widget onclick="save()" role="button">Save</my-widget>
+<x:div (click)="save()">Save</x:div>

--- a/sonar-html-plugin/src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.component-elements.html
+++ b/sonar-html-plugin/src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.component-elements.html
@@ -1,0 +1,9 @@
+<mat-radio-button (click)="checkDeselect(mode)">Default</mat-radio-button>
+<ion-button (click)="dismiss()">Close</ion-button>
+<app-button (click)="save()">Save</app-button>
+<app-button @click="save()">Save</app-button>
+<app-button (mouseover)="showHint()">Show hint</app-button>
+<app-button @mouseover="showHint()">Show hint</app-button>
+<app-button (mouseout)="hideHint()">Hide hint</app-button>
+<app-button @mouseout="hideHint()">Hide hint</app-button>
+<my-widget onclick="save()" role="button">Save</my-widget>

--- a/sonar-html-plugin/src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.html
@@ -105,3 +105,11 @@
 <!-- Non-compliant Vue key modifier cases -->
 <div onClick="doSomething();" @keydown.toolongkeyname="doSomething();"></div> <!-- Non-Compliant - too long key name -->
 <div onClick="doSomething();" @keydown.1.2.3.4.5.6="doSomething();"></div>   <!-- Non-Compliant - unrealistic key combination -->
+
+<!-- Vue.js event modifiers -->
+<div @mouseover="doSomething();" @focus.capture="doSomething();"></div> <!-- Compliant -->
+<div @mouseout="doSomething();" @blur.once="doSomething();"></div> <!-- Compliant -->
+<div @click="doSomething();" @keydown.arrow-up="doSomething();"></div> <!-- Compliant -->
+<div @click.prevent="doSomething();"></div> <!-- Non-Compliant -->
+<div v-on:click.prevent="doSomething();"></div> <!-- Non-Compliant -->
+<div role="checkbox" @click="doSomething();"></div> <!-- Non-Compliant -->

--- a/sonar-html-plugin/src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.native-elements.html
+++ b/sonar-html-plugin/src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.native-elements.html
@@ -1,0 +1,6 @@
+<div (click)="save()">Save</div> <!-- Non-Compliant -->
+<span onClick="openDialog()">Open</span> <!-- Non-Compliant -->
+<img onClick="selectCar(car)"> <!-- Non-Compliant -->
+<div (click)="save()" (keydown.enter)="save()">Save</div>
+<span onClick="openDialog()" @keyup="openDialog()">Open</span>
+<img onClick="selectCar(car)" v-on:keydown.enter="selectCar(car)">

--- a/sonar-html-plugin/src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.native-elements.html
+++ b/sonar-html-plugin/src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.native-elements.html
@@ -10,3 +10,6 @@
 <div @mouseover="showHint()" @focus="showHint()">Hint</div>
 <div @mouseout="hideHint()">Hint</div> <!-- Non-Compliant - Vue @mouseout, no @blur -->
 <div @mouseout="hideHint()" @blur="hideHint()">Hint</div>
+<input type="checkbox" @click="toggleScope(scope.id)">
+<input type="radio" @click="selectOption()">
+<select @click="selectOption()"></select>

--- a/sonar-html-plugin/src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.native-elements.html
+++ b/sonar-html-plugin/src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.native-elements.html
@@ -12,4 +12,5 @@
 <div @mouseout="hideHint()" @blur="hideHint()">Hint</div>
 <input type="checkbox" @click="toggleScope(scope.id)">
 <input type="radio" @click="selectOption()">
-<select @click="selectOption()"></select>
+<select @click="selectOption()"></select> <!-- Compliant: implicit combobox -->
+<select multiple @click="selectOption()"></select> <!-- Compliant: implicit listbox -->

--- a/sonar-html-plugin/src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.native-elements.html
+++ b/sonar-html-plugin/src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.native-elements.html
@@ -4,3 +4,9 @@
 <div (click)="save()" (keydown.enter)="save()">Save</div>
 <span onClick="openDialog()" @keyup="openDialog()">Open</span>
 <img onClick="selectCar(car)" v-on:keydown.enter="selectCar(car)">
+<div @click="save()">Save</div> <!-- Non-Compliant - Vue @click, no keyboard equivalent -->
+<div @click="save()" @keyup="save()">Save</div>
+<div @mouseover="showHint()">Hint</div> <!-- Non-Compliant - Vue @mouseover, no @focus -->
+<div @mouseover="showHint()" @focus="showHint()">Hint</div>
+<div @mouseout="hideHint()">Hint</div> <!-- Non-Compliant - Vue @mouseout, no @blur -->
+<div @mouseout="hideHint()" @blur="hideHint()">Hint</div>

--- a/sonar-html-plugin/src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.whitelisted-elements.html
+++ b/sonar-html-plugin/src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.whitelisted-elements.html
@@ -1,1 +1,3 @@
 <div onclick="save()">Save</div> <!-- Compliant - whitelisted element -->
+<div onmouseover="showHint()">Show hint</div> <!-- Compliant - whitelisted element -->
+<div onmouseout="hideHint()">Hide hint</div> <!-- Compliant - whitelisted element -->

--- a/sonar-html-plugin/src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.whitelisted-elements.html
+++ b/sonar-html-plugin/src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.whitelisted-elements.html
@@ -1,0 +1,1 @@
+<div onclick="save()">Save</div> <!-- Compliant - whitelisted element -->

--- a/sonar-html-plugin/src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.whitelisted-elements.html
+++ b/sonar-html-plugin/src/test/resources/checks/MouseEventWithoutKeyboardEquivalentCheck.whitelisted-elements.html
@@ -1,4 +1,0 @@
-<lightning-button onclick={doSomething}></lightning-button> <!-- Compliant by default -->
-<clr-button onclick="doSomething();"></clr-button> <!-- Non-Compliant by default -->
-<ion-button onclick="doSomething();"></ion-button> <!-- Non-Compliant by default -->
-<foo-button onclick="doSomething();"></foo-button> <!-- Non-Compliant -->


### PR DESCRIPTION
## Summary
S1082 now evaluates mouse-event keyboard equivalence only for known native HTML elements, avoiding false positives on framework and design-system components. A native-element allowlist remains available for explicit opt-outs, and Vue mouse-event shorthands are recognized.
RSPEC PR: https://github.com/SonarSource/rspec/pull/7862

## Changes
- Gate S1082 before role and mouse-event evaluation using the canonical native tag classifier.
- Retain `whitelistedElements` for native-element opt-outs and document its full scope.
- Cover Angular, Vue, and native HTML mouse-handler cases.

## Functional Validation
Artifact:  [SONARHTML-441-fv.zip](https://github.com/user-attachments/files/30980438/SONARHTML-441-fv.zip)

Once the file is attached to the PR description, unzip and run:
    ./run.sh

Expected output:
```text
******************* MASTER *******************
Analyzing "sample.html"...
Results:
    - Rule "Web:MouseEventWithoutKeyboardEquivalentCheck" -> L.1
    - Rule "Web:MouseEventWithoutKeyboardEquivalentCheck" -> L.2
    - Rule "Web:MouseEventWithoutKeyboardEquivalentCheck" -> L.3
    - Rule "Web:MouseEventWithoutKeyboardEquivalentCheck" -> L.4
    - Rule "Web:MouseEventWithoutKeyboardEquivalentCheck" -> L.5
    - Rule "Web:MouseEventWithoutKeyboardEquivalentCheck" -> L.6
    - Rule "Web:MouseEventWithoutKeyboardEquivalentCheck" -> L.7
    - Rule "Web:MouseEventWithoutKeyboardEquivalentCheck" -> L.8

****** Branch "fix/sonarhtml-441-native-html-s1082" ******
Analyzing "sample.html"...
Results:
    - Rule "Web:MouseEventWithoutKeyboardEquivalentCheck" -> L.1
    - Rule "Web:MouseEventWithoutKeyboardEquivalentCheck" -> L.2
    - Rule "Web:MouseEventWithoutKeyboardEquivalentCheck" -> L.3
    - Rule "Web:MouseEventWithoutKeyboardEquivalentCheck" -> L.11
    - Rule "Web:MouseEventWithoutKeyboardEquivalentCheck" -> L.12
    - Rule "Web:MouseEventWithoutKeyboardEquivalentCheck" -> L.13
```

