### PR TITLE
SONARHTML-465 Ignore PascalCase Vue Table components

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
@@ -109,6 +109,10 @@ public class Helpers {
     return code.inputFile().filename().endsWith(".cshtml");
   }
 
+  public static boolean isVueFile(HtmlSourceCode code) {
+    return code.inputFile().filename().endsWith(".vue");
+  }
+
   /**
    * Returns true if any ancestor of {@code node} satisfies {@code predicate}.
    *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheck.java
@@ -33,6 +33,8 @@ import org.sonar.plugins.html.node.TextNode;
 @Rule(key = "S5256")
 public class TableWithoutHeaderCheck extends AbstractPageCheck {
 
+  private static final String TABLE_TAG = "TABLE";
+
   private final Set<TagNode> tablesWithRazorFragmentRendering = new HashSet<>();
   private boolean isVueFile;
 
@@ -88,7 +90,7 @@ public class TableWithoutHeaderCheck extends AbstractPageCheck {
 
   private static boolean isStructuralTableContext(TagNode node) {
     String name = node.getNodeName();
-    return "TABLE".equalsIgnoreCase(name)
+    return TABLE_TAG.equalsIgnoreCase(name)
       || "THEAD".equalsIgnoreCase(name)
       || "TBODY".equalsIgnoreCase(name)
       || "TFOOT".equalsIgnoreCase(name)
@@ -96,11 +98,11 @@ public class TableWithoutHeaderCheck extends AbstractPageCheck {
   }
 
   private boolean isTable(TagNode node) {
-    return isVueFile ? "table".equals(node.getNodeName()) : "TABLE".equalsIgnoreCase(node.getNodeName());
+    return isVueFile ? "table".equals(node.getNodeName()) : TABLE_TAG.equalsIgnoreCase(node.getNodeName());
   }
 
   private static boolean isTableScope(TagNode node) {
-    return "TABLE".equalsIgnoreCase(node.getNodeName());
+    return TABLE_TAG.equalsIgnoreCase(node.getNodeName());
   }
 
   private static boolean isLayout(TagNode node) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheck.java
@@ -34,10 +34,12 @@ import org.sonar.plugins.html.node.TextNode;
 public class TableWithoutHeaderCheck extends AbstractPageCheck {
 
   private final Set<TagNode> tablesWithRazorFragmentRendering = new HashSet<>();
+  private boolean isVueFile;
 
   @Override
   public void startDocument(List<Node> nodes) {
     tablesWithRazorFragmentRendering.clear();
+    isVueFile = getHtmlSourceCode().inputFile().filename().endsWith(".vue");
     if (!Helpers.isRazorFile(getHtmlSourceCode())) {
       return;
     }
@@ -93,8 +95,8 @@ public class TableWithoutHeaderCheck extends AbstractPageCheck {
       || "TR".equalsIgnoreCase(name);
   }
 
-  private static boolean isTable(TagNode node) {
-    return "TABLE".equalsIgnoreCase(node.getNodeName());
+  private boolean isTable(TagNode node) {
+    return isVueFile ? "table".equals(node.getNodeName()) : "TABLE".equalsIgnoreCase(node.getNodeName());
   }
 
   private static boolean isLayout(TagNode node) {
@@ -107,9 +109,9 @@ public class TableWithoutHeaderCheck extends AbstractPageCheck {
     return "TRUE".equalsIgnoreCase(ariaHidden);
   }
 
-  private static boolean hasHeader(TagNode node) {
+  private boolean hasHeader(TagNode node) {
     return node.getChildren().stream().anyMatch(TableWithoutHeaderCheck::isTableHeader) ||
-      node.getChildren().stream().filter(child -> !isTable(child)).anyMatch(TableWithoutHeaderCheck::hasHeader);
+      node.getChildren().stream().filter(child -> !isTable(child)).anyMatch(this::hasHeader);
   }
 
   private static boolean isTableHeader(TagNode node) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheck.java
@@ -39,7 +39,7 @@ public class TableWithoutHeaderCheck extends AbstractPageCheck {
   @Override
   public void startDocument(List<Node> nodes) {
     tablesWithRazorFragmentRendering.clear();
-    isVueFile = getHtmlSourceCode().inputFile().filename().endsWith(".vue");
+    isVueFile = Helpers.isVueFile(getHtmlSourceCode());
     if (!Helpers.isRazorFile(getHtmlSourceCode())) {
       return;
     }
@@ -99,6 +99,10 @@ public class TableWithoutHeaderCheck extends AbstractPageCheck {
     return isVueFile ? "table".equals(node.getNodeName()) : "TABLE".equalsIgnoreCase(node.getNodeName());
   }
 
+  private static boolean isTableScope(TagNode node) {
+    return "TABLE".equalsIgnoreCase(node.getNodeName());
+  }
+
   private static boolean isLayout(TagNode node) {
     String role = node.getAttribute("role");
     return "PRESENTATION".equalsIgnoreCase(role) || "NONE".equalsIgnoreCase(role);
@@ -109,9 +113,9 @@ public class TableWithoutHeaderCheck extends AbstractPageCheck {
     return "TRUE".equalsIgnoreCase(ariaHidden);
   }
 
-  private boolean hasHeader(TagNode node) {
+  private static boolean hasHeader(TagNode node) {
     return node.getChildren().stream().anyMatch(TableWithoutHeaderCheck::isTableHeader) ||
-      node.getChildren().stream().filter(child -> !isTable(child)).anyMatch(this::hasHeader);
+      node.getChildren().stream().filter(child -> !isTableScope(child)).anyMatch(TableWithoutHeaderCheck::hasHeader);
   }
 
   private static boolean isTableHeader(TagNode node) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/UnsupportedTagsInHtml5Check.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/UnsupportedTagsInHtml5Check.java
@@ -19,6 +19,7 @@ package org.sonar.plugins.html.checks.sonar;
 import java.util.Locale;
 import java.util.Set;
 import org.sonar.check.Rule;
+import org.sonar.plugins.html.api.Helpers;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
 import org.sonar.plugins.html.node.TagNode;
 
@@ -56,8 +57,7 @@ public class UnsupportedTagsInHtml5Check extends AbstractPageCheck {
 
   @Override
   public void startDocument(java.util.List<org.sonar.plugins.html.node.Node> nodes) {
-    String filename = getHtmlSourceCode().inputFile().filename();
-    isVueFile = filename.endsWith(".vue");
+    isVueFile = Helpers.isVueFile(getHtmlSourceCode());
   }
 
   @Override

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/HelpersTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/HelpersTest.java
@@ -80,6 +80,12 @@ class HelpersTest {
   }
 
   @Test
+  void is_vue_file_recognizes_vue_suffix() {
+    assertThat(Helpers.isVueFile(sourceCode("component.vue"))).isTrue();
+    assertThat(Helpers.isVueFile(sourceCode("component.html"))).isFalse();
+  }
+
+  @Test
   void is_server_side_file_recognizes_template_suffixes() {
     assertThat(Helpers.isServerSideFile(sourceCode("page.jsp"))).isTrue();
     assertThat(Helpers.isServerSideFile(sourceCode("page.jspf"))).isTrue();

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheckTest.java
@@ -47,6 +47,27 @@ class TableWithoutHeaderCheckTest {
   }
 
   @Test
+  void vue_pascal_case_table_component_is_ignored() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/TableWithoutHeaderCheck/vue-components.vue"),
+      new TableWithoutHeaderCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(8).withMessage("Add \"<th>\" headers to this \"<table>\".");
+  }
+
+  @Test
+  void table_tag_remains_case_insensitive_outside_vue() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/TableWithoutHeaderCheck/mixed-case.html"),
+      new TableWithoutHeaderCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(1).withMessage("Add \"<th>\" headers to this \"<table>\".")
+      .next().atLine(2).withMessage("Add \"<th>\" headers to this \"<table>\".");
+  }
+
+  @Test
   void razor_layout_fragment_rendering_is_compliant() {
     HtmlSourceCode sourceCode = TestHelper.scan(
       new File("src/test/resources/checks/TableWithoutHeaderCheck/razor.cshtml"),

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheckTest.java
@@ -53,7 +53,8 @@ class TableWithoutHeaderCheckTest {
       new TableWithoutHeaderCheck());
 
     checkMessagesVerifier.verify(sourceCode.getIssues())
-      .next().atLine(8).withMessage("Add \"<th>\" headers to this \"<table>\".");
+      .next().atLine(8).withMessage("Add \"<th>\" headers to this \"<table>\".")
+      .next().atLine(13).withMessage("Add \"<th>\" headers to this \"<table>\".");
   }
 
   @Test

--- a/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/mixed-case.html
+++ b/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/mixed-case.html
@@ -1,0 +1,2 @@
+<TABLE></TABLE>
+<TaBlE></TaBlE>

--- a/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/vue-components.vue
+++ b/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/vue-components.vue
@@ -8,4 +8,11 @@
   <table>
     <CustomTableHeader />
   </table>
+
+  <!-- Headers inside a nested table component do not belong to the native table. -->
+  <table>
+    <Table>
+      <tr><th>Name</th></tr>
+    </Table>
+  </table>
 </template>

--- a/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/vue-components.vue
+++ b/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/vue-components.vue
@@ -1,0 +1,11 @@
+<template>
+  <Table>
+    <CustomTableHeader />
+    <TableRow />
+  </Table>
+
+  <!-- A native table without a literal header remains noncompliant. -->
+  <table>
+    <CustomTableHeader />
+  </table>
+</template>


### PR DESCRIPTION
Part of SONARHTML-465

## Summary
- Treat only exact lowercase `<table>` tags as native tables in Vue files.
- Ignore PascalCase `<Table>` component references while preserving non-Vue case-insensitive behavior.
- Keep nested table-component headers scoped away from enclosing native tables.
- Centralize Vue file detection and add focused regression fixtures.

## Testing
- `mvn -pl sonar-html-plugin -Dtest=TableWithoutHeaderCheckTest,UnsupportedTagsInHtml5CheckTest,HelpersTest test` (29 tests)
- `mvn -pl sonar-html-plugin test` (688 tests)