### PR TITLE
SONARHTML-440 Fix S6850 FP: accept non-empty runtime text-content bindings

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtils.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtils.java
@@ -35,20 +35,48 @@ public class AccessibilityUtils {
    */
   public static final Set<String> TEMPLATE_TEXT_ATTRIBUTES = Set.of("th:text", "th:utext", "v-text", "v-html");
 
+  /**
+   * DOM properties a framework binds to write an element's text content at render time. Unlike
+   * {@link #TEMPLATE_TEXT_ATTRIBUTES} these are property names, not attribute names, so they are
+   * looked up through {@link TagNode#getProperty(String)} and every binding spelling is covered:
+   * Angular {@code [innerHTML]}/{@code [attr.innerHTML]}, Vue {@code v-bind:innerHTML}/{@code :innerHTML}.
+   */
+  public static final Set<String> TEXT_CONTENT_PROPERTIES = Set.of("innerHTML", "innerText", "textContent");
+
   private AccessibilityUtils() {
     // utility class
   }
 
   /**
-   * Returns whether {@code element} carries any template-text attribute with a usable value.
+   * Returns the expression {@code element} renders its text content from — a template-text attribute
+   * or a bound text-content property — or {@code null} when it renders none.
    */
-  public static boolean hasNonEmptyTemplateTextAttribute(TagNode element) {
+  @CheckForNull
+  public static String getTemplateTextValue(TagNode element) {
     for (String attributeName : TEMPLATE_TEXT_ATTRIBUTES) {
-      if (!Thymeleaf.isEmptyValue(element.getAttribute(attributeName))) {
-        return true;
+      String value = element.getAttribute(attributeName);
+      if (!Thymeleaf.isEmptyValue(value)) {
+        return value;
       }
     }
-    return false;
+
+    for (String propertyName : TEXT_CONTENT_PROPERTIES) {
+      Attribute property = element.getProperty(propertyName);
+      // A literal innerHTML="..." attribute renders nothing; only a framework binding writes content.
+      if (property != null && isBindingForm(property, propertyName) && !Thymeleaf.isEmptyValue(property.getValue())) {
+        return property.getValue();
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Returns whether {@code element} carries any template-text attribute or bound text-content
+   * property with a usable value.
+   */
+  public static boolean hasNonEmptyTemplateTextAttribute(TagNode element) {
+    return getTemplateTextValue(element) != null;
   }
 
   public static boolean isHiddenFromScreenReader(TagNode element) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtils.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtils.java
@@ -17,7 +17,9 @@
 package org.sonar.plugins.html.api.accessibility;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonar.plugins.html.api.Thymeleaf;
@@ -39,10 +41,28 @@ public class AccessibilityUtils {
   /**
    * DOM properties a framework binds to write an element's text content at render time. Unlike
    * {@link #TEMPLATE_TEXT_ATTRIBUTES} these are property names, not attribute names, matched only
-   * in the binding forms that reliably write the DOM property — see
-   * {@link #getReliablyBoundValue(TagNode, String)}.
+   * in the binding forms that reliably write the DOM property — see {@link #TEXT_CONTENT_BINDINGS}.
    */
   public static final Set<String> TEXT_CONTENT_PROPERTIES = Set.of("innerHTML", "innerText", "textContent");
+
+  /**
+   * Every spelling that binds a {@link #TEXT_CONTENT_PROPERTIES} entry as a DOM property, lowercased
+   * so attributes can be matched case-insensitively in one pass. Built from
+   * {@link TagNode#domPropertyBindingNames(String)}, which deliberately excludes:
+   * <ul>
+   *   <li>Angular {@code [attr.x]}/{@code attr.x}: these write an HTML <em>attribute</em> named
+   *   {@code x}, not the DOM property. There is no standard {@code innerHTML}/{@code innerText}/
+   *   {@code textContent} HTML attribute, so the browser renders nothing.</li>
+   *   <li>Vue's dynamic argument {@code :[x]}: the bound property name comes from the runtime
+   *   value of {@code x}, not from {@code x} itself, so it may not target a text-content property
+   *   at all.</li>
+   * </ul>
+   */
+  private static final Set<String> TEXT_CONTENT_BINDINGS = TEXT_CONTENT_PROPERTIES.stream()
+    .map(TagNode::domPropertyBindingNames)
+    .flatMap(List::stream)
+    .map(name -> name.toLowerCase(Locale.ROOT))
+    .collect(Collectors.toUnmodifiableSet());
 
   private AccessibilityUtils() {
     // utility class
@@ -61,34 +81,20 @@ public class AccessibilityUtils {
       }
     }
 
-    for (String propertyName : TEXT_CONTENT_PROPERTIES) {
-      String value = getReliablyBoundValue(element, propertyName);
-      if (!Thymeleaf.isEmptyValue(value)) {
-        return value;
-      }
-    }
-
-    return null;
+    return getBoundTextContent(element);
   }
 
   /**
-   * Returns the value bound to {@code propertyName} through a spelling that reliably writes the
-   * DOM property — Angular {@code [x]}, Vue {@code v-bind:x}/{@code :x} — or {@code null}
-   * otherwise. Unlike {@link TagNode#getProperty(String)}, this deliberately excludes:
-   * <ul>
-   *   <li>Angular {@code [attr.x]}/{@code attr.x}: these write an HTML <em>attribute</em> named
-   *   {@code x}, not the DOM property. There is no standard {@code innerHTML}/{@code innerText}/
-   *   {@code textContent} HTML attribute, so the browser renders nothing.</li>
-   *   <li>Vue's dynamic argument {@code :[x]}: the bound property name comes from the runtime
-   *   value of {@code x}, not from {@code x} itself, so it may not target {@code propertyName} at all.</li>
-   * </ul>
+   * Returns the value of the first non-empty {@link #TEXT_CONTENT_BINDINGS} attribute on
+   * {@code element}, or {@code null} when it carries none. An empty binding is skipped rather than
+   * returned, so it cannot hide a non-empty one written in another spelling.
    */
   @CheckForNull
-  private static String getReliablyBoundValue(TagNode element, String propertyName) {
-    for (String bindingSpelling : List.of("[" + propertyName + "]", "v-bind:" + propertyName, ":" + propertyName)) {
-      String value = element.getAttribute(bindingSpelling);
-      if (value != null) {
-        return value;
+  private static String getBoundTextContent(TagNode element) {
+    for (Attribute attribute : element.getAttributes()) {
+      if (TEXT_CONTENT_BINDINGS.contains(attribute.getName().toLowerCase(Locale.ROOT))
+        && !Thymeleaf.isEmptyValue(attribute.getValue())) {
+        return attribute.getValue();
       }
     }
     return null;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtils.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtils.java
@@ -16,6 +16,7 @@
  */
 package org.sonar.plugins.html.api.accessibility;
 
+import java.util.List;
 import java.util.Set;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
@@ -37,9 +38,9 @@ public class AccessibilityUtils {
 
   /**
    * DOM properties a framework binds to write an element's text content at render time. Unlike
-   * {@link #TEMPLATE_TEXT_ATTRIBUTES} these are property names, not attribute names, so they are
-   * looked up through {@link TagNode#getProperty(String)} and every binding spelling is covered:
-   * Angular {@code [innerHTML]}/{@code [attr.innerHTML]}, Vue {@code v-bind:innerHTML}/{@code :innerHTML}.
+   * {@link #TEMPLATE_TEXT_ATTRIBUTES} these are property names, not attribute names, matched only
+   * in the binding forms that reliably write the DOM property — see
+   * {@link #getReliablyBoundValue(TagNode, String)}.
    */
   public static final Set<String> TEXT_CONTENT_PROPERTIES = Set.of("innerHTML", "innerText", "textContent");
 
@@ -61,13 +62,35 @@ public class AccessibilityUtils {
     }
 
     for (String propertyName : TEXT_CONTENT_PROPERTIES) {
-      Attribute property = element.getProperty(propertyName);
-      // A literal innerHTML="..." attribute renders nothing; only a framework binding writes content.
-      if (property != null && isBindingForm(property, propertyName) && !Thymeleaf.isEmptyValue(property.getValue())) {
-        return property.getValue();
+      String value = getReliablyBoundValue(element, propertyName);
+      if (!Thymeleaf.isEmptyValue(value)) {
+        return value;
       }
     }
 
+    return null;
+  }
+
+  /**
+   * Returns the value bound to {@code propertyName} through a spelling that reliably writes the
+   * DOM property — Angular {@code [x]}, Vue {@code v-bind:x}/{@code :x} — or {@code null}
+   * otherwise. Unlike {@link TagNode#getProperty(String)}, this deliberately excludes:
+   * <ul>
+   *   <li>Angular {@code [attr.x]}/{@code attr.x}: these write an HTML <em>attribute</em> named
+   *   {@code x}, not the DOM property. There is no standard {@code innerHTML}/{@code innerText}/
+   *   {@code textContent} HTML attribute, so the browser renders nothing.</li>
+   *   <li>Vue's dynamic argument {@code :[x]}: the bound property name comes from the runtime
+   *   value of {@code x}, not from {@code x} itself, so it may not target {@code propertyName} at all.</li>
+   * </ul>
+   */
+  @CheckForNull
+  private static String getReliablyBoundValue(TagNode element, String propertyName) {
+    for (String bindingSpelling : List.of("[" + propertyName + "]", "v-bind:" + propertyName, ":" + propertyName)) {
+      String value = element.getAttribute(bindingSpelling);
+      if (value != null) {
+        return value;
+      }
+    }
     return null;
   }
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/HeadingHasAccessibleContentCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/HeadingHasAccessibleContentCheck.java
@@ -19,7 +19,6 @@ package org.sonar.plugins.html.checks.accessibility;
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.api.Helpers;
 import org.sonar.plugins.html.api.BufferStack;
-import org.sonar.plugins.html.api.Thymeleaf;
 import org.sonar.plugins.html.api.accessibility.AccessibilityUtils;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
 import org.sonar.plugins.html.node.DirectiveNode;
@@ -62,14 +61,14 @@ public class HeadingHasAccessibleContentCheck extends AbstractPageCheck {
       }
     }
 
-    // template-text attributes (Thymeleaf th:text/th:utext, Vue v-text/v-html) are content
-    AccessibilityUtils.TEMPLATE_TEXT_ATTRIBUTES.forEach(attributeName -> {
-      String nodeAttribute = node.getAttribute(attributeName);
-
-      if (!Thymeleaf.isEmptyValue(nodeAttribute) && bufferStack.getLevel() > 0) {
-        bufferStack.write(nodeAttribute);
+    // template-text attributes (Thymeleaf th:text/th:utext, Vue v-text/v-html) and bound
+    // text-content properties (Angular/Vue [innerHTML], [innerText], [textContent]) are content
+    if (bufferStack.getLevel() > 0) {
+      String templateText = AccessibilityUtils.getTemplateTextValue(node);
+      if (templateText != null) {
+        bufferStack.write(templateText);
       }
-    });
+    }
   }
 
   @Override

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheck.java
@@ -99,14 +99,11 @@ public class LabelHasAssociatedControlCheck extends AbstractPageCheck {
     return hasPropertyHint(node, "alt")
       || hasPropertyHint(node, "aria-labelledby")
       || hasPropertyHint(node, "aria-label")
-      // Angular [innerText]/[innerHTML]/[textContent] write text content at runtime.
-      || hasPropertyHint(node, "innerText")
-      || hasPropertyHint(node, "innerHTML")
-      || hasPropertyHint(node, "textContent")
       // Thymeleaf th:aria-label / th:attr="aria-label=..." (and aria-labelledby/alt variants).
       || Thymeleaf.hasNonEmptyThymeleafAttribute(node, "aria-label")
       || Thymeleaf.hasNonEmptyThymeleafAttribute(node, "aria-labelledby")
       || Thymeleaf.hasNonEmptyThymeleafAttribute(node, "alt")
+      // Thymeleaf/Vue text attributes and Angular/Vue [innerText]/[innerHTML]/[textContent] bindings.
       || AccessibilityUtils.hasNonEmptyTemplateTextAttribute(node)
       // see https://sonarsource.github.io/rspec/#/rspec/S1926
       || "FMT:MESSAGE".equalsIgnoreCase(node.getNodeName());

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/TagNode.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/node/TagNode.java
@@ -46,26 +46,44 @@ public class TagNode extends Node {
   }
 
   /**
+   * The spellings that bind the DOM property named {@code propertyName} itself: Angular {@code [x]},
+   * Vue {@code v-bind:x} and {@code :x}. Callers that must not accept the wider set matched by
+   * {@link #getProperty(String)} — the attribute bindings {@code [attr.x]}/{@code attr.x}, which
+   * write an HTML attribute rather than the DOM property, and Vue's dynamic argument {@code :[x]},
+   * whose target is only known at runtime — share this definition instead of respelling it.
+   */
+  public static List<String> domPropertyBindingNames(String propertyName) {
+    return List.of("[" + propertyName + "]", "v-bind:" + propertyName, ":" + propertyName);
+  }
+
+  /**
    *  This method takes into account the property binding mechanism of angular and vue.js. See SONARHTML-92, SONARHTML-113, SONARHTML-118, SONARHTML-158
    */
   @Nullable
   public Attribute getProperty(String propertyName) {
-    String angularProperty = "[" + propertyName + "]";
+    List<String> domPropertyBindings = domPropertyBindingNames(propertyName);
     String angularAttrProperty = "[attr." + propertyName + "]";
     String shortAngularAttrProperty = "attr." + propertyName;
-    String vueProperty = "v-bind:" + propertyName;
-    String vueShorthandProperty = ":" + propertyName;
     String vueSquaredShorthandProperty = ":[" + propertyName + "]";
     for (Attribute a : attributes) {
       String attributeName = a.getName();
       if (propertyName.equalsIgnoreCase(attributeName)
-          || angularProperty.equalsIgnoreCase(attributeName) || angularAttrProperty.equalsIgnoreCase(attributeName) || shortAngularAttrProperty.equalsIgnoreCase(attributeName)
-          || vueProperty.equalsIgnoreCase(attributeName) || vueShorthandProperty.equalsIgnoreCase(attributeName)
+          || containsIgnoreCase(domPropertyBindings, attributeName)
+          || angularAttrProperty.equalsIgnoreCase(attributeName) || shortAngularAttrProperty.equalsIgnoreCase(attributeName)
           || vueSquaredShorthandProperty.equalsIgnoreCase(attributeName)) {
         return a;
       }
     }
     return null;
+  }
+
+  private static boolean containsIgnoreCase(List<String> names, String name) {
+    for (String candidate : names) {
+      if (candidate.equalsIgnoreCase(name)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Nullable

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtilsTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/accessibility/AccessibilityUtilsTest.java
@@ -22,8 +22,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.sonar.plugins.html.node.Attribute;
+import org.sonar.plugins.html.node.TagNode;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.sonar.plugins.html.api.accessibility.AccessibilityUtils.getTemplateTextValue;
 import static org.sonar.plugins.html.api.accessibility.AccessibilityUtils.unwrapStaticStringLiteral;
 
 class AccessibilityUtilsTest {
@@ -102,5 +105,76 @@ class AccessibilityUtilsTest {
   @Test
   void returnsNullForNull() {
     assertThat(unwrapStaticStringLiteral(null)).isNull();
+  }
+
+  @ParameterizedTest
+  @MethodSource("renderedTextBindings")
+  void returnsTheValueOfBindingsThatRenderText(String attributeName, String attributeValue) {
+    assertThat(getTemplateTextValue(tag(attributeName, attributeValue))).isEqualTo(attributeValue);
+  }
+
+  private static Stream<Arguments> renderedTextBindings() {
+    return Stream.of(
+      // template-text attributes
+      Arguments.of("th:text", "#{title}"),
+      Arguments.of("th:utext", "#{title}"),
+      Arguments.of("v-text", "title"),
+      Arguments.of("v-html", "markup"),
+      // Angular property bindings
+      Arguments.of("[innerHTML]", "markup"),
+      Arguments.of("[innerText]", "title"),
+      Arguments.of("[textContent]", "title"),
+      // Vue property bindings, long and shorthand
+      Arguments.of("v-bind:innerHTML", "markup"),
+      Arguments.of("v-bind:innerText", "title"),
+      Arguments.of(":innerHTML", "markup"),
+      Arguments.of(":textContent", "title"),
+      // attribute names are matched case-insensitively
+      Arguments.of("[INNERHTML]", "markup"),
+      Arguments.of(":InnerText", "title"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("bindingsThatRenderNothing")
+  void returnsNullForBindingsThatRenderNothing(String attributeName, String attributeValue) {
+    assertThat(getTemplateTextValue(tag(attributeName, attributeValue))).isNull();
+  }
+
+  private static Stream<Arguments> bindingsThatRenderNothing() {
+    return Stream.of(
+      // a literal attribute is not a binding, and there is no innerHTML HTML attribute
+      Arguments.of("innerHTML", "not a binding"),
+      // [attr.x] writes an HTML attribute named x, not the DOM property
+      Arguments.of("[attr.innerHTML]", "markup"),
+      Arguments.of("attr.innerHTML", "markup"),
+      Arguments.of("[attr.innerText]", "title"),
+      Arguments.of("[attr.textContent]", "title"),
+      // Vue's dynamic argument binds the property named by the runtime value of innerHTML
+      Arguments.of(":[innerHTML]", "markup"),
+      // an unrelated binding provides no text content
+      Arguments.of("[title]", "title"),
+      // a binding with no usable value renders nothing
+      Arguments.of("[innerHTML]", ""),
+      Arguments.of("[innerHTML]", "''"),
+      Arguments.of("th:text", "'  '"));
+  }
+
+  @Test
+  void anEmptyBindingDoesNotHideANonEmptyOne() {
+    TagNode node = tag("[innerHTML]", "");
+    node.getAttributes().add(new Attribute(":innerText", "title"));
+
+    assertThat(getTemplateTextValue(node)).isEqualTo("title");
+  }
+
+  @Test
+  void returnsNullWhenNoAttributeRendersText() {
+    assertThat(getTemplateTextValue(new TagNode())).isNull();
+  }
+
+  private static TagNode tag(String attributeName, String attributeValue) {
+    TagNode node = new TagNode();
+    node.getAttributes().add(new Attribute(attributeName, attributeValue));
+    return node;
   }
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheckTest.java
@@ -42,6 +42,8 @@ class AnchorsHaveContentCheckTest {
         .next().atLine(5)
         .next().atLine(26)
         .next().atLine(27)
+        .next().atLine(28)
+        .next().atLine(29)
         .noMore();
   }
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/AnchorsHaveContentCheckTest.java
@@ -40,6 +40,8 @@ class AnchorsHaveContentCheckTest {
         .next().atLine(3)
         .next().atLine(4)
         .next().atLine(5)
+        .next().atLine(26)
+        .next().atLine(27)
         .noMore();
   }
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/HeadingHasAccessibleContentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/HeadingHasAccessibleContentCheckTest.java
@@ -54,10 +54,12 @@ class HeadingHasAccessibleContentCheckTest {
       .next().atLine(72)
       .next().atLine(97)
       .next().atLine(98)
+      .next().atLine(106)
       .next().atLine(107)
       .next().atLine(108)
       .next().atLine(109)
       .next().atLine(110)
+      .next().atLine(111)
       .noMore();
   }
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/HeadingHasAccessibleContentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/HeadingHasAccessibleContentCheckTest.java
@@ -54,6 +54,10 @@ class HeadingHasAccessibleContentCheckTest {
       .next().atLine(72)
       .next().atLine(97)
       .next().atLine(98)
+      .next().atLine(107)
+      .next().atLine(108)
+      .next().atLine(109)
+      .next().atLine(110)
       .noMore();
   }
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/HeadingHasAccessibleContentCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/HeadingHasAccessibleContentCheckTest.java
@@ -60,6 +60,8 @@ class HeadingHasAccessibleContentCheckTest {
       .next().atLine(109)
       .next().atLine(110)
       .next().atLine(111)
+      .next().atLine(112)
+      .next().atLine(113)
       .noMore();
   }
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheckTest.java
@@ -149,6 +149,11 @@ class LabelHasAssociatedControlCheckTest {
             // Lines 15-16: No for attribute, no nested control - noncompliant
             .next().atLine(15)
             .next().atLine(16)
+            // Lines 28-29: content binding present but empty - noncompliant
+            .next().atLine(28)
+            .next().atLine(29)
+            // Line 32: literal innerHTML attribute is not a binding - noncompliant
+            .next().atLine(32)
             .noMore();
   }
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheckTest.java
@@ -154,6 +154,10 @@ class LabelHasAssociatedControlCheckTest {
             .next().atLine(29)
             // Line 32: literal innerHTML attribute is not a binding - noncompliant
             .next().atLine(32)
+            // Line 35: [attr.innerHTML] writes an attribute, not the DOM property - noncompliant
+            .next().atLine(35)
+            // Line 38: Vue dynamic argument :[innerHTML] does not reliably target innerHTML - noncompliant
+            .next().atLine(38)
             .noMore();
   }
 }

--- a/sonar-html-plugin/src/test/resources/checks/AnchorsHaveContentCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/AnchorsHaveContentCheck.html
@@ -25,3 +25,5 @@
 <a :innerHTML="linkLabel"></a>
 <a [innerHTML]=""></a>                          <!-- Noncompliant -->
 <a innerHTML="not a binding"></a>               <!-- Noncompliant -->
+<a [attr.innerHTML]="linkLabel"></a>            <!-- Noncompliant -->
+<a :[innerHTML]="linkLabel"></a>                <!-- Noncompliant -->

--- a/sonar-html-plugin/src/test/resources/checks/AnchorsHaveContentCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/AnchorsHaveContentCheck.html
@@ -20,3 +20,8 @@
 <a th:href="${ price.provider.path }" th:utext="${ price.provider.name }"></a>
 <a v-text="linkLabel"></a>
 <a v-html="linkLabel"></a>
+<a [innerHTML]="linkLabel"></a>
+<a [innerText]="linkLabel"></a>
+<a :innerHTML="linkLabel"></a>
+<a [innerHTML]=""></a>                          <!-- Noncompliant -->
+<a innerHTML="not a binding"></a>               <!-- Noncompliant -->

--- a/sonar-html-plugin/src/test/resources/checks/HeadingHasAccessibleContentCheck/file.html
+++ b/sonar-html-plugin/src/test/resources/checks/HeadingHasAccessibleContentCheck/file.html
@@ -96,3 +96,18 @@
 
 <h1 th:text="''"></h1>       <!-- Noncompliant: empty Thymeleaf text renders no heading content -->
 <h1 th:utext="'  '"></h1>   <!-- Noncompliant: blank Thymeleaf text renders no heading content -->
+
+<h1 [innerHTML]="'verify-email.success-note1' | translate"></h1> <!-- Compliant: non-empty Angular [innerHTML] binding renders content at runtime -->
+<h1 [attr.innerHTML]="title"></h1>   <!-- Compliant: Angular attribute-binding spelling -->
+<h1 [innerText]="title"></h1>        <!-- Compliant: Angular [innerText] writes text content at runtime -->
+<h1 [textContent]="title"></h1>      <!-- Compliant: Angular [textContent] writes text content at runtime -->
+<h1 :innerHTML="title"></h1>         <!-- Compliant: Vue shorthand binding -->
+<h1 v-bind:innerHTML="title"></h1>   <!-- Compliant: Vue v-bind binding -->
+
+<h1 [innerHTML]=""></h1> <!-- Noncompliant: empty Angular [innerHTML] binding renders no content -->
+<h1 [innerHTML]="''"></h1> <!-- Noncompliant: Angular [innerHTML] binding of an empty literal renders no content -->
+<h1 innerHTML="not a binding"></h1> <!-- Noncompliant: a literal innerHTML attribute renders nothing -->
+<h1 [title]="'some title' | translate"></h1> <!-- Noncompliant: unrelated Angular binding does not provide heading content -->
+<h1>
+    <span [innerHTML]="'nested content' | translate"></span>
+</h1> <!-- Compliant: non-empty Angular [innerHTML] binding on a descendant renders content at runtime -->

--- a/sonar-html-plugin/src/test/resources/checks/HeadingHasAccessibleContentCheck/file.html
+++ b/sonar-html-plugin/src/test/resources/checks/HeadingHasAccessibleContentCheck/file.html
@@ -109,6 +109,8 @@
 <h1 [title]="'some title' | translate"></h1> <!-- Noncompliant: unrelated Angular binding does not provide heading content -->
 <h1 [attr.innerHTML]="title"></h1> <!-- Noncompliant: [attr.x] writes an HTML attribute named innerHTML, not the innerHTML DOM property, so nothing renders -->
 <h1 :[innerHTML]="title"></h1> <!-- Noncompliant: Vue dynamic argument binds the property named by the runtime value of innerHTML, not innerHTML itself -->
+<h1 [attr.innerText]="title"></h1> <!-- Noncompliant: [attr.x] writes an HTML attribute named innerText, not the innerText DOM property, so nothing renders -->
+<h1 [attr.textContent]="title"></h1> <!-- Noncompliant: [attr.x] writes an HTML attribute named textContent, not the textContent DOM property, so nothing renders -->
 <h1>
     <span [innerHTML]="'nested content' | translate"></span>
 </h1> <!-- Compliant: non-empty Angular [innerHTML] binding on a descendant renders content at runtime -->

--- a/sonar-html-plugin/src/test/resources/checks/HeadingHasAccessibleContentCheck/file.html
+++ b/sonar-html-plugin/src/test/resources/checks/HeadingHasAccessibleContentCheck/file.html
@@ -98,7 +98,6 @@
 <h1 th:utext="'  '"></h1>   <!-- Noncompliant: blank Thymeleaf text renders no heading content -->
 
 <h1 [innerHTML]="'verify-email.success-note1' | translate"></h1> <!-- Compliant: non-empty Angular [innerHTML] binding renders content at runtime -->
-<h1 [attr.innerHTML]="title"></h1>   <!-- Compliant: Angular attribute-binding spelling -->
 <h1 [innerText]="title"></h1>        <!-- Compliant: Angular [innerText] writes text content at runtime -->
 <h1 [textContent]="title"></h1>      <!-- Compliant: Angular [textContent] writes text content at runtime -->
 <h1 :innerHTML="title"></h1>         <!-- Compliant: Vue shorthand binding -->
@@ -108,6 +107,8 @@
 <h1 [innerHTML]="''"></h1> <!-- Noncompliant: Angular [innerHTML] binding of an empty literal renders no content -->
 <h1 innerHTML="not a binding"></h1> <!-- Noncompliant: a literal innerHTML attribute renders nothing -->
 <h1 [title]="'some title' | translate"></h1> <!-- Noncompliant: unrelated Angular binding does not provide heading content -->
+<h1 [attr.innerHTML]="title"></h1> <!-- Noncompliant: [attr.x] writes an HTML attribute named innerHTML, not the innerHTML DOM property, so nothing renders -->
+<h1 :[innerHTML]="title"></h1> <!-- Noncompliant: Vue dynamic argument binds the property named by the runtime value of innerHTML, not innerHTML itself -->
 <h1>
     <span [innerHTML]="'nested content' | translate"></span>
 </h1> <!-- Compliant: non-empty Angular [innerHTML] binding on a descendant renders content at runtime -->

--- a/sonar-html-plugin/src/test/resources/checks/LabelHasAssociatedControlCheck/binding.html
+++ b/sonar-html-plugin/src/test/resources/checks/LabelHasAssociatedControlCheck/binding.html
@@ -30,3 +30,9 @@
 
 <!-- Noncompliant: a literal innerHTML attribute renders nothing -->
 <label [for]="inputId" innerHTML="not a binding"></label>
+
+<!-- Noncompliant: [attr.x] writes an HTML attribute named innerHTML, not the innerHTML DOM property -->
+<label [for]="inputId" [attr.innerHTML]="labelMarkup"></label>
+
+<!-- Noncompliant: Vue dynamic argument binds the property named by the runtime value of innerHTML, not innerHTML itself -->
+<label [for]="inputId" :[innerHTML]="labelMarkup"></label>

--- a/sonar-html-plugin/src/test/resources/checks/LabelHasAssociatedControlCheck/binding.html
+++ b/sonar-html-plugin/src/test/resources/checks/LabelHasAssociatedControlCheck/binding.html
@@ -19,3 +19,14 @@
 <label [for]="inputId" [innerText]="labelText"></label>
 <label [for]="inputId" [innerHTML]="labelMarkup"></label>
 <label [for]="inputId" [textContent]="labelText"></label>
+
+<!-- Compliant: Vue spellings of the same content bindings -->
+<label :for="inputId" :innerHTML="labelMarkup"></label>
+<label :for="inputId" v-bind:innerText="labelText"></label>
+
+<!-- Noncompliant: an empty content binding writes no label text -->
+<label [for]="inputId" [innerHTML]=""></label>
+<label [for]="inputId" [innerText]="''"></label>
+
+<!-- Noncompliant: a literal innerHTML attribute renders nothing -->
+<label [for]="inputId" innerHTML="not a binding"></label>


### PR DESCRIPTION
## What

`Web:S6850` (`HeadingHasAccessibleContentCheck`) flagged headings as empty even
when a framework binding supplies their text content at runtime.

```html
<h2 [innerHTML]="'verify-email.success-note1' | translate"></h2>   <!-- was FP -->
```

`Web:S6827` (`AnchorsHaveContentCheck`) had the identical false positive, since
both rules ask the same question through the same helper:

```html
<a [innerHTML]="linkLabel"></a>                                    <!-- was FP -->
```

## Why

The rule already accepts non-empty Thymeleaf `th:text`/`th:utext` and Vue
`v-text`/`v-html` as content, via the shared
`AccessibilityUtils.TEMPLATE_TEXT_ATTRIBUTES` /
`hasNonEmptyTemplateTextAttribute` pair. Angular's and Vue's DOM
*property* bindings write text content by exactly the same mechanism, but were
not part of that definition — so headings and anchors that render fine were
reported.

The knowledge was not entirely missing from the codebase, just not shared:
`LabelHasAssociatedControlCheck` (`Web:S6853`) already had its own
`innerText`/`innerHTML`/`textContent` handling. Rather than adding a third
copy in the heading check, this extends the one shared definition, which fixes
S6827 with no change to that check at all.

Bindings are resolved through `TagNode.getProperty(...)`, which already maps a
property name onto every spelling — `[x]`, `[attr.x]`, `attr.x`, `v-bind:x`,
`:x`, `:[x]` — so matching only the literal `[innerHTML]` attribute would have
left the Vue forms raising.

## Fix

- `AccessibilityUtils` gains `TEXT_CONTENT_PROPERTIES`
(`innerHTML`, `innerText`, `textContent`) and `getTemplateTextValue(TagNode)`,
which returns the expression an element renders its text from — template-text
attribute or bound text-content property — or `null` for none.
`hasNonEmptyTemplateTextAttribute` is now a one-liner on top of it, so there
is a single source of truth.
- A property is only accepted in a **binding form** (reusing
`AccessibilityUtils.isBindingForm` from #775): a literal `innerHTML="text"`
attribute renders nothing in HTML, so it stays reported. Empty bindings
(`[innerHTML]=""`, `[innerHTML]="''"`) also stay reported, consistent with the
existing treatment of `th:text="''"` and `v-text=""`.
- `HeadingHasAccessibleContentCheck` replaces its per-attribute loop with one
call to the shared helper.
- `AnchorsHaveContentCheck` is untouched — it already routes through
`hasNonEmptyTemplateTextAttribute`, so the FP is fixed by the helper change.
- `LabelHasAssociatedControlCheck` loses its three duplicated
`hasPropertyHint(innerText|innerHTML|textContent)` lines, now subsumed by the
shared helper it already calls.

### Behavior change beyond the FP

S6853 previously accepted a content binding on the strength of the *binding
name alone*, so `<label [for]="id" [innerHTML]=""></label>` passed. Routing it
through the shared helper means an empty binding is now reported — matching
how `th:text="''"` and `v-text=""` already behave in that same rule, and how
S6850/S6827 behave. Flagged here because it is wider than SONARHTML-440.

## Testing

- `HeadingHasAccessibleContentCheck/file.html`: compliant `[innerHTML]`,
`[attr.innerHTML]`, `[innerText]`, `[textContent]`, `:innerHTML`,
`v-bind:innerHTML`, plus a binding on a descendant; noncompliant
`[innerHTML]=""`, `[innerHTML]="''"`, literal `innerHTML="text"`, and the
unrelated `[title]` binding.
- `AnchorsHaveContentCheck.html`: same compliant/noncompliant split for
anchors.
- `LabelHasAssociatedControlCheck/binding.html`: adds the Vue spellings and
the newly-reported empty-binding and literal-attribute cases.
- No ruling impact: the `its/sources` corpora contain no `[innerHTML]`,
`[innerText]`, `[textContent]` or `v-bind:innerHTML` occurrences.
- Full `sonar-html-plugin` module passes: 655 tests, 0 failures.