### PR TITLE
SONARHTML-466 Update minimum JDK version from 17 to 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <mockito.version>5.23.0</mockito.version>
 
     <artifactsToPublish>${project.groupId}:sonar-html-plugin:jar</artifactsToPublish>
-    <jdk.min.version>17</jdk.min.version>
+    <jdk.min.version>21</jdk.min.version>
   </properties>
 
   <dependencyManagement>

--- a/sonar-html-plugin/pom.xml
+++ b/sonar-html-plugin/pom.xml
@@ -156,8 +156,8 @@
           <pluginKey>web</pluginKey>
           <jreMinVersion>${jdk.min.version}</jreMinVersion>
           <!-- this value is translated to Sonar-Version property in META-INF/MANIFEST.MF file inside jar. It is used at runtime
-          by products to detect compatibility. We keep LTS -->
-          <pluginApiMinVersion>9.9</pluginApiMinVersion>
+          by products to detect compatibility. Must stay >= the first LTA that runs on Java ${jdk.min.version}. -->
+          <pluginApiMinVersion>2025.1</pluginApiMinVersion>
           <requiredForLanguages>web,jsp,js,php</requiredForLanguages>
         </configuration>
       </plugin>

--- a/sonar-html-plugin/pom.xml
+++ b/sonar-html-plugin/pom.xml
@@ -156,8 +156,9 @@
           <pluginKey>web</pluginKey>
           <jreMinVersion>${jdk.min.version}</jreMinVersion>
           <!-- this value is translated to Sonar-Version property in META-INF/MANIFEST.MF file inside jar. It is used at runtime
-          by products to detect compatibility. Must stay >= the first LTA that runs on Java ${jdk.min.version}. -->
-          <pluginApiMinVersion>2025.1</pluginApiMinVersion>
+          by products to detect compatibility. This is a Sonar Plugin API version (not a SonarQube Server calendar
+          version) - 11.1 is the Plugin API shipped with SonarQube Server 2025.1, the first LTA that runs on Java ${jdk.min.version}. -->
+          <pluginApiMinVersion>11.1</pluginApiMinVersion>
           <requiredForLanguages>web,jsp,js,php</requiredForLanguages>
         </configuration>
       </plugin>


### PR DESCRIPTION
Part of CLP-278

----
## Summary by Gitar

- **Build configuration:**
    - Updated `jdk.min.version` from `17` to `21` in `pom.xml`
    - Raised `pluginApiMinVersion` to `2025.1` to support the JDK 21 requirement

<sub>This will update automatically on new commits.</sub>