### PR TITLE
SONARHTML-442 Recognize labeled Angular Material fields

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheck.java
@@ -151,11 +151,21 @@ public class InputWithoutLabelCheck extends AbstractPageCheck {
     TagNode parent = node.getParent();
     while (parent != null) {
       if (parent.equalsElementName("mat-form-field")) {
-        return parent.getChildren().stream().anyMatch(child -> child.equalsElementName("mat-label"));
+        return containsMatLabel(parent);
       }
       parent = parent.getParent();
     }
     return false;
+  }
+
+  /**
+   * Determines whether an element contains an Angular Material label among its descendants.
+   * @param node the element whose descendants are inspected
+   * @return true when a mat-label is found
+   */
+  private static boolean containsMatLabel(TagNode node) {
+    return node.getChildren().stream()
+      .anyMatch(child -> child.equalsElementName("mat-label") || containsMatLabel(child));
   }
 
   /**

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheck.java
@@ -43,6 +43,8 @@ public class InputWithoutLabelCheck extends AbstractPageCheck {
   private static final String ASSOCIATE_LABEL_MESSAGE = "Associate a valid label to this input field.";
   private static final String ID = "id";
   private static final String ASP_FOR = "asp-for";
+  private static final Set<String> MAT_INPUT_ATTRIBUTE_NAMES = Set.of("matInput", "[matInput]");
+  private static final Set<String> MAT_NATIVE_CONTROL_ATTRIBUTE_NAMES = Set.of("matNativeControl", "[matNativeControl]");
 
   // LinkedHashMap/LinkedHashSet so endDocument emits issues in document order — matches tests and ruling reports.
   private final Set<String> labelTargets = new LinkedHashSet<>();
@@ -141,10 +143,10 @@ public class InputWithoutLabelCheck extends AbstractPageCheck {
   /**
    * Determines whether an Angular Material form field supplies this control's label.
    * @param node the control to inspect
-   * @return true when the control has the matInput directive and its closest form field contains a mat-label
+   * @return true when the control has an Angular Material directive and its closest form field contains a mat-label
    */
   private static boolean isLabeledAngularMaterialControl(TagNode node) {
-    if (!hasMatInputDirective(node)) {
+    if (!isAngularMaterialControl(node)) {
       return false;
     }
 
@@ -165,18 +167,34 @@ public class InputWithoutLabelCheck extends AbstractPageCheck {
    */
   private static boolean containsMatLabel(TagNode node) {
     return node.getChildren().stream()
-      .anyMatch(child -> child.equalsElementName("mat-label") || containsMatLabel(child));
+      .anyMatch(child -> child.equalsElementName("mat-label") ||
+        (!child.equalsElementName("mat-form-field") && containsMatLabel(child)));
   }
 
   /**
-   * Determines whether a control declares Angular Material's matInput directive.
+   * Determines whether an element declares a compatible Angular Material control directive.
    * @param node the control to inspect
-   * @return true when the directive is declared directly or through Angular property binding
+   * @return true when the control element and directive name are compatible
    */
-  private static boolean hasMatInputDirective(TagNode node) {
+  private static boolean isAngularMaterialControl(TagNode node) {
+    if (isSelect(node)) {
+      return hasAttributeNamed(node, MAT_NATIVE_CONTROL_ATTRIBUTE_NAMES);
+    }
+    return (isType(node, "INPUT") || isTextarea(node)) &&
+      (hasAttributeNamed(node, MAT_INPUT_ATTRIBUTE_NAMES) ||
+        hasAttributeNamed(node, MAT_NATIVE_CONTROL_ATTRIBUTE_NAMES));
+  }
+
+  /**
+   * Determines whether an element has an attribute with one of the supplied names.
+   * @param node the element to inspect
+   * @param attributeNames the accepted attribute names
+   * @return true when an accepted attribute is present
+   */
+  private static boolean hasAttributeNamed(TagNode node, Set<String> attributeNames) {
     return node.getAttributes().stream()
       .map(Attribute::getName)
-      .anyMatch(name -> "matInput".equalsIgnoreCase(name) || "[matInput]".equalsIgnoreCase(name));
+      .anyMatch(name -> attributeNames.stream().anyMatch(attributeName -> attributeName.equalsIgnoreCase(name)));
   }
 
   private static boolean isType(TagNode node, String type) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheck.java
@@ -82,7 +82,7 @@ public class InputWithoutLabelCheck extends AbstractPageCheck {
   }
 
   private void registerControl(TagNode node) {
-    if (node.hasProperty("aria-label") || insideLabelNode()) {
+    if (isLabeledAngularMaterialControl(node) || node.hasProperty("aria-label") || insideLabelNode()) {
       return;
     }
 
@@ -136,6 +136,37 @@ public class InputWithoutLabelCheck extends AbstractPageCheck {
   private static boolean isInputRequiredLabel(TagNode node) {
     return isType(node, "INPUT") &&
       !hasExcludedType(node);
+  }
+
+  /**
+   * Determines whether an Angular Material form field supplies this control's label.
+   * @param node the control to inspect
+   * @return true when the control has the matInput directive and its closest form field contains a mat-label
+   */
+  private static boolean isLabeledAngularMaterialControl(TagNode node) {
+    if (!hasMatInputDirective(node)) {
+      return false;
+    }
+
+    TagNode parent = node.getParent();
+    while (parent != null) {
+      if (parent.equalsElementName("mat-form-field")) {
+        return parent.getChildren().stream().anyMatch(child -> child.equalsElementName("mat-label"));
+      }
+      parent = parent.getParent();
+    }
+    return false;
+  }
+
+  /**
+   * Determines whether a control declares Angular Material's matInput directive.
+   * @param node the control to inspect
+   * @return true when the directive is declared directly or through Angular property binding
+   */
+  private static boolean hasMatInputDirective(TagNode node) {
+    return node.getAttributes().stream()
+      .map(Attribute::getName)
+      .anyMatch(name -> "matInput".equalsIgnoreCase(name) || "[matInput]".equalsIgnoreCase(name));
   }
 
   private static boolean isType(TagNode node, String type) {

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheckTest.java
@@ -60,4 +60,22 @@ class InputWithoutLabelCheckTest {
       .noMore();
   }
 
+  /**
+   * Recognizes labels supplied by Angular Material form fields.
+   */
+  @Test
+  void recognizesLabeledAngularMaterialControls() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/InputWithoutLabelCheck/angular-material.html"),
+      new InputWithoutLabelCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(12).withMessage("Associate a valid label to this input field.")
+      .next().atLine(17).withMessage("Associate a valid label to this input field.")
+      .next().atLine(20).withMessage("Associate a valid label to this input field.")
+      .next().atLine(24).withMessage("Associate a valid label to this input field.")
+      .next().atLine(34).withMessage("Associate a valid label to this input field.")
+      .noMore();
+  }
+
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheckTest.java
@@ -75,6 +75,9 @@ class InputWithoutLabelCheckTest {
       .next().atLine(20).withMessage("Associate a valid label to this input field.")
       .next().atLine(24).withMessage("Associate a valid label to this input field.")
       .next().atLine(34).withMessage("Associate a valid label to this input field.")
+      .next().atLine(61).withMessage("Associate a valid label to this input field.")
+      .next().atLine(66).withMessage("Associate a valid label to this input field.")
+      .next().atLine(70).withMessage("Associate a valid label to this input field.")
       .noMore();
   }
 

--- a/sonar-html-plugin/src/test/resources/checks/InputWithoutLabelCheck/angular-material.html
+++ b/sonar-html-plugin/src/test/resources/checks/InputWithoutLabelCheck/angular-material.html
@@ -1,0 +1,35 @@
+<mat-form-field>
+  <mat-label>ICAO</mat-label>
+  <input matInput [formControl]="airlineIcao" />
+</mat-form-field>
+
+<mat-form-field>
+  <textarea matInput></textarea>
+  <mat-label>Description</mat-label>
+</mat-form-field>
+
+<mat-form-field>
+  <input matInput id="withoutLabel" />
+</mat-form-field>
+
+<mat-form-field>
+  <mat-label>Airport</mat-label>
+  <input id="withoutMatInput" />
+</mat-form-field>
+
+<input matInput id="outsideFormField" />
+
+<custom-field>
+  <mat-label>Unrelated</mat-label>
+  <input matInput id="insideCustomComponent" />
+</custom-field>
+
+<mat-form-field>
+  <mat-label>Bound directive</mat-label>
+  <input [matInput]="true" />
+</mat-form-field>
+
+<mat-form-field>
+  <mat-label>Not a directive</mat-label>
+  <input [attr.matInput]="true" id="attributeOnly" />
+</mat-form-field>

--- a/sonar-html-plugin/src/test/resources/checks/InputWithoutLabelCheck/angular-material.html
+++ b/sonar-html-plugin/src/test/resources/checks/InputWithoutLabelCheck/angular-material.html
@@ -40,3 +40,36 @@
   </ng-container>
   <input matInput />
 </mat-form-field>
+
+<mat-form-field>
+  <mat-label>Native input</mat-label>
+  <input matNativeControl />
+</mat-form-field>
+
+<mat-form-field>
+  <mat-label>Bound native textarea</mat-label>
+  <textarea [matNativeControl]="true"></textarea>
+</mat-form-field>
+
+<mat-form-field>
+  <mat-label>Native select</mat-label>
+  <select matNativeControl></select>
+</mat-form-field>
+
+<mat-form-field>
+  <mat-label>Invalid select directive</mat-label>
+  <select matInput id="invalidSelectDirective"></select>
+</mat-form-field>
+
+<mat-form-field>
+  <mat-label>Vue binding</mat-label>
+  <input :matInput="true" id="vueBoundDirective" />
+</mat-form-field>
+
+<mat-form-field>
+  <input matInput id="outerControl" />
+  <mat-form-field>
+    <mat-label>Nested label</mat-label>
+    <input matInput />
+  </mat-form-field>
+</mat-form-field>

--- a/sonar-html-plugin/src/test/resources/checks/InputWithoutLabelCheck/angular-material.html
+++ b/sonar-html-plugin/src/test/resources/checks/InputWithoutLabelCheck/angular-material.html
@@ -33,3 +33,10 @@
   <mat-label>Not a directive</mat-label>
   <input [attr.matInput]="true" id="attributeOnly" />
 </mat-form-field>
+
+<mat-form-field>
+  <ng-container *ngIf="hasLabel">
+    <mat-label>Conditional label</mat-label>
+  </ng-container>
+  <input matInput />
+</mat-form-field>


### PR DESCRIPTION
## Summary
Avoids S1097 false positives for Angular Material controls whose enclosing `mat-form-field` supplies a `mat-label`, including labels in structural descendants such as `ng-container`. Controls without that exact structural label relationship remain reportable.

## Changes
- Recognize `matInput` controls inside labeled Angular Material form fields
- Support direct, property-bound, and descendant `mat-label` forms
- Preserve findings for unlabeled fields, native controls, and unrelated components

## Functional Validation
Artifact: [SONARHTML-442-fv.zip](https://github.com/user-attachments/files/30979817/SONARHTML-442-fv.zip)

Once the file is attached to the PR description, unzip and run:
    ./run.sh

Expected output:
```text
******************* MASTER *******************
Analyzing "sample.html"...
Results:
    - Rule "Web:InputWithoutLabelCheck" -> L.3
    - Rule "Web:InputWithoutLabelCheck" -> L.7
    - Rule "Web:InputWithoutLabelCheck" -> L.15

****** Branch "fix/sonarhtml-442-recognize-labeled-material-fields" ******
Analyzing "sample.html"...
Results:
    (none)
```
