### PR TITLE
SONARHTML-432 Sync RSPEC before 3.31 release

### DIFF
--- a/sonarpedia.json
+++ b/sonarpedia.json
@@ -3,7 +3,7 @@
   "languages": [
     "HTML"
   ],
-  "latest-update": "2026-07-14T12:31:42.630722Z",
+  "latest-update": "2026-08-14T09:27:24.027301Z",
   "options": {
     "no-language-in-filenames": true,
     "preserve-filenames": true


### PR DESCRIPTION
## Summary
Synchronizes SonarHTML's generated rule metadata with current RSPEC definitions before the 3.31 release.

## Changes
- Refresh generated SonarPedia metadata from RSPEC master

:warning::warning: This is not ready for review :warning::warning:
