### PR TITLE
SONARHTML-443 Ignore presentational roles in S6819

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheck.java
@@ -18,6 +18,7 @@ package org.sonar.plugins.html.checks.accessibility;
 
 import static org.sonar.plugins.html.api.HtmlConstants.isAbstractRole;
 import static org.sonar.plugins.html.api.HtmlConstants.hasKnownHTMLTag;
+import static org.sonar.plugins.html.api.HtmlConstants.PRESENTATION_ROLES;
 
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -80,7 +81,7 @@ public class PreferTagOverRoleCheck extends AbstractPageCheck {
     }
 
     AriaRole ariaRole = roleDef.getName();
-    if (allowedRolesCache.contains(ariaRole)) {
+    if (ariaRole == AriaRole.PRESENTATION || allowedRolesCache.contains(ariaRole)) {
       return;
     }
 
@@ -105,7 +106,11 @@ public class PreferTagOverRoleCheck extends AbstractPageCheck {
 
   private static Aria.RoleDefinition resolveFirstApplicableRole(String roleAttr) {
     for (String token : roleAttr.trim().split("\\s+")) {
-      AriaRole role = AriaRole.of(token.toLowerCase(Locale.ROOT));
+      String normalizedToken = token.toLowerCase(Locale.ROOT);
+      if (PRESENTATION_ROLES.contains(normalizedToken)) {
+        return Aria.getRole(AriaRole.PRESENTATION);
+      }
+      AriaRole role = AriaRole.of(normalizedToken);
       if (role == null || isAbstractRole(role)) {
         continue;
       }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheck.java
@@ -81,7 +81,7 @@ public class PreferTagOverRoleCheck extends AbstractPageCheck {
     }
 
     AriaRole ariaRole = roleDef.getName();
-    if (ariaRole == AriaRole.PRESENTATION || allowedRolesCache.contains(ariaRole)) {
+    if (allowedRolesCache.contains(ariaRole)) {
       return;
     }
 
@@ -108,7 +108,8 @@ public class PreferTagOverRoleCheck extends AbstractPageCheck {
     for (String token : roleAttr.trim().split("\\s+")) {
       String normalizedToken = token.toLowerCase(Locale.ROOT);
       if (PRESENTATION_ROLES.contains(normalizedToken)) {
-        return Aria.getRole(AriaRole.PRESENTATION);
+        // Presentational roles opt out of semantics; there is nothing to suggest.
+        return null;
       }
       AriaRole role = AriaRole.of(normalizedToken);
       if (role == null || isAbstractRole(role)) {

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheckTest.java
@@ -92,6 +92,17 @@ class PreferTagOverRoleCheckTest {
       .consume();
   }
 
+  /** Verifies that presentational role aliases do not suggest a replacement tag. */
+  @Test
+  void presentationAndNoneRolesAreIgnored() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/PreferTagOverRoleCheckPresentationalRoles.html"),
+      new PreferTagOverRoleCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(5).withMessage("Use <button> or <input> instead of the button role to ensure accessibility across all devices.");
+  }
+
   @Test
   void unknownAllowedRolesAreReportedAsAnalysisWarning() {
     var check = new PreferTagOverRoleCheck();

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/PreferTagOverRoleCheckTest.java
@@ -92,7 +92,6 @@ class PreferTagOverRoleCheckTest {
       .consume();
   }
 
-  /** Verifies that presentational role aliases do not suggest a replacement tag. */
   @Test
   void presentationAndNoneRolesAreIgnored() {
     HtmlSourceCode sourceCode = TestHelper.scan(
@@ -100,7 +99,8 @@ class PreferTagOverRoleCheckTest {
       new PreferTagOverRoleCheck());
 
     checkMessagesVerifier.verify(sourceCode.getIssues())
-      .next().atLine(5).withMessage("Use <button> or <input> instead of the button role to ensure accessibility across all devices.");
+      .next().atLine(6).withMessage("Use <button> or <input> instead of the button role to ensure accessibility across all devices.")
+      .noMore();
   }
 
   @Test

--- a/sonar-html-plugin/src/test/resources/checks/PreferTagOverRoleCheckPresentationalRoles.html
+++ b/sonar-html-plugin/src/test/resources/checks/PreferTagOverRoleCheckPresentationalRoles.html
@@ -1,0 +1,5 @@
+<li role="presentation"></li>
+<table role="presentation"></table>
+<svg role="presentation" focusable="false"></svg>
+<div role="none button"></div>
+<div role="button"></div>

--- a/sonar-html-plugin/src/test/resources/checks/PreferTagOverRoleCheckPresentationalRoles.html
+++ b/sonar-html-plugin/src/test/resources/checks/PreferTagOverRoleCheckPresentationalRoles.html
@@ -1,5 +1,6 @@
 <li role="presentation"></li>
 <table role="presentation"></table>
 <svg role="presentation" focusable="false"></svg>
+<div role="none"></div>
 <div role="none button"></div>
 <div role="button"></div>


### PR DESCRIPTION
## Summary
S6819 no longer suggests a replacement tag for the ARIA `presentation` and `none` roles. It continues reporting real semantic roles such as `button`.

## Changes
- Treat `none` as the `presentation` alias when resolving the first applicable ARIA role
- Skip replacement-tag suggestions for the resolved presentational role
- Cover list, table, SVG, alias, and control cases

## Functional Validation
Artifact: [SONARHTML-443-fv.zip](https://github.com/user-attachments/files/31020906/SONARHTML-443-fv.zip)

Once the file is attached to the PR description, unzip and run:
    ./run.sh

Expected output:
```text
******************* MASTER *******************
Analyzing "sample.html"...
Results:
    - Rule "Web:S6819" -> L.1
    - Rule "Web:S6819" -> L.2
    - Rule "Web:S6819" -> L.3
    - Rule "Web:S6819" -> L.4
    - Rule "Web:S6819" -> L.5
****** Branch "fix/sonarhtml-443-ignore-presentation-roles" ******
Analyzing "sample.html"...
Results:
    - Rule "Web:S6819" -> L.5
```
