### PR TITLE
SONARHTML-472 Handle plain C# conditionals in Razor code blocks

### DIFF
--- a/its/ruling/src/test/resources/expected/Web-S9379.json
+++ b/its/ruling/src/test/resources/expected/Web-S9379.json
@@ -1,0 +1,47 @@
+{
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/autofill-popup-location.html": [
+18
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/dashboards/_create_form.html.erb": [
+19
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/dashboards/_edit_form.html.erb": [
+18
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/issue/_comment_form.html.erb": [
+7
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/issue/_edit_comment_form.html.erb": [
+6
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/issue/_issue.html.erb": [
+66
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/issue/_severity_form.html.erb": [
+7
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/issue/_show_modal.html.erb": [
+5
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/issues/_shared_form.html.erb": [
+5
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/measures/_copy_form.html.erb": [
+13
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/measures/_edit_form.html.erb": [
+13
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/measures/_save_as_form.html.erb": [
+15
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/profiles/_copy_form.html.erb": [
+17
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/profiles/_create_form.html.erb": [
+17
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/profiles/_rename_form.html.erb": [
+16
+]
+}

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/HtmlConstants.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/HtmlConstants.java
@@ -47,6 +47,15 @@ public class HtmlConstants {
    * output is HTML.
    */
   public static final List<String> OTHER_FILE_SUFFIXES = List.of("php", "php3", "php4", "php5", "phtml", "inc", "vue");
+
+  /**
+   * Void elements can't have any content.
+   * See https://html.spec.whatwg.org/multipage/syntax.html#void-elements
+   */
+  public static final Set<String> VOID_ELEMENTS = Set.of(
+    "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source", "track", "wbr"
+  );
+
   public static final List<String> KNOWN_HTML_TAGS = List.of(
     "a",
     "acronym", // deprecated

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/HtmlConstants.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/HtmlConstants.java
@@ -26,6 +26,12 @@ import org.sonar.plugins.html.node.TagNode;
 
 public class HtmlConstants {
 
+  private static final String EMBED_TAG = "embed";
+  private static final String INPUT_TAG = "input";
+  private static final String PARAM_TAG = "param";
+  private static final String SOURCE_TAG = "source";
+  private static final String TRACK_TAG = "track";
+
   /** The language key. */
   public static final String LANGUAGE_KEY = "web";
   public static final String LANGUAGE_NAME = "HTML";
@@ -53,7 +59,7 @@ public class HtmlConstants {
    * See https://html.spec.whatwg.org/multipage/syntax.html#void-elements
    */
   public static final Set<String> VOID_ELEMENTS = Set.of(
-    "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source", "track", "wbr"
+    "area", "base", "br", "col", EMBED_TAG, "hr", "img", INPUT_TAG, "link", "meta", PARAM_TAG, SOURCE_TAG, TRACK_TAG, "wbr"
   );
 
   public static final List<String> KNOWN_HTML_TAGS = List.of(
@@ -96,7 +102,7 @@ public class HtmlConstants {
     "dl",
     "dt",
     "em",
-    "embed",
+    EMBED_TAG,
     "fieldset",
     "figcaption",
     "figure",
@@ -120,7 +126,7 @@ public class HtmlConstants {
     "iframe",
     "image", // deprecated
     "img",
-    "input",
+    INPUT_TAG,
     "ins",
     "kbd",
     "keygen", // deprecated
@@ -147,7 +153,7 @@ public class HtmlConstants {
     "option",
     "output",
     "p",
-    "param", // deprecated
+    PARAM_TAG, // deprecated
     "picture",
     "plaintext", // deprecated
     "pre",
@@ -166,7 +172,7 @@ public class HtmlConstants {
     "select",
     "shadow", // deprecated
     "small",
-    "source",
+    SOURCE_TAG,
     "spacer", // deprecated
     "span",
     "strike", // deprecated
@@ -187,7 +193,7 @@ public class HtmlConstants {
     "time",
     "title",
     "tr",
-    "track",
+    TRACK_TAG,
     "tt", // deprecated
     "u",
     "ul",
@@ -198,7 +204,7 @@ public class HtmlConstants {
   );
 
   // computed from https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/src/util/isInteractiveElement.js
-  public static final Set<String> INTERACTIVE_ELEMENTS = Set.of("a", "audio", "button", "canvas", "datalist", "embed", "input", "menuitem", "option", "select", "summary",
+  public static final Set<String> INTERACTIVE_ELEMENTS = Set.of("a", "audio", "button", "canvas", "datalist", EMBED_TAG, INPUT_TAG, "menuitem", "option", "select", "summary",
     "td", "textarea", "th", "tr", "video");
 
   // computed from https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/src/util/isNonInteractiveElement.js
@@ -232,7 +238,7 @@ public class HtmlConstants {
 
   // computed from https://github.com/A11yance/aria-query/blob/main/src/domMap.js
   public static final Set<String> RESERVED_NODE_SET = Set.of(
-    "base", "col", "colgroup", "head", "html", "link", "meta", "noembed", "noscript", "param", "picture", "script", "source", "style", "title", "track"
+    "base", "col", "colgroup", "head", "html", "link", "meta", "noembed", "noscript", PARAM_TAG, "picture", "script", SOURCE_TAG, "style", "title", TRACK_TAG
   );
 
   public static boolean isInteractiveElement(TagNode element) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -49,7 +49,6 @@ public final class TemplateConditionalScopeTracker {
   private static final Pattern CSHARP_BLOCK_START_PATTERN = Pattern.compile("(if|switch)\\s*\\(", Pattern.CASE_INSENSITIVE);
   private static final Pattern CSHARP_GENERIC_ARGUMENT_PATTERN = Pattern.compile("<\\s*[\\p{L}_][\\p{L}\\p{N}_.,:?\\[\\]\\s<>]*>");
   private static final int CSHARP_RAW_STRING_MIN_QUOTE_COUNT = 3;
-  private static final int CSHARP_EMPTY_RAW_STRING_QUOTE_COUNT = 6;
   // Angular block control flow branches: @case (value) { and @default { inside an @switch
   private static final Pattern ANGULAR_BRANCH_START_PATTERN = Pattern.compile("@(case|default)\\s*[({]", Pattern.CASE_INSENSITIVE);
   private static final Pattern PHP_DIRECTIVE_CONDITIONAL_START_PATTERN = Pattern.compile("(if|foreach|for)\\b", Pattern.CASE_INSENSITIVE);
@@ -529,11 +528,14 @@ public final class TemplateConditionalScopeTracker {
   }
 
   private static boolean isCompleteEmptyRawString(String text, int index, int quoteCount) {
-    if (quoteCount != CSHARP_EMPTY_RAW_STRING_QUOTE_COUNT) {
+    if (quoteCount < 2 * CSHARP_RAW_STRING_MIN_QUOTE_COUNT || quoteCount % 2 != 0) {
       return false;
     }
-    int nextTokenIndex = skipWhitespace(text, index + quoteCount);
-    return nextTokenIndex < text.length() && ";,)]}+-*/%&|^!=<>?:".indexOf(text.charAt(nextTokenIndex)) >= 0;
+    int nextIndex = index + quoteCount;
+    while (nextIndex < text.length() && isHorizontalWhitespace(text.charAt(nextIndex))) {
+      nextIndex++;
+    }
+    return nextIndex >= text.length() || !isLineBreak(text.charAt(nextIndex));
   }
 
   private static boolean hasVerbatimPrefix(String text, int quoteIndex) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -59,6 +59,7 @@ public final class TemplateConditionalScopeTracker {
   private int textConditionalDepth;
   private int braceBasedTextConditionalDepth;
   private int pendingConditionalBranchOpenings;
+  private boolean pendingConditionalBranchRazorBrace;
   private boolean awaitingConditionalHeaderParenthesis;
   private int pendingConditionalHeaderParenthesisDepth;
   private int nestedTextBlockDepth;
@@ -68,6 +69,7 @@ public final class TemplateConditionalScopeTracker {
   private int styleDepth;
   private int razorCodeBraceDepth;
   private int pendingRenderedClosingBraceDepth;
+  private boolean pendingRenderedRazorCodeBlockClosing;
   private final Deque<TagNode> openElements = new ArrayDeque<>();
   private final Deque<Integer> markupBraceDepths = new ArrayDeque<>();
   private final Deque<ConditionalBrace> conditionalBraces = new ArrayDeque<>();
@@ -76,15 +78,7 @@ public final class TemplateConditionalScopeTracker {
   private boolean inRazorExplicitText;
   private boolean inCSharpLineComment;
   private boolean inCSharpBlockComment;
-  private boolean escapedCSharpStringCharacter;
-  private boolean verbatimCSharpString;
-  private boolean interpolatedCSharpString;
-  private int csharpInterpolationBraceDepth;
-  private char csharpInterpolationStringDelimiter;
-  private boolean escapedCSharpInterpolationStringCharacter;
-  private boolean verbatimCSharpInterpolationString;
-  private int csharpRawStringQuoteCount;
-  private char csharpStringDelimiter;
+  private final Deque<CSharpStringContext> csharpStringContexts = new ArrayDeque<>();
   private char csharpGenericTypeOwnerInitial;
   private boolean razorCodeEnabled;
 
@@ -96,6 +90,7 @@ public final class TemplateConditionalScopeTracker {
     textConditionalDepth = 0;
     braceBasedTextConditionalDepth = 0;
     pendingConditionalBranchOpenings = 0;
+    pendingConditionalBranchRazorBrace = false;
     awaitingConditionalHeaderParenthesis = false;
     pendingConditionalHeaderParenthesisDepth = 0;
     nestedTextBlockDepth = 0;
@@ -105,6 +100,7 @@ public final class TemplateConditionalScopeTracker {
     styleDepth = 0;
     razorCodeBraceDepth = 0;
     pendingRenderedClosingBraceDepth = -1;
+    pendingRenderedRazorCodeBlockClosing = false;
     openElements.clear();
     markupBraceDepths.clear();
     conditionalBraces.clear();
@@ -258,7 +254,7 @@ public final class TemplateConditionalScopeTracker {
    * by checks that reason about rendered elements.
    */
   public boolean isInNonRenderedRazorContent() {
-    return inRazorComment || inCSharpLineComment || inCSharpBlockComment || csharpStringDelimiter != '\0';
+    return inRazorComment || inCSharpLineComment || inCSharpBlockComment || !csharpStringContexts.isEmpty();
   }
 
   private boolean hasOpenConditionalScope() {
@@ -314,7 +310,7 @@ public final class TemplateConditionalScopeTracker {
       state.index++;
       return true;
     }
-    if (razorCodeEnabled && !isInPersistentRazorComment() && csharpStringDelimiter == '\0'
+    if (razorCodeEnabled && !isInPersistentRazorComment() && csharpStringContexts.isEmpty()
       && isInRazorCodeContext() && startsWith(text, state.index, "@:")) {
       inRazorExplicitText = true;
       state.index += 2;
@@ -340,7 +336,7 @@ public final class TemplateConditionalScopeTracker {
       consumeCSharpBlockCommentCharacter(text, state);
       return true;
     }
-    if (csharpStringDelimiter != '\0') {
+    if (!csharpStringContexts.isEmpty()) {
       consumeCSharpStringCharacter(text, state);
       return true;
     }
@@ -373,94 +369,97 @@ public final class TemplateConditionalScopeTracker {
   }
 
   private void consumeCSharpStringCharacter(String text, FragmentScanState state) {
-    if (csharpRawStringQuoteCount > 0) {
-      consumeCSharpRawStringCharacter(text, state);
+    CSharpStringContext context = csharpStringContexts.peek();
+    if (context.rawQuoteCount > 0) {
+      consumeCSharpRawStringCharacter(text, state, context);
       return;
     }
-    if (csharpInterpolationBraceDepth > 0) {
-      consumeCSharpInterpolationCharacter(text, state);
+    if (context.interpolationBraceDepth > 0) {
+      consumeCSharpInterpolationCharacter(text, state, context);
       return;
     }
     char current = text.charAt(state.index);
-    if (interpolatedCSharpString && current == '{') {
+    if (context.interpolated && current == '{') {
       if (startsWith(text, state.index, "{{")) {
         state.index += 2;
       } else {
-        csharpInterpolationBraceDepth++;
+        context.interpolationBraceDepth++;
         state.index++;
       }
       return;
     }
-    if (isEscapedVerbatimQuote(text, state, current)) {
-      state.index += 2;
-      return;
-    }
-    updateCSharpStringState(current);
-    state.index++;
+    consumeCSharpStringContent(text, state, context, current);
   }
 
-  private void consumeCSharpInterpolationCharacter(String text, FragmentScanState state) {
+  private void consumeCSharpInterpolationCharacter(String text, FragmentScanState state, CSharpStringContext context) {
     char current = text.charAt(state.index);
-    if (csharpInterpolationStringDelimiter != '\0') {
-      consumeCSharpInterpolationStringCharacter(text, state, current);
-    } else if (current == '\'' || current == '"') {
-      csharpInterpolationStringDelimiter = current;
-      escapedCSharpInterpolationStringCharacter = false;
-      verbatimCSharpInterpolationString = current == '"' && hasVerbatimPrefix(text, state.index);
-      state.index++;
+    if (current == '\'' || current == '"') {
+      consumeCSharpStringStart(text, state, context);
     } else {
       if (current == '{') {
-        csharpInterpolationBraceDepth++;
+        context.interpolationBraceDepth++;
       } else if (current == '}') {
-        csharpInterpolationBraceDepth--;
+        context.interpolationBraceDepth--;
       }
       state.index++;
     }
   }
 
-  private void consumeCSharpInterpolationStringCharacter(String text, FragmentScanState state, char current) {
-    if (verbatimCSharpInterpolationString && current == csharpInterpolationStringDelimiter
-      && state.index + 1 < text.length() && text.charAt(state.index + 1) == csharpInterpolationStringDelimiter) {
-      state.index += 2;
+  private void consumeCSharpStringContent(String text, FragmentScanState state, CSharpStringContext context, char current) {
+    int quoteCount = current == '"' ? consecutiveQuoteCount(text, state.index) : 0;
+    if (context.verbatim && quoteCount >= 2 * context.delimiterWidth) {
+      state.index += 2 * context.delimiterWidth;
       return;
     }
-    if (escapedCSharpInterpolationStringCharacter) {
-      escapedCSharpInterpolationStringCharacter = false;
-    } else if (!verbatimCSharpInterpolationString && current == '\\') {
-      escapedCSharpInterpolationStringCharacter = true;
-    } else if (current == csharpInterpolationStringDelimiter) {
-      csharpInterpolationStringDelimiter = '\0';
-      verbatimCSharpInterpolationString = false;
+    if (context.escaped) {
+      context.escaped = false;
+    } else if (!context.verbatim && current == '\\') {
+      context.escaped = true;
+    } else if (current == context.delimiter && (current != '"' || quoteCount >= context.delimiterWidth)) {
+      csharpStringContexts.pop();
+      state.index += context.delimiterWidth;
+      return;
     }
     state.index++;
   }
 
-  private void consumeCSharpRawStringCharacter(String text, FragmentScanState state) {
+  private void consumeCSharpRawStringCharacter(String text, FragmentScanState state, CSharpStringContext context) {
     int quoteCount = consecutiveQuoteCount(text, state.index);
-    if (quoteCount >= csharpRawStringQuoteCount) {
+    if (quoteCount >= context.rawQuoteCount) {
       state.index += quoteCount;
-      csharpRawStringQuoteCount = 0;
-      csharpStringDelimiter = '\0';
+      csharpStringContexts.pop();
     } else {
       state.index += Math.max(quoteCount, 1);
     }
   }
 
-  private boolean isEscapedVerbatimQuote(String text, FragmentScanState state, char current) {
-    return verbatimCSharpString && current == csharpStringDelimiter
-      && state.index + 1 < text.length() && text.charAt(state.index + 1) == csharpStringDelimiter;
+  private boolean consumeCSharpStringStart(String text, FragmentScanState state,
+    @Nullable CSharpStringContext enclosingContext) {
+    char current = text.charAt(state.index);
+    if (current != '\'' && current != '"') {
+      return false;
+    }
+    int quoteCount = consecutiveQuoteCount(text, state.index);
+    int delimiterWidth = nestedCSharpStringDelimiterWidth(text, state.index, enclosingContext, current);
+    if (delimiterWidth == 1 && isCompleteEmptyRawString(text, state.index, quoteCount)) {
+      state.index += quoteCount;
+      return true;
+    }
+    int rawQuoteCount = delimiterWidth == 1 && quoteCount >= CSHARP_RAW_STRING_MIN_QUOTE_COUNT ? quoteCount : 0;
+    boolean verbatim = rawQuoteCount == 0 && current == '"' && hasVerbatimPrefix(text, state.index);
+    boolean interpolated = rawQuoteCount == 0 && current == '"' && hasInterpolatedPrefix(text, state.index);
+    csharpStringContexts.push(new CSharpStringContext(current, delimiterWidth, rawQuoteCount, verbatim, interpolated));
+    state.index += rawQuoteCount > 0 ? rawQuoteCount : delimiterWidth;
+    return true;
   }
 
-  private void updateCSharpStringState(char current) {
-    if (escapedCSharpStringCharacter) {
-      escapedCSharpStringCharacter = false;
-    } else if (!verbatimCSharpString && current == '\\') {
-      escapedCSharpStringCharacter = true;
-    } else if (current == csharpStringDelimiter) {
-      csharpStringDelimiter = '\0';
-      verbatimCSharpString = false;
-      interpolatedCSharpString = false;
+  private static int nestedCSharpStringDelimiterWidth(String text, int quoteIndex,
+    @Nullable CSharpStringContext enclosingContext, char delimiter) {
+    if (enclosingContext == null || !enclosingContext.verbatim || delimiter != '"'
+      || !startsWith(text, quoteIndex, "\"\"") || text.indexOf("\"\"", quoteIndex + 2) < 0) {
+      return 1;
     }
+    return 2;
   }
 
   /**
@@ -489,31 +488,7 @@ public final class TemplateConditionalScopeTracker {
       state.index += 2;
       return true;
     }
-    char current = text.charAt(state.index);
-    int quoteCount = consecutiveQuoteCount(text, state.index);
-    if (isCompleteEmptyRawString(text, state.index, quoteCount)) {
-      state.index += quoteCount;
-      return true;
-    }
-    if (quoteCount >= CSHARP_RAW_STRING_MIN_QUOTE_COUNT) {
-      csharpStringDelimiter = '"';
-      csharpRawStringQuoteCount = quoteCount;
-      escapedCSharpStringCharacter = false;
-      verbatimCSharpString = false;
-      interpolatedCSharpString = false;
-      state.index += quoteCount;
-      return true;
-    }
-    if (current == '\'' || current == '"') {
-      csharpStringDelimiter = current;
-      csharpRawStringQuoteCount = 0;
-      escapedCSharpStringCharacter = false;
-      verbatimCSharpString = current == '"' && hasVerbatimPrefix(text, state.index);
-      interpolatedCSharpString = current == '"' && hasInterpolatedPrefix(text, state.index);
-      state.index++;
-      return true;
-    }
-    return false;
+    return consumeCSharpStringStart(text, state, null);
   }
 
   private boolean consumeRazorCodeBlockStart(String text, FragmentScanState state) {
@@ -851,8 +826,13 @@ public final class TemplateConditionalScopeTracker {
       pendingConditionalBranchOpenings--;
       clearConditionalHeaderTracking();
       if (!razorCodeBlocks.isEmpty()) {
-        conditionalBraces.push(new ConditionalBrace(currentElementDepth(), inRazorCodeContext));
+        boolean razorBraceTracked = inRazorCodeContext || pendingConditionalBranchRazorBrace;
+        conditionalBraces.push(new ConditionalBrace(currentElementDepth(), razorBraceTracked));
+        if (pendingConditionalBranchRazorBrace && !inRazorCodeContext) {
+          razorCodeBraceDepth++;
+        }
       }
+      pendingConditionalBranchRazorBrace = false;
     } else if (!razorCodeBlocks.isEmpty() && !inRazorCodeContext) {
       markupBraceDepths.push(currentElementDepth());
     } else if (braceBasedTextConditionalDepth > 0) {
@@ -896,17 +876,56 @@ public final class TemplateConditionalScopeTracker {
     if (razorCodeBlocks.isEmpty() || inRazorCodeContext) {
       return false;
     }
+    if (pendingRenderedRazorCodeBlockClosing && braceBasedTextConditionalDepth == 0
+      && skipLeadingTrivia(text, state.index + 1) >= text.length()) {
+      pendingRenderedRazorCodeBlockClosing = false;
+      closeTrackedRazorCodeBrace();
+      state.index++;
+      return true;
+    }
     int elementDepth = currentElementDepth();
     if (!markupBraceDepths.isEmpty() && markupBraceDepths.peek() == elementDepth) {
       markupBraceDepths.pop();
+      state.index++;
     } else if (!conditionalBraces.isEmpty() && conditionalBraces.peek().elementDepth() == elementDepth) {
-      conditionalBraces.pop();
+      if (continueRenderedConditionalBranch(text, state)) {
+        return true;
+      }
+      closeRenderedConditionalBrace();
       return false;
-    } else if (!conditionalBraces.isEmpty() && conditionalBraces.peek().elementDepth() < elementDepth
-      && skipLeadingTrivia(text, state.index + 1) >= text.length()) {
-      pendingRenderedClosingBraceDepth = elementDepth;
+    } else if (!conditionalBraces.isEmpty() && conditionalBraces.peek().elementDepth() < elementDepth) {
+      if (!continueRenderedConditionalBranch(text, state)) {
+        if (skipLeadingTrivia(text, state.index + 1) >= text.length()) {
+          pendingRenderedClosingBraceDepth = elementDepth;
+        }
+        state.index++;
+      }
+    } else {
+      state.index++;
     }
-    state.index++;
+    return true;
+  }
+
+  private void closeRenderedConditionalBrace() {
+    ConditionalBrace conditionalBrace = conditionalBraces.pop();
+    if (conditionalBrace.razorBraceTracked()) {
+      razorCodeBraceDepth--;
+      pendingRenderedRazorCodeBlockClosing = true;
+    }
+  }
+
+  private boolean continueRenderedConditionalBranch(String text, FragmentScanState state) {
+    int continuationIndex = conditionalContinuationEndIndex(text, state.index);
+    if (continuationIndex < 0) {
+      return false;
+    }
+    ConditionalBrace conditionalBrace = conditionalBraces.pop();
+    if (conditionalBrace.razorBraceTracked()) {
+      razorCodeBraceDepth--;
+      pendingConditionalBranchRazorBrace = true;
+    }
+    pendingConditionalBranchOpenings++;
+    state.index = continuationIndex;
     return true;
   }
 
@@ -914,6 +933,10 @@ public final class TemplateConditionalScopeTracker {
     if (!isInRazorCodeContext()) {
       return;
     }
+    closeTrackedRazorCodeBrace();
+  }
+
+  private void closeTrackedRazorCodeBrace() {
     razorCodeBraceDepth--;
     if (razorCodeBraceDepth < razorCodeBlocks.peek().openingBraceDepth()) {
       razorCodeBlocks.pop();
@@ -922,6 +945,7 @@ public final class TemplateConditionalScopeTracker {
       markupBraceDepths.clear();
       conditionalBraces.clear();
       pendingRenderedClosingBraceDepth = -1;
+      pendingRenderedRazorCodeBlockClosing = false;
       razorCodeBraceDepth = 0;
       inRazorExplicitText = false;
       resetCSharpProtectedState();
@@ -931,15 +955,7 @@ public final class TemplateConditionalScopeTracker {
   private void resetCSharpProtectedState() {
     inCSharpLineComment = false;
     inCSharpBlockComment = false;
-    escapedCSharpStringCharacter = false;
-    verbatimCSharpString = false;
-    interpolatedCSharpString = false;
-    csharpInterpolationBraceDepth = 0;
-    csharpInterpolationStringDelimiter = '\0';
-    escapedCSharpInterpolationStringCharacter = false;
-    verbatimCSharpInterpolationString = false;
-    csharpRawStringQuoteCount = 0;
-    csharpStringDelimiter = '\0';
+    csharpStringContexts.clear();
   }
 
   /**
@@ -1083,6 +1099,7 @@ public final class TemplateConditionalScopeTracker {
   private void clearBraceTracking() {
     braceBasedTextConditionalDepth = 0;
     pendingConditionalBranchOpenings = 0;
+    pendingConditionalBranchRazorBrace = false;
     clearConditionalHeaderTracking();
     nestedTextBlockDepth = 0;
     conditionalBraces.clear();
@@ -1398,6 +1415,26 @@ public final class TemplateConditionalScopeTracker {
 
     private FragmentScanState(int index) {
       this.index = index;
+    }
+  }
+
+  private static final class CSharpStringContext {
+
+    private final char delimiter;
+    private final int delimiterWidth;
+    private final int rawQuoteCount;
+    private final boolean verbatim;
+    private final boolean interpolated;
+    private boolean escaped;
+    private int interpolationBraceDepth;
+
+    private CSharpStringContext(char delimiter, int delimiterWidth, int rawQuoteCount,
+      boolean verbatim, boolean interpolated) {
+      this.delimiter = delimiter;
+      this.delimiterWidth = delimiterWidth;
+      this.rawQuoteCount = rawQuoteCount;
+      this.verbatim = verbatim;
+      this.interpolated = interpolated;
     }
   }
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -44,6 +44,10 @@ public final class TemplateConditionalScopeTracker {
     "*ngIf", "*ngFor", "*ngSwitchCase", "*ngSwitchDefault"
   );
 
+  private static final Set<String> VOID_ELEMENTS = Set.of(
+    "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source", "track", "wbr"
+  );
+
   private static final Pattern RAZOR_BLOCK_START_PATTERN = Pattern.compile("@(if|switch)\\s*\\(", Pattern.CASE_INSENSITIVE);
   private static final Pattern CSHARP_BLOCK_START_PATTERN = Pattern.compile("(if|switch)\\s*\\(", Pattern.CASE_INSENSITIVE);
   // Angular block control flow branches: @case (value) { and @default { inside an @switch
@@ -71,6 +75,7 @@ public final class TemplateConditionalScopeTracker {
   private boolean inCSharpBlockComment;
   private boolean escapedCSharpStringCharacter;
   private boolean verbatimCSharpString;
+  private boolean trailingCSharpVerbatimPrefix;
   private char csharpStringDelimiter;
   private boolean razorCodeEnabled = true;
 
@@ -93,11 +98,7 @@ public final class TemplateConditionalScopeTracker {
     razorCodeBraceDepth = 0;
     razorCodeBlocks.clear();
     inRazorComment = false;
-    inCSharpLineComment = false;
-    inCSharpBlockComment = false;
-    escapedCSharpStringCharacter = false;
-    verbatimCSharpString = false;
-    csharpStringDelimiter = '\0';
+    resetCSharpProtectedState();
     this.razorCodeEnabled = razorCodeEnabled;
   }
 
@@ -111,6 +112,7 @@ public final class TemplateConditionalScopeTracker {
   }
 
   public void startElement(TagNode node) {
+    trailingCSharpVerbatimPrefix = false;
     if (isInNonRenderedRazorContent()) {
       return;
     }
@@ -123,10 +125,13 @@ public final class TemplateConditionalScopeTracker {
     } else if (isStyleTag(node)) {
       styleDepth++;
     }
-    elementDepth++;
+    if (tracksElementDepth(node)) {
+      elementDepth++;
+    }
   }
 
   public void endElement(TagNode node) {
+    trailingCSharpVerbatimPrefix = false;
     if (isInNonRenderedRazorContent()) {
       return;
     }
@@ -183,6 +188,7 @@ public final class TemplateConditionalScopeTracker {
     if (textConditionalDepth == 0) {
       clearBraceTracking();
     }
+    trailingCSharpVerbatimPrefix = hasTrailingCSharpVerbatimPrefix(text, trailingCSharpVerbatimPrefix);
   }
 
   private boolean consumeFragmentCharacter(String text, boolean directive, FragmentScanState state) {
@@ -305,7 +311,7 @@ public final class TemplateConditionalScopeTracker {
     if (current == '\'' || current == '"') {
       csharpStringDelimiter = current;
       escapedCSharpStringCharacter = false;
-      verbatimCSharpString = current == '"' && state.index > 0 && text.charAt(state.index - 1) == '@';
+      verbatimCSharpString = current == '"' && hasVerbatimPrefix(text, state.index, trailingCSharpVerbatimPrefix);
       state.index++;
       return true;
     }
@@ -340,7 +346,35 @@ public final class TemplateConditionalScopeTracker {
   }
 
   private boolean isInRazorCodeContext() {
-    return !razorCodeBlocks.isEmpty() && elementDepth == razorCodeBlocks.peek().elementDepth();
+    return !razorCodeBlocks.isEmpty() && elementDepth <= razorCodeBlocks.peek().elementDepth();
+  }
+
+  private boolean hasTrailingCSharpVerbatimPrefix(String text, boolean verbatimPrefixFromPreviousFragment) {
+    if (!isInRazorCodeContext() || isInNonRenderedRazorContent()) {
+      return false;
+    }
+    int index = text.length() - 1;
+    boolean containsAt = false;
+    while (index >= 0 && isCSharpStringPrefix(text.charAt(index))) {
+      containsAt |= text.charAt(index) == '@';
+      index--;
+    }
+    return index < 0 ? containsAt || verbatimPrefixFromPreviousFragment : containsAt;
+  }
+
+  private static boolean hasVerbatimPrefix(String text, int quoteIndex, boolean verbatimPrefixFromPreviousFragment) {
+    int index = quoteIndex - 1;
+    while (index >= 0 && isCSharpStringPrefix(text.charAt(index))) {
+      if (text.charAt(index) == '@') {
+        return true;
+      }
+      index--;
+    }
+    return index < 0 && verbatimPrefixFromPreviousFragment;
+  }
+
+  private static boolean isCSharpStringPrefix(char character) {
+    return character == '@' || character == '$';
   }
 
   private boolean isInPersistentRazorComment() {
@@ -571,10 +605,10 @@ public final class TemplateConditionalScopeTracker {
     if (pendingConditionalBranchOpenings > 0) {
       pendingConditionalBranchOpenings--;
       clearConditionalHeaderTracking();
-    } else if (braceBasedTextConditionalDepth > 0) {
+    } else if (braceBasedTextConditionalDepth > 0 && (razorCodeBlocks.isEmpty() || isInRazorCodeContext())) {
       nestedTextBlockDepth++;
     }
-    if (!razorCodeBlocks.isEmpty()) {
+    if (isInRazorCodeContext()) {
       razorCodeBraceDepth++;
     }
     state.index++;
@@ -601,13 +635,26 @@ public final class TemplateConditionalScopeTracker {
   }
 
   private void closeRazorCodeBrace() {
-    if (razorCodeBlocks.isEmpty()) {
+    if (!isInRazorCodeContext()) {
       return;
     }
-    if (razorCodeBlocks.peek().openingBraceDepth() == razorCodeBraceDepth) {
+    razorCodeBraceDepth--;
+    if (razorCodeBraceDepth < razorCodeBlocks.peek().openingBraceDepth()) {
       razorCodeBlocks.pop();
     }
-    razorCodeBraceDepth--;
+    if (razorCodeBlocks.isEmpty()) {
+      razorCodeBraceDepth = 0;
+      resetCSharpProtectedState();
+    }
+  }
+
+  private void resetCSharpProtectedState() {
+    inCSharpLineComment = false;
+    inCSharpBlockComment = false;
+    escapedCSharpStringCharacter = false;
+    verbatimCSharpString = false;
+    trailingCSharpVerbatimPrefix = false;
+    csharpStringDelimiter = '\0';
   }
 
   /**
@@ -941,6 +988,10 @@ public final class TemplateConditionalScopeTracker {
   private static boolean isWordBoundary(String text, int index) {
     return index >= text.length()
       || (!Character.isLetterOrDigit(text.charAt(index)) && text.charAt(index) != '_');
+  }
+
+  private static boolean tracksElementDepth(TagNode node) {
+    return node.hasEnd() || !VOID_ELEMENTS.contains(node.getNodeName().toLowerCase(Locale.ROOT));
   }
 
   private static boolean isWordStart(String text, int index) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -877,6 +877,7 @@ public final class TemplateConditionalScopeTracker {
       return false;
     }
     if (pendingRenderedRazorCodeBlockClosing && braceBasedTextConditionalDepth == 0
+      && markupBraceDepths.isEmpty() && conditionalBraces.isEmpty()
       && skipLeadingTrivia(text, state.index + 1) >= text.length()) {
       pendingRenderedRazorCodeBlockClosing = false;
       closeTrackedRazorCodeBrace();

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -45,12 +45,10 @@ public final class TemplateConditionalScopeTracker {
     "*ngIf", "*ngFor", "*ngSwitchCase", "*ngSwitchDefault"
   );
 
-  private static final Set<String> VOID_ELEMENTS = Set.of(
-    "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source", "track", "wbr"
-  );
-
   private static final Pattern RAZOR_BLOCK_START_PATTERN = Pattern.compile("@(if|switch)\\s*\\(", Pattern.CASE_INSENSITIVE);
   private static final Pattern CSHARP_BLOCK_START_PATTERN = Pattern.compile("(if|switch)\\s*\\(", Pattern.CASE_INSENSITIVE);
+  private static final Pattern CSHARP_GENERIC_ARGUMENT_PATTERN = Pattern.compile("<\\s*[\\p{L}_][\\p{L}\\p{N}_.,:?\\[\\]\\s<>]*>");
+  private static final int CSHARP_RAW_STRING_MIN_QUOTE_COUNT = 3;
   // Angular block control flow branches: @case (value) { and @default { inside an @switch
   private static final Pattern ANGULAR_BRANCH_START_PATTERN = Pattern.compile("@(case|default)\\s*[({]", Pattern.CASE_INSENSITIVE);
   private static final Pattern PHP_DIRECTIVE_CONDITIONAL_START_PATTERN = Pattern.compile("(if|foreach|for)\\b", Pattern.CASE_INSENSITIVE);
@@ -80,7 +78,9 @@ public final class TemplateConditionalScopeTracker {
   private boolean inCSharpBlockComment;
   private boolean escapedCSharpStringCharacter;
   private boolean verbatimCSharpString;
+  private int csharpRawStringQuoteCount;
   private char csharpStringDelimiter;
+  private boolean csharpGenericTypeArgumentExpected;
   private boolean razorCodeEnabled;
 
   public void reset() {
@@ -106,20 +106,35 @@ public final class TemplateConditionalScopeTracker {
     razorCodeBlocks.clear();
     inRazorComment = false;
     inRazorExplicitText = false;
+    csharpGenericTypeArgumentExpected = false;
     resetCSharpProtectedState();
     this.razorCodeEnabled = razorCodeEnabled;
   }
 
   public void visitText(TextNode textNode) {
-    scanFragment(textNode.getCode(), false);
+    String code = textNode.getCode();
+    if (!isInNonRenderedRazorContent()) {
+      synchronizeOpenElements(textNode.getParent());
+    }
+    scanFragment(code, false);
+    csharpGenericTypeArgumentExpected = isInRazorCodeContext()
+      && !inRazorExplicitText
+      && !isInNonRenderedRazorContent()
+      && endsWithCSharpIdentifier(code);
   }
 
   public void visitDirective(DirectiveNode directiveNode) {
+    csharpGenericTypeArgumentExpected = false;
     flushPendingBranchContinuation();
     scanFragment(unwrapDirective(directiveNode.getCode()), true);
   }
 
   public void startElement(TagNode node) {
+    if (isCSharpGenericTypeArgument(node)) {
+      csharpGenericTypeArgumentExpected = false;
+      return;
+    }
+    csharpGenericTypeArgumentExpected = false;
     if (isInNonRenderedRazorContent()) {
       return;
     }
@@ -140,6 +155,7 @@ public final class TemplateConditionalScopeTracker {
   }
 
   public void endElement(TagNode node) {
+    csharpGenericTypeArgumentExpected = false;
     if (isInNonRenderedRazorContent()) {
       return;
     }
@@ -159,14 +175,9 @@ public final class TemplateConditionalScopeTracker {
   }
 
   private void closeElement(TagNode node) {
-    if (openElements.stream().noneMatch(openElement -> matchesClosingElement(openElement, node))) {
-      return;
-    }
-    TagNode closedElement;
-    do {
-      closedElement = openElements.peek();
+    if (!openElements.isEmpty() && matchesClosingElement(openElements.peek(), node)) {
       closeCurrentElement();
-    } while (!matchesClosingElement(closedElement, node));
+    }
     discardClosedMarkupScopes();
   }
 
@@ -356,6 +367,10 @@ public final class TemplateConditionalScopeTracker {
   }
 
   private void consumeCSharpStringCharacter(String text, FragmentScanState state) {
+    if (csharpRawStringQuoteCount > 0) {
+      consumeCSharpRawStringCharacter(text, state);
+      return;
+    }
     char current = text.charAt(state.index);
     if (isEscapedVerbatimQuote(text, state, current)) {
       state.index += 2;
@@ -363,6 +378,17 @@ public final class TemplateConditionalScopeTracker {
     }
     updateCSharpStringState(current);
     state.index++;
+  }
+
+  private void consumeCSharpRawStringCharacter(String text, FragmentScanState state) {
+    int quoteCount = consecutiveQuoteCount(text, state.index);
+    if (quoteCount >= csharpRawStringQuoteCount) {
+      state.index += csharpRawStringQuoteCount;
+      csharpRawStringQuoteCount = 0;
+      csharpStringDelimiter = '\0';
+    } else {
+      state.index += Math.max(quoteCount, 1);
+    }
   }
 
   private boolean isEscapedVerbatimQuote(String text, FragmentScanState state, char current) {
@@ -408,8 +434,18 @@ public final class TemplateConditionalScopeTracker {
       return true;
     }
     char current = text.charAt(state.index);
+    int quoteCount = consecutiveQuoteCount(text, state.index);
+    if (quoteCount >= CSHARP_RAW_STRING_MIN_QUOTE_COUNT) {
+      csharpStringDelimiter = '"';
+      csharpRawStringQuoteCount = quoteCount;
+      escapedCSharpStringCharacter = false;
+      verbatimCSharpString = false;
+      state.index += quoteCount;
+      return true;
+    }
     if (current == '\'' || current == '"') {
       csharpStringDelimiter = current;
+      csharpRawStringQuoteCount = 0;
       escapedCSharpStringCharacter = false;
       verbatimCSharpString = current == '"' && hasVerbatimPrefix(text, state.index);
       state.index++;
@@ -447,6 +483,32 @@ public final class TemplateConditionalScopeTracker {
 
   private boolean isInRazorCodeContext() {
     return !razorCodeBlocks.isEmpty() && currentElementDepth() <= razorCodeBlocks.peek().elementDepth();
+  }
+
+  private boolean isCSharpGenericTypeArgument(TagNode node) {
+    return csharpGenericTypeArgumentExpected
+      && isInRazorCodeContext()
+      && CSHARP_GENERIC_ARGUMENT_PATTERN.matcher(node.getCode()).matches();
+  }
+
+  private static boolean endsWithCSharpIdentifier(String text) {
+    int index = text.length() - 1;
+    while (index >= 0 && isHorizontalWhitespace(text.charAt(index))) {
+      index--;
+    }
+    return index >= 0 && (Character.isLetterOrDigit(text.charAt(index)) || text.charAt(index) == '_');
+  }
+
+  private static boolean isHorizontalWhitespace(char character) {
+    return character == ' ' || character == '\t' || character == '\f';
+  }
+
+  private static int consecutiveQuoteCount(String text, int index) {
+    int quoteCount = 0;
+    while (index + quoteCount < text.length() && text.charAt(index + quoteCount) == '"') {
+      quoteCount++;
+    }
+    return quoteCount;
   }
 
   private static boolean hasVerbatimPrefix(String text, int quoteIndex) {
@@ -775,6 +837,7 @@ public final class TemplateConditionalScopeTracker {
     inCSharpBlockComment = false;
     escapedCSharpStringCharacter = false;
     verbatimCSharpString = false;
+    csharpRawStringQuoteCount = 0;
     csharpStringDelimiter = '\0';
   }
 
@@ -1114,7 +1177,7 @@ public final class TemplateConditionalScopeTracker {
   }
 
   private static boolean tracksElementDepth(TagNode node) {
-    return node.hasEnd() || !VOID_ELEMENTS.contains(node.getNodeName().toLowerCase(Locale.ROOT));
+    return node.hasEnd() || !HtmlConstants.VOID_ELEMENTS.contains(node.getNodeName().toLowerCase(Locale.ROOT));
   }
 
   private static boolean isWordStart(String text, int index) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -174,31 +174,30 @@ public final class TemplateConditionalScopeTracker {
       if (!directive && resolvePendingInThisFragment && pendingBranchContinuation && !isInPersistentRazorComment()) {
         resolvePendingBranchContinuation(text, state);
         resolvePendingInThisFragment = false;
-        if (state.index >= text.length()) {
-          break;
-        }
       }
-      boolean fullCode = directive || isScanningConditionalHeader();
-      boolean hashComments = fullCode;
-      boolean slashComments = fullCode || scriptDepth > 0;
-      boolean stringsAndBlockComments = fullCode || scriptDepth > 0 || styleDepth > 0 || nestedTextBlockDepth > 0;
-      if (consumePersistentRazorProtectedCharacter(text, state)
-        || consumePersistentRazorProtectedStart(text, state)
-        || consumeProtectedCharacter(text, state)
-        || consumeCommentOrStringStart(text, directive, hashComments, slashComments, stringsAndBlockComments, state)
-        || consumeConditionalHeaderCharacter(text, state)
-        || consumeRazorCodeBlockStart(text, state)
-        || consumeCSharpConditionalStart(text, state)
-        || consumeConditionalToken(text, directive, state)
-        || consumeStructuralToken(text, state)) {
-        continue;
+      if (state.index < text.length() && !consumeFragmentCharacter(text, directive, state)) {
+        state.index++;
       }
-      state.index++;
     }
 
     if (textConditionalDepth == 0) {
       clearBraceTracking();
     }
+  }
+
+  private boolean consumeFragmentCharacter(String text, boolean directive, FragmentScanState state) {
+    boolean fullCode = directive || isScanningConditionalHeader();
+    boolean slashComments = fullCode || scriptDepth > 0;
+    boolean stringsAndBlockComments = fullCode || scriptDepth > 0 || styleDepth > 0 || nestedTextBlockDepth > 0;
+    return consumePersistentRazorProtectedCharacter(text, state)
+      || consumePersistentRazorProtectedStart(text, state)
+      || consumeProtectedCharacter(text, state)
+      || consumeCommentOrStringStart(text, directive, fullCode, slashComments, stringsAndBlockComments, state)
+      || consumeConditionalHeaderCharacter(text, state)
+      || consumeRazorCodeBlockStart(text, state)
+      || consumeCSharpConditionalStart(text, state)
+      || consumeConditionalToken(text, directive, state)
+      || consumeStructuralToken(text, state);
   }
 
   /**
@@ -207,49 +206,73 @@ public final class TemplateConditionalScopeTracker {
    */
   private boolean consumePersistentRazorProtectedCharacter(String text, FragmentScanState state) {
     if (inRazorComment) {
-      if (startsWith(text, state.index, "*@")) {
-        inRazorComment = false;
-        state.index += 2;
-      } else {
-        state.index++;
-      }
+      consumeRazorCommentCharacter(text, state);
       return true;
     }
     if (inCSharpLineComment) {
-      if (isLineBreak(text.charAt(state.index))) {
-        inCSharpLineComment = false;
-      }
-      state.index++;
+      consumeCSharpLineCommentCharacter(text, state);
       return true;
     }
     if (inCSharpBlockComment) {
-      if (startsWith(text, state.index, "*/")) {
-        inCSharpBlockComment = false;
-        state.index += 2;
-      } else {
-        state.index++;
-      }
+      consumeCSharpBlockCommentCharacter(text, state);
       return true;
     }
     if (csharpStringDelimiter != '\0') {
-      char current = text.charAt(state.index);
-      if (verbatimCSharpString && current == csharpStringDelimiter
-        && state.index + 1 < text.length() && text.charAt(state.index + 1) == csharpStringDelimiter) {
-        state.index += 2;
-      } else {
-        if (escapedCSharpStringCharacter) {
-          escapedCSharpStringCharacter = false;
-        } else if (!verbatimCSharpString && current == '\\') {
-          escapedCSharpStringCharacter = true;
-        } else if (current == csharpStringDelimiter) {
-          csharpStringDelimiter = '\0';
-          verbatimCSharpString = false;
-        }
-        state.index++;
-      }
+      consumeCSharpStringCharacter(text, state);
       return true;
     }
     return false;
+  }
+
+  private void consumeRazorCommentCharacter(String text, FragmentScanState state) {
+    if (startsWith(text, state.index, "*@")) {
+      inRazorComment = false;
+      state.index += 2;
+    } else {
+      state.index++;
+    }
+  }
+
+  private void consumeCSharpLineCommentCharacter(String text, FragmentScanState state) {
+    if (isLineBreak(text.charAt(state.index))) {
+      inCSharpLineComment = false;
+    }
+    state.index++;
+  }
+
+  private void consumeCSharpBlockCommentCharacter(String text, FragmentScanState state) {
+    if (startsWith(text, state.index, "*/")) {
+      inCSharpBlockComment = false;
+      state.index += 2;
+    } else {
+      state.index++;
+    }
+  }
+
+  private void consumeCSharpStringCharacter(String text, FragmentScanState state) {
+    char current = text.charAt(state.index);
+    if (isEscapedVerbatimQuote(text, state, current)) {
+      state.index += 2;
+      return;
+    }
+    updateCSharpStringState(current);
+    state.index++;
+  }
+
+  private boolean isEscapedVerbatimQuote(String text, FragmentScanState state, char current) {
+    return verbatimCSharpString && current == csharpStringDelimiter
+      && state.index + 1 < text.length() && text.charAt(state.index + 1) == csharpStringDelimiter;
+  }
+
+  private void updateCSharpStringState(char current) {
+    if (escapedCSharpStringCharacter) {
+      escapedCSharpStringCharacter = false;
+    } else if (!verbatimCSharpString && current == '\\') {
+      escapedCSharpStringCharacter = true;
+    } else if (current == csharpStringDelimiter) {
+      csharpStringDelimiter = '\0';
+      verbatimCSharpString = false;
+    }
   }
 
   /**

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -49,6 +49,7 @@ public final class TemplateConditionalScopeTracker {
   private static final Pattern CSHARP_BLOCK_START_PATTERN = Pattern.compile("(if|switch)\\s*\\(", Pattern.CASE_INSENSITIVE);
   private static final Pattern CSHARP_GENERIC_ARGUMENT_PATTERN = Pattern.compile("<\\s*[\\p{L}_][\\p{L}\\p{N}_.,:?\\[\\]\\s<>]*>");
   private static final int CSHARP_RAW_STRING_MIN_QUOTE_COUNT = 3;
+  private static final int CSHARP_EMPTY_RAW_STRING_QUOTE_COUNT = 6;
   // Angular block control flow branches: @case (value) { and @default { inside an @switch
   private static final Pattern ANGULAR_BRANCH_START_PATTERN = Pattern.compile("@(case|default)\\s*[({]", Pattern.CASE_INSENSITIVE);
   private static final Pattern PHP_DIRECTIVE_CONDITIONAL_START_PATTERN = Pattern.compile("(if|foreach|for)\\b", Pattern.CASE_INSENSITIVE);
@@ -80,7 +81,7 @@ public final class TemplateConditionalScopeTracker {
   private boolean verbatimCSharpString;
   private int csharpRawStringQuoteCount;
   private char csharpStringDelimiter;
-  private boolean csharpGenericTypeArgumentExpected;
+  private char csharpGenericTypeOwnerInitial;
   private boolean razorCodeEnabled;
 
   public void reset() {
@@ -106,7 +107,7 @@ public final class TemplateConditionalScopeTracker {
     razorCodeBlocks.clear();
     inRazorComment = false;
     inRazorExplicitText = false;
-    csharpGenericTypeArgumentExpected = false;
+    csharpGenericTypeOwnerInitial = '\0';
     resetCSharpProtectedState();
     this.razorCodeEnabled = razorCodeEnabled;
   }
@@ -117,24 +118,25 @@ public final class TemplateConditionalScopeTracker {
       synchronizeOpenElements(textNode.getParent());
     }
     scanFragment(code, false);
-    csharpGenericTypeArgumentExpected = isInRazorCodeContext()
+    csharpGenericTypeOwnerInitial = isInRazorCodeContext()
       && !inRazorExplicitText
       && !isInNonRenderedRazorContent()
-      && endsWithCSharpIdentifier(code);
+      ? trailingCSharpIdentifierInitial(code)
+      : '\0';
   }
 
   public void visitDirective(DirectiveNode directiveNode) {
-    csharpGenericTypeArgumentExpected = false;
+    csharpGenericTypeOwnerInitial = '\0';
     flushPendingBranchContinuation();
     scanFragment(unwrapDirective(directiveNode.getCode()), true);
   }
 
   public void startElement(TagNode node) {
-    if (isCSharpGenericTypeArgument(node)) {
-      csharpGenericTypeArgumentExpected = false;
+    boolean csharpGenericTypeArgument = isCSharpGenericTypeArgument(node);
+    csharpGenericTypeOwnerInitial = '\0';
+    if (csharpGenericTypeArgument) {
       return;
     }
-    csharpGenericTypeArgumentExpected = false;
     if (isInNonRenderedRazorContent()) {
       return;
     }
@@ -155,7 +157,7 @@ public final class TemplateConditionalScopeTracker {
   }
 
   public void endElement(TagNode node) {
-    csharpGenericTypeArgumentExpected = false;
+    csharpGenericTypeOwnerInitial = '\0';
     if (isInNonRenderedRazorContent()) {
       return;
     }
@@ -435,6 +437,10 @@ public final class TemplateConditionalScopeTracker {
     }
     char current = text.charAt(state.index);
     int quoteCount = consecutiveQuoteCount(text, state.index);
+    if (isCompleteEmptyRawString(text, state.index, quoteCount)) {
+      state.index += quoteCount;
+      return true;
+    }
     if (quoteCount >= CSHARP_RAW_STRING_MIN_QUOTE_COUNT) {
       csharpStringDelimiter = '"';
       csharpRawStringQuoteCount = quoteCount;
@@ -486,18 +492,28 @@ public final class TemplateConditionalScopeTracker {
   }
 
   private boolean isCSharpGenericTypeArgument(TagNode node) {
-    return csharpGenericTypeArgumentExpected
+    return csharpGenericTypeOwnerInitial != '\0'
       && isInRazorCodeContext()
-      && !HtmlConstants.hasKnownHTMLTag(node)
+      && (!HtmlConstants.hasKnownHTMLTag(node) || Character.isUpperCase(csharpGenericTypeOwnerInitial))
       && CSHARP_GENERIC_ARGUMENT_PATTERN.matcher(node.getCode()).matches();
   }
 
-  private static boolean endsWithCSharpIdentifier(String text) {
+  private static char trailingCSharpIdentifierInitial(String text) {
     int index = text.length() - 1;
     while (index >= 0 && isHorizontalWhitespace(text.charAt(index))) {
       index--;
     }
-    return index >= 0 && (Character.isLetterOrDigit(text.charAt(index)) || text.charAt(index) == '_');
+    if (index < 0 || !isCSharpIdentifierPart(text.charAt(index))) {
+      return '\0';
+    }
+    while (index > 0 && isCSharpIdentifierPart(text.charAt(index - 1))) {
+      index--;
+    }
+    return text.charAt(index);
+  }
+
+  private static boolean isCSharpIdentifierPart(char character) {
+    return Character.isLetterOrDigit(character) || character == '_';
   }
 
   private static boolean isHorizontalWhitespace(char character) {
@@ -510,6 +526,14 @@ public final class TemplateConditionalScopeTracker {
       quoteCount++;
     }
     return quoteCount;
+  }
+
+  private static boolean isCompleteEmptyRawString(String text, int index, int quoteCount) {
+    if (quoteCount != CSHARP_EMPTY_RAW_STRING_QUOTE_COUNT) {
+      return false;
+    }
+    int nextTokenIndex = skipWhitespace(text, index + quoteCount);
+    return nextTokenIndex < text.length() && ";,)]}+-*/%&|^!=<>?:".indexOf(text.charAt(nextTokenIndex)) >= 0;
   }
 
   private static boolean hasVerbatimPrefix(String text, int quoteIndex) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -67,20 +67,22 @@ public final class TemplateConditionalScopeTracker {
   private boolean pendingBranchContinuation;
   private int scriptDepth;
   private int styleDepth;
-  private int elementDepth;
-  private int markupBraceDepth;
   private int razorCodeBraceDepth;
+  private final Deque<TagNode> openElements = new ArrayDeque<>();
+  private final Deque<Integer> markupBraceDepths = new ArrayDeque<>();
+  private final Deque<Integer> renderedConditionalBraceDepths = new ArrayDeque<>();
   private final Deque<RazorCodeBlock> razorCodeBlocks = new ArrayDeque<>();
   private boolean inRazorComment;
+  private boolean inRazorExplicitText;
   private boolean inCSharpLineComment;
   private boolean inCSharpBlockComment;
   private boolean escapedCSharpStringCharacter;
   private boolean verbatimCSharpString;
   private char csharpStringDelimiter;
-  private boolean razorCodeEnabled = true;
+  private boolean razorCodeEnabled;
 
   public void reset() {
-    reset(true);
+    reset(false);
   }
 
   public void reset(boolean razorCodeEnabled) {
@@ -94,11 +96,13 @@ public final class TemplateConditionalScopeTracker {
     pendingBranchContinuation = false;
     scriptDepth = 0;
     styleDepth = 0;
-    elementDepth = 0;
-    markupBraceDepth = 0;
     razorCodeBraceDepth = 0;
+    openElements.clear();
+    markupBraceDepths.clear();
+    renderedConditionalBraceDepths.clear();
     razorCodeBlocks.clear();
     inRazorComment = false;
+    inRazorExplicitText = false;
     resetCSharpProtectedState();
     this.razorCodeEnabled = razorCodeEnabled;
   }
@@ -116,6 +120,7 @@ public final class TemplateConditionalScopeTracker {
     if (isInNonRenderedRazorContent()) {
       return;
     }
+    synchronizeOpenElements(node.getParent());
     flushPendingBranchContinuation();
     if (isJstlConditionalTag(node)) {
       tagConditionalDepth++;
@@ -126,7 +131,7 @@ public final class TemplateConditionalScopeTracker {
       styleDepth++;
     }
     if (tracksElementDepth(node)) {
-      elementDepth++;
+      openElements.push(node);
     }
   }
 
@@ -134,6 +139,40 @@ public final class TemplateConditionalScopeTracker {
     if (isInNonRenderedRazorContent()) {
       return;
     }
+    closeElement(node);
+  }
+
+  private void synchronizeOpenElements(TagNode parent) {
+    if (parent == null) {
+      closeAllOpenElements();
+    } else if (openElements.contains(parent)) {
+      while (openElements.peek() != parent) {
+        closeCurrentElement();
+      }
+    }
+    discardClosedMarkupScopes();
+  }
+
+  private void closeElement(TagNode node) {
+    if (!openElements.stream().anyMatch(openElement -> matchesClosingElement(openElement, node))) {
+      return;
+    }
+    TagNode closedElement;
+    do {
+      closedElement = openElements.peek();
+      closeCurrentElement();
+    } while (!matchesClosingElement(closedElement, node));
+    discardClosedMarkupScopes();
+  }
+
+  private void closeAllOpenElements() {
+    while (!openElements.isEmpty()) {
+      closeCurrentElement();
+    }
+  }
+
+  private void closeCurrentElement() {
+    TagNode node = openElements.pop();
     if (isJstlConditionalTag(node) && tagConditionalDepth > 0) {
       tagConditionalDepth--;
     }
@@ -142,9 +181,27 @@ public final class TemplateConditionalScopeTracker {
     } else if (isStyleTag(node) && styleDepth > 0) {
       styleDepth--;
     }
-    if (elementDepth > 0) {
-      elementDepth--;
+  }
+
+  private void discardClosedMarkupScopes() {
+    int elementDepth = currentElementDepth();
+    while (!markupBraceDepths.isEmpty() && markupBraceDepths.peek() > elementDepth) {
+      markupBraceDepths.pop();
     }
+    while (!renderedConditionalBraceDepths.isEmpty() && renderedConditionalBraceDepths.peek() > elementDepth) {
+      renderedConditionalBraceDepths.pop();
+      closeBraceBasedConditional();
+    }
+  }
+
+  private static boolean matchesClosingElement(TagNode openElement, TagNode closingElement) {
+    return closingElement.hasEnd()
+      ? openElement == closingElement
+      : openElement.equalsElementName(closingElement.getNodeName());
+  }
+
+  private int currentElementDepth() {
+    return openElements.size();
   }
 
   public boolean isInConditional(TagNode node) {
@@ -193,7 +250,8 @@ public final class TemplateConditionalScopeTracker {
     boolean fullCode = directive || isScanningConditionalHeader();
     boolean slashComments = fullCode || scriptDepth > 0;
     boolean stringsAndBlockComments = fullCode || scriptDepth > 0 || styleDepth > 0 || nestedTextBlockDepth > 0;
-    return consumePersistentRazorProtectedCharacter(text, state)
+    return consumeRazorExplicitText(text, state)
+      || consumePersistentRazorProtectedCharacter(text, state)
       || consumePersistentRazorProtectedStart(text, state)
       || consumeProtectedCharacter(text, state)
       || consumeCommentOrStringStart(text, directive, fullCode, slashComments, stringsAndBlockComments, state)
@@ -202,6 +260,22 @@ public final class TemplateConditionalScopeTracker {
       || consumeCSharpConditionalStart(text, state)
       || consumeConditionalToken(text, directive, state)
       || consumeStructuralToken(text, state);
+  }
+
+  private boolean consumeRazorExplicitText(String text, FragmentScanState state) {
+    if (inRazorExplicitText) {
+      if (isLineBreak(text.charAt(state.index))) {
+        inRazorExplicitText = false;
+      }
+      state.index++;
+      return true;
+    }
+    if (razorCodeEnabled && isInRazorCodeContext() && startsWith(text, state.index, "@:")) {
+      inRazorExplicitText = true;
+      state.index += 2;
+      return true;
+    }
+    return false;
   }
 
   /**
@@ -324,7 +398,7 @@ public final class TemplateConditionalScopeTracker {
       nestedTextBlockDepth++;
     }
     razorCodeBraceDepth++;
-    razorCodeBlocks.push(new RazorCodeBlock(razorCodeBraceDepth, elementDepth));
+    razorCodeBlocks.push(new RazorCodeBlock(razorCodeBraceDepth, currentElementDepth()));
     state.index += 2;
     return true;
   }
@@ -344,7 +418,7 @@ public final class TemplateConditionalScopeTracker {
   }
 
   private boolean isInRazorCodeContext() {
-    return !razorCodeBlocks.isEmpty() && elementDepth <= razorCodeBlocks.peek().elementDepth();
+    return !razorCodeBlocks.isEmpty() && currentElementDepth() <= razorCodeBlocks.peek().elementDepth();
   }
 
   private static boolean hasVerbatimPrefix(String text, int quoteIndex) {
@@ -590,8 +664,11 @@ public final class TemplateConditionalScopeTracker {
     if (pendingConditionalBranchOpenings > 0) {
       pendingConditionalBranchOpenings--;
       clearConditionalHeaderTracking();
+      if (!razorCodeBlocks.isEmpty() && !isInRazorCodeContext()) {
+        renderedConditionalBraceDepths.push(currentElementDepth());
+      }
     } else if (!razorCodeBlocks.isEmpty() && !isInRazorCodeContext()) {
-      markupBraceDepth++;
+      markupBraceDepths.push(currentElementDepth());
     } else if (braceBasedTextConditionalDepth > 0) {
       nestedTextBlockDepth++;
     }
@@ -609,10 +686,19 @@ public final class TemplateConditionalScopeTracker {
    * @param state the mutable scan state
    */
   private void consumeClosingBrace(String text, FragmentScanState state) {
-    if (markupBraceDepth > 0 && !isInRazorCodeContext()) {
-      markupBraceDepth--;
-      state.index++;
-      return;
+    if (!razorCodeBlocks.isEmpty() && !isInRazorCodeContext()) {
+      int elementDepth = currentElementDepth();
+      if (!markupBraceDepths.isEmpty() && markupBraceDepths.peek() == elementDepth) {
+        markupBraceDepths.pop();
+        state.index++;
+        return;
+      }
+      if (!renderedConditionalBraceDepths.isEmpty() && renderedConditionalBraceDepths.peek() == elementDepth) {
+        renderedConditionalBraceDepths.pop();
+      } else {
+        state.index++;
+        return;
+      }
     }
     if (nestedTextBlockDepth > 0) {
       nestedTextBlockDepth--;
@@ -635,8 +721,10 @@ public final class TemplateConditionalScopeTracker {
       razorCodeBlocks.pop();
     }
     if (razorCodeBlocks.isEmpty()) {
-      markupBraceDepth = 0;
+      markupBraceDepths.clear();
+      renderedConditionalBraceDepths.clear();
       razorCodeBraceDepth = 0;
+      inRazorExplicitText = false;
       resetCSharpProtectedState();
     }
   }
@@ -792,6 +880,7 @@ public final class TemplateConditionalScopeTracker {
     pendingConditionalBranchOpenings = 0;
     clearConditionalHeaderTracking();
     nestedTextBlockDepth = 0;
+    renderedConditionalBraceDepths.clear();
   }
 
   /**

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -876,25 +876,23 @@ public final class TemplateConditionalScopeTracker {
     if (razorCodeBlocks.isEmpty() || inRazorCodeContext) {
       return false;
     }
-    if (pendingRenderedRazorCodeBlockClosing && braceBasedTextConditionalDepth == 0
-      && markupBraceDepths.isEmpty() && conditionalBraces.isEmpty()
-      && skipLeadingTrivia(text, state.index + 1) >= text.length()) {
+    if (canClosePendingRenderedRazorCodeBlock(text, state)) {
       pendingRenderedRazorCodeBlockClosing = false;
       closeTrackedRazorCodeBrace();
       state.index++;
       return true;
     }
     int elementDepth = currentElementDepth();
-    if (!markupBraceDepths.isEmpty() && markupBraceDepths.peek() == elementDepth) {
+    if (hasMarkupBraceAtDepth(elementDepth)) {
       markupBraceDepths.pop();
       state.index++;
-    } else if (!conditionalBraces.isEmpty() && conditionalBraces.peek().elementDepth() == elementDepth) {
+    } else if (hasConditionalBraceAtDepth(elementDepth)) {
       if (continueRenderedConditionalBranch(text, state)) {
         return true;
       }
       closeRenderedConditionalBrace();
       return false;
-    } else if (!conditionalBraces.isEmpty() && conditionalBraces.peek().elementDepth() < elementDepth) {
+    } else if (hasConditionalBraceBelowDepth(elementDepth)) {
       if (!continueRenderedConditionalBranch(text, state)) {
         if (skipLeadingTrivia(text, state.index + 1) >= text.length()) {
           pendingRenderedClosingBraceDepth = elementDepth;
@@ -905,6 +903,24 @@ public final class TemplateConditionalScopeTracker {
       state.index++;
     }
     return true;
+  }
+
+  private boolean canClosePendingRenderedRazorCodeBlock(String text, FragmentScanState state) {
+    return pendingRenderedRazorCodeBlockClosing && braceBasedTextConditionalDepth == 0
+      && markupBraceDepths.isEmpty() && conditionalBraces.isEmpty()
+      && skipLeadingTrivia(text, state.index + 1) >= text.length();
+  }
+
+  private boolean hasMarkupBraceAtDepth(int elementDepth) {
+    return !markupBraceDepths.isEmpty() && markupBraceDepths.peek() == elementDepth;
+  }
+
+  private boolean hasConditionalBraceAtDepth(int elementDepth) {
+    return !conditionalBraces.isEmpty() && conditionalBraces.peek().elementDepth() == elementDepth;
+  }
+
+  private boolean hasConditionalBraceBelowDepth(int elementDepth) {
+    return !conditionalBraces.isEmpty() && conditionalBraces.peek().elementDepth() < elementDepth;
   }
 
   private void closeRenderedConditionalBrace() {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -69,9 +69,10 @@ public final class TemplateConditionalScopeTracker {
   private int scriptDepth;
   private int styleDepth;
   private int razorCodeBraceDepth;
+  private int pendingRenderedClosingBraceDepth;
   private final Deque<TagNode> openElements = new ArrayDeque<>();
   private final Deque<Integer> markupBraceDepths = new ArrayDeque<>();
-  private final Deque<Integer> renderedConditionalBraceDepths = new ArrayDeque<>();
+  private final Deque<ConditionalBrace> conditionalBraces = new ArrayDeque<>();
   private final Deque<RazorCodeBlock> razorCodeBlocks = new ArrayDeque<>();
   private boolean inRazorComment;
   private boolean inRazorExplicitText;
@@ -98,9 +99,10 @@ public final class TemplateConditionalScopeTracker {
     scriptDepth = 0;
     styleDepth = 0;
     razorCodeBraceDepth = 0;
+    pendingRenderedClosingBraceDepth = -1;
     openElements.clear();
     markupBraceDepths.clear();
-    renderedConditionalBraceDepths.clear();
+    conditionalBraces.clear();
     razorCodeBlocks.clear();
     inRazorComment = false;
     inRazorExplicitText = false;
@@ -122,6 +124,7 @@ public final class TemplateConditionalScopeTracker {
       return;
     }
     synchronizeOpenElements(node.getParent());
+    resolvePendingRenderedClosingBrace();
     flushPendingBranchContinuation();
     if (isJstlConditionalTag(node)) {
       tagConditionalDepth++;
@@ -141,6 +144,7 @@ public final class TemplateConditionalScopeTracker {
       return;
     }
     closeElement(node);
+    discardPendingRenderedClosingBrace();
   }
 
   private void synchronizeOpenElements(@Nullable TagNode parent) {
@@ -189,9 +193,31 @@ public final class TemplateConditionalScopeTracker {
     while (!markupBraceDepths.isEmpty() && markupBraceDepths.peek() > elementDepth) {
       markupBraceDepths.pop();
     }
-    while (!renderedConditionalBraceDepths.isEmpty() && renderedConditionalBraceDepths.peek() > elementDepth) {
-      renderedConditionalBraceDepths.pop();
-      closeBraceBasedConditional();
+    while (!conditionalBraces.isEmpty() && conditionalBraces.peek().elementDepth() > elementDepth) {
+      recoverConditionalBrace(conditionalBraces.pop());
+    }
+  }
+
+  private void resolvePendingRenderedClosingBrace() {
+    if (pendingRenderedClosingBraceDepth < 0) {
+      return;
+    }
+    if (currentElementDepth() >= pendingRenderedClosingBraceDepth && !conditionalBraces.isEmpty()) {
+      recoverConditionalBrace(conditionalBraces.pop());
+    }
+    pendingRenderedClosingBraceDepth = -1;
+  }
+
+  private void discardPendingRenderedClosingBrace() {
+    if (currentElementDepth() < pendingRenderedClosingBraceDepth) {
+      pendingRenderedClosingBraceDepth = -1;
+    }
+  }
+
+  private void recoverConditionalBrace(ConditionalBrace conditionalBrace) {
+    closeBraceBasedConditional();
+    if (conditionalBrace.razorBraceTracked()) {
+      razorCodeBraceDepth--;
     }
   }
 
@@ -251,8 +277,8 @@ public final class TemplateConditionalScopeTracker {
     boolean fullCode = directive || isScanningConditionalHeader();
     boolean slashComments = fullCode || scriptDepth > 0;
     boolean stringsAndBlockComments = fullCode || scriptDepth > 0 || styleDepth > 0 || nestedTextBlockDepth > 0;
-    return consumeRazorExplicitText(text, state)
-      || consumePersistentRazorProtectedCharacter(text, state)
+    return consumePersistentRazorProtectedCharacter(text, state)
+      || consumeRazorExplicitText(text, state)
       || consumePersistentRazorProtectedStart(text, state)
       || consumeProtectedCharacter(text, state)
       || consumeCommentOrStringStart(text, directive, fullCode, slashComments, stringsAndBlockComments, state)
@@ -271,7 +297,8 @@ public final class TemplateConditionalScopeTracker {
       state.index++;
       return true;
     }
-    if (razorCodeEnabled && isInRazorCodeContext() && startsWith(text, state.index, "@:")) {
+    if (razorCodeEnabled && !isInPersistentRazorComment() && csharpStringDelimiter == '\0'
+      && isInRazorCodeContext() && startsWith(text, state.index, "@:")) {
       inRazorExplicitText = true;
       state.index += 2;
       return true;
@@ -662,18 +689,19 @@ public final class TemplateConditionalScopeTracker {
    * @return always {@code true}
    */
   private boolean consumeOpeningBrace(FragmentScanState state) {
+    boolean inRazorCodeContext = isInRazorCodeContext();
     if (pendingConditionalBranchOpenings > 0) {
       pendingConditionalBranchOpenings--;
       clearConditionalHeaderTracking();
-      if (!razorCodeBlocks.isEmpty() && !isInRazorCodeContext()) {
-        renderedConditionalBraceDepths.push(currentElementDepth());
+      if (!razorCodeBlocks.isEmpty()) {
+        conditionalBraces.push(new ConditionalBrace(currentElementDepth(), inRazorCodeContext));
       }
-    } else if (!razorCodeBlocks.isEmpty() && !isInRazorCodeContext()) {
+    } else if (!razorCodeBlocks.isEmpty() && !inRazorCodeContext) {
       markupBraceDepths.push(currentElementDepth());
     } else if (braceBasedTextConditionalDepth > 0) {
       nestedTextBlockDepth++;
     }
-    if (isInRazorCodeContext()) {
+    if (inRazorCodeContext) {
       razorCodeBraceDepth++;
     }
     state.index++;
@@ -687,19 +715,27 @@ public final class TemplateConditionalScopeTracker {
    * @param state the mutable scan state
    */
   private void consumeClosingBrace(String text, FragmentScanState state) {
-    if (!razorCodeBlocks.isEmpty() && !isInRazorCodeContext()) {
+    boolean inRazorCodeContext = isInRazorCodeContext();
+    if (!razorCodeBlocks.isEmpty() && !inRazorCodeContext) {
       int elementDepth = currentElementDepth();
       if (!markupBraceDepths.isEmpty() && markupBraceDepths.peek() == elementDepth) {
         markupBraceDepths.pop();
         state.index++;
         return;
       }
-      if (!renderedConditionalBraceDepths.isEmpty() && renderedConditionalBraceDepths.peek() == elementDepth) {
-        renderedConditionalBraceDepths.pop();
+      if (!conditionalBraces.isEmpty() && conditionalBraces.peek().elementDepth() == elementDepth) {
+        conditionalBraces.pop();
+      } else if (!conditionalBraces.isEmpty() && conditionalBraces.peek().elementDepth() < elementDepth) {
+        pendingRenderedClosingBraceDepth = elementDepth;
+        state.index++;
+        return;
       } else {
         state.index++;
         return;
       }
+    } else if (!conditionalBraces.isEmpty() && nestedTextBlockDepth == 0
+      && conditionalBraces.peek().elementDepth() == currentElementDepth()) {
+      conditionalBraces.pop();
     }
     if (nestedTextBlockDepth > 0) {
       nestedTextBlockDepth--;
@@ -723,7 +759,8 @@ public final class TemplateConditionalScopeTracker {
     }
     if (razorCodeBlocks.isEmpty()) {
       markupBraceDepths.clear();
-      renderedConditionalBraceDepths.clear();
+      conditionalBraces.clear();
+      pendingRenderedClosingBraceDepth = -1;
       razorCodeBraceDepth = 0;
       inRazorExplicitText = false;
       resetCSharpProtectedState();
@@ -881,7 +918,8 @@ public final class TemplateConditionalScopeTracker {
     pendingConditionalBranchOpenings = 0;
     clearConditionalHeaderTracking();
     nestedTextBlockDepth = 0;
-    renderedConditionalBraceDepths.clear();
+    conditionalBraces.clear();
+    pendingRenderedClosingBraceDepth = -1;
   }
 
   /**
@@ -1197,6 +1235,9 @@ public final class TemplateConditionalScopeTracker {
   }
 
   private record RazorCodeBlock(int openingBraceDepth, int elementDepth) {
+  }
+
+  private record ConditionalBrace(int elementDepth, boolean razorBraceTracked) {
   }
 
   private static boolean isLineBreak(char character) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -716,24 +716,10 @@ public final class TemplateConditionalScopeTracker {
    */
   private void consumeClosingBrace(String text, FragmentScanState state) {
     boolean inRazorCodeContext = isInRazorCodeContext();
-    if (!razorCodeBlocks.isEmpty() && !inRazorCodeContext) {
-      int elementDepth = currentElementDepth();
-      if (!markupBraceDepths.isEmpty() && markupBraceDepths.peek() == elementDepth) {
-        markupBraceDepths.pop();
-        state.index++;
-        return;
-      }
-      if (!conditionalBraces.isEmpty() && conditionalBraces.peek().elementDepth() == elementDepth) {
-        conditionalBraces.pop();
-      } else if (!conditionalBraces.isEmpty() && conditionalBraces.peek().elementDepth() < elementDepth) {
-        pendingRenderedClosingBraceDepth = elementDepth;
-        state.index++;
-        return;
-      } else {
-        state.index++;
-        return;
-      }
-    } else if (!conditionalBraces.isEmpty() && nestedTextBlockDepth == 0
+    if (consumeRenderedMarkupClosingBrace(state, inRazorCodeContext)) {
+      return;
+    }
+    if (inRazorCodeContext && !conditionalBraces.isEmpty() && nestedTextBlockDepth == 0
       && conditionalBraces.peek().elementDepth() == currentElementDepth()) {
       conditionalBraces.pop();
     }
@@ -747,6 +733,23 @@ public final class TemplateConditionalScopeTracker {
     }
     closeRazorCodeBrace();
     state.index++;
+  }
+
+  private boolean consumeRenderedMarkupClosingBrace(FragmentScanState state, boolean inRazorCodeContext) {
+    if (razorCodeBlocks.isEmpty() || inRazorCodeContext) {
+      return false;
+    }
+    int elementDepth = currentElementDepth();
+    if (!markupBraceDepths.isEmpty() && markupBraceDepths.peek() == elementDepth) {
+      markupBraceDepths.pop();
+    } else if (!conditionalBraces.isEmpty() && conditionalBraces.peek().elementDepth() == elementDepth) {
+      conditionalBraces.pop();
+      return false;
+    } else if (!conditionalBraces.isEmpty() && conditionalBraces.peek().elementDepth() < elementDepth) {
+      pendingRenderedClosingBraceDepth = elementDepth;
+    }
+    state.index++;
+    return true;
   }
 
   private void closeRazorCodeBrace() {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -68,6 +68,7 @@ public final class TemplateConditionalScopeTracker {
   private int scriptDepth;
   private int styleDepth;
   private int elementDepth;
+  private int markupBraceDepth;
   private int razorCodeBraceDepth;
   private final Deque<RazorCodeBlock> razorCodeBlocks = new ArrayDeque<>();
   private boolean inRazorComment;
@@ -75,7 +76,6 @@ public final class TemplateConditionalScopeTracker {
   private boolean inCSharpBlockComment;
   private boolean escapedCSharpStringCharacter;
   private boolean verbatimCSharpString;
-  private boolean trailingCSharpVerbatimPrefix;
   private char csharpStringDelimiter;
   private boolean razorCodeEnabled = true;
 
@@ -95,6 +95,7 @@ public final class TemplateConditionalScopeTracker {
     scriptDepth = 0;
     styleDepth = 0;
     elementDepth = 0;
+    markupBraceDepth = 0;
     razorCodeBraceDepth = 0;
     razorCodeBlocks.clear();
     inRazorComment = false;
@@ -112,7 +113,6 @@ public final class TemplateConditionalScopeTracker {
   }
 
   public void startElement(TagNode node) {
-    trailingCSharpVerbatimPrefix = false;
     if (isInNonRenderedRazorContent()) {
       return;
     }
@@ -131,7 +131,6 @@ public final class TemplateConditionalScopeTracker {
   }
 
   public void endElement(TagNode node) {
-    trailingCSharpVerbatimPrefix = false;
     if (isInNonRenderedRazorContent()) {
       return;
     }
@@ -188,7 +187,6 @@ public final class TemplateConditionalScopeTracker {
     if (textConditionalDepth == 0) {
       clearBraceTracking();
     }
-    trailingCSharpVerbatimPrefix = hasTrailingCSharpVerbatimPrefix(text, trailingCSharpVerbatimPrefix);
   }
 
   private boolean consumeFragmentCharacter(String text, boolean directive, FragmentScanState state) {
@@ -311,7 +309,7 @@ public final class TemplateConditionalScopeTracker {
     if (current == '\'' || current == '"') {
       csharpStringDelimiter = current;
       escapedCSharpStringCharacter = false;
-      verbatimCSharpString = current == '"' && hasVerbatimPrefix(text, state.index, trailingCSharpVerbatimPrefix);
+      verbatimCSharpString = current == '"' && hasVerbatimPrefix(text, state.index);
       state.index++;
       return true;
     }
@@ -349,20 +347,7 @@ public final class TemplateConditionalScopeTracker {
     return !razorCodeBlocks.isEmpty() && elementDepth <= razorCodeBlocks.peek().elementDepth();
   }
 
-  private boolean hasTrailingCSharpVerbatimPrefix(String text, boolean verbatimPrefixFromPreviousFragment) {
-    if (!isInRazorCodeContext() || isInNonRenderedRazorContent()) {
-      return false;
-    }
-    int index = text.length() - 1;
-    boolean containsAt = false;
-    while (index >= 0 && isCSharpStringPrefix(text.charAt(index))) {
-      containsAt |= text.charAt(index) == '@';
-      index--;
-    }
-    return index < 0 ? containsAt || verbatimPrefixFromPreviousFragment : containsAt;
-  }
-
-  private static boolean hasVerbatimPrefix(String text, int quoteIndex, boolean verbatimPrefixFromPreviousFragment) {
+  private static boolean hasVerbatimPrefix(String text, int quoteIndex) {
     int index = quoteIndex - 1;
     while (index >= 0 && isCSharpStringPrefix(text.charAt(index))) {
       if (text.charAt(index) == '@') {
@@ -370,7 +355,7 @@ public final class TemplateConditionalScopeTracker {
       }
       index--;
     }
-    return index < 0 && verbatimPrefixFromPreviousFragment;
+    return false;
   }
 
   private static boolean isCSharpStringPrefix(char character) {
@@ -605,7 +590,9 @@ public final class TemplateConditionalScopeTracker {
     if (pendingConditionalBranchOpenings > 0) {
       pendingConditionalBranchOpenings--;
       clearConditionalHeaderTracking();
-    } else if (braceBasedTextConditionalDepth > 0 && (razorCodeBlocks.isEmpty() || isInRazorCodeContext())) {
+    } else if (!razorCodeBlocks.isEmpty() && !isInRazorCodeContext()) {
+      markupBraceDepth++;
+    } else if (braceBasedTextConditionalDepth > 0) {
       nestedTextBlockDepth++;
     }
     if (isInRazorCodeContext()) {
@@ -622,6 +609,11 @@ public final class TemplateConditionalScopeTracker {
    * @param state the mutable scan state
    */
   private void consumeClosingBrace(String text, FragmentScanState state) {
+    if (markupBraceDepth > 0 && !isInRazorCodeContext()) {
+      markupBraceDepth--;
+      state.index++;
+      return;
+    }
     if (nestedTextBlockDepth > 0) {
       nestedTextBlockDepth--;
     } else if (continueBraceBasedConditional(text, state)) {
@@ -643,6 +635,7 @@ public final class TemplateConditionalScopeTracker {
       razorCodeBlocks.pop();
     }
     if (razorCodeBlocks.isEmpty()) {
+      markupBraceDepth = 0;
       razorCodeBraceDepth = 0;
       resetCSharpProtectedState();
     }
@@ -653,7 +646,6 @@ public final class TemplateConditionalScopeTracker {
     inCSharpBlockComment = false;
     escapedCSharpStringCharacter = false;
     verbatimCSharpString = false;
-    trailingCSharpVerbatimPrefix = false;
     csharpStringDelimiter = '\0';
   }
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -16,6 +16,8 @@
  */
 package org.sonar.plugins.html.api;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -43,6 +45,7 @@ public final class TemplateConditionalScopeTracker {
   );
 
   private static final Pattern RAZOR_BLOCK_START_PATTERN = Pattern.compile("@(if|switch)\\s*\\(", Pattern.CASE_INSENSITIVE);
+  private static final Pattern CSHARP_BLOCK_START_PATTERN = Pattern.compile("(if|switch)\\s*\\(", Pattern.CASE_INSENSITIVE);
   // Angular block control flow branches: @case (value) { and @default { inside an @switch
   private static final Pattern ANGULAR_BRANCH_START_PATTERN = Pattern.compile("@(case|default)\\s*[({]", Pattern.CASE_INSENSITIVE);
   private static final Pattern PHP_DIRECTIVE_CONDITIONAL_START_PATTERN = Pattern.compile("(if|foreach|for)\\b", Pattern.CASE_INSENSITIVE);
@@ -60,8 +63,22 @@ public final class TemplateConditionalScopeTracker {
   private boolean pendingBranchContinuation;
   private int scriptDepth;
   private int styleDepth;
+  private int elementDepth;
+  private int razorCodeBraceDepth;
+  private final Deque<RazorCodeBlock> razorCodeBlocks = new ArrayDeque<>();
+  private boolean inRazorComment;
+  private boolean inCSharpLineComment;
+  private boolean inCSharpBlockComment;
+  private boolean escapedCSharpStringCharacter;
+  private boolean verbatimCSharpString;
+  private char csharpStringDelimiter;
+  private boolean razorCodeEnabled = true;
 
   public void reset() {
+    reset(true);
+  }
+
+  public void reset(boolean razorCodeEnabled) {
     textConditionalDepth = 0;
     braceBasedTextConditionalDepth = 0;
     pendingConditionalBranchOpenings = 0;
@@ -72,6 +89,16 @@ public final class TemplateConditionalScopeTracker {
     pendingBranchContinuation = false;
     scriptDepth = 0;
     styleDepth = 0;
+    elementDepth = 0;
+    razorCodeBraceDepth = 0;
+    razorCodeBlocks.clear();
+    inRazorComment = false;
+    inCSharpLineComment = false;
+    inCSharpBlockComment = false;
+    escapedCSharpStringCharacter = false;
+    verbatimCSharpString = false;
+    csharpStringDelimiter = '\0';
+    this.razorCodeEnabled = razorCodeEnabled;
   }
 
   public void visitText(TextNode textNode) {
@@ -84,6 +111,9 @@ public final class TemplateConditionalScopeTracker {
   }
 
   public void startElement(TagNode node) {
+    if (isInNonRenderedRazorContent()) {
+      return;
+    }
     flushPendingBranchContinuation();
     if (isJstlConditionalTag(node)) {
       tagConditionalDepth++;
@@ -93,9 +123,13 @@ public final class TemplateConditionalScopeTracker {
     } else if (isStyleTag(node)) {
       styleDepth++;
     }
+    elementDepth++;
   }
 
   public void endElement(TagNode node) {
+    if (isInNonRenderedRazorContent()) {
+      return;
+    }
     if (isJstlConditionalTag(node) && tagConditionalDepth > 0) {
       tagConditionalDepth--;
     }
@@ -104,10 +138,22 @@ public final class TemplateConditionalScopeTracker {
     } else if (isStyleTag(node) && styleDepth > 0) {
       styleDepth--;
     }
+    if (elementDepth > 0) {
+      elementDepth--;
+    }
   }
 
   public boolean isInConditional(TagNode node) {
     return hasOpenConditionalScope() || hasConditionalAttribute(node);
+  }
+
+  /**
+   * Returns whether the current lexer position is inside Razor or C# content that is not rendered.
+   * HTML-like tags in these regions are still emitted by the generic HTML lexer and must be ignored
+   * by checks that reason about rendered elements.
+   */
+  public boolean isInNonRenderedRazorContent() {
+    return inRazorComment || inCSharpLineComment || inCSharpBlockComment || csharpStringDelimiter != '\0';
   }
 
   private boolean hasOpenConditionalScope() {
@@ -123,17 +169,26 @@ public final class TemplateConditionalScopeTracker {
    */
   private void scanFragment(String text, boolean directive) {
     FragmentScanState state = new FragmentScanState();
-    if (!directive) {
-      resolvePendingBranchContinuation(text, state);
-    }
+    boolean resolvePendingInThisFragment = pendingBranchContinuation;
     while (state.index < text.length()) {
+      if (!directive && resolvePendingInThisFragment && pendingBranchContinuation && !isInPersistentRazorComment()) {
+        resolvePendingBranchContinuation(text, state);
+        resolvePendingInThisFragment = false;
+        if (state.index >= text.length()) {
+          break;
+        }
+      }
       boolean fullCode = directive || isScanningConditionalHeader();
       boolean hashComments = fullCode;
       boolean slashComments = fullCode || scriptDepth > 0;
       boolean stringsAndBlockComments = fullCode || scriptDepth > 0 || styleDepth > 0 || nestedTextBlockDepth > 0;
-      if (consumeProtectedCharacter(text, state)
+      if (consumePersistentRazorProtectedCharacter(text, state)
+        || consumePersistentRazorProtectedStart(text, state)
+        || consumeProtectedCharacter(text, state)
         || consumeCommentOrStringStart(text, directive, hashComments, slashComments, stringsAndBlockComments, state)
         || consumeConditionalHeaderCharacter(text, state)
+        || consumeRazorCodeBlockStart(text, state)
+        || consumeCSharpConditionalStart(text, state)
         || consumeConditionalToken(text, directive, state)
         || consumeStructuralToken(text, state)) {
         continue;
@@ -144,6 +199,129 @@ public final class TemplateConditionalScopeTracker {
     if (textConditionalDepth == 0) {
       clearBraceTracking();
     }
+  }
+
+  /**
+   * Continues a Razor comment, C# comment, or C# string across text fragments. The HTML lexer
+   * splits such fragments whenever their contents resemble an HTML tag.
+   */
+  private boolean consumePersistentRazorProtectedCharacter(String text, FragmentScanState state) {
+    if (inRazorComment) {
+      if (startsWith(text, state.index, "*@")) {
+        inRazorComment = false;
+        state.index += 2;
+      } else {
+        state.index++;
+      }
+      return true;
+    }
+    if (inCSharpLineComment) {
+      if (isLineBreak(text.charAt(state.index))) {
+        inCSharpLineComment = false;
+      }
+      state.index++;
+      return true;
+    }
+    if (inCSharpBlockComment) {
+      if (startsWith(text, state.index, "*/")) {
+        inCSharpBlockComment = false;
+        state.index += 2;
+      } else {
+        state.index++;
+      }
+      return true;
+    }
+    if (csharpStringDelimiter != '\0') {
+      char current = text.charAt(state.index);
+      if (verbatimCSharpString && current == csharpStringDelimiter
+        && state.index + 1 < text.length() && text.charAt(state.index + 1) == csharpStringDelimiter) {
+        state.index += 2;
+      } else {
+        if (escapedCSharpStringCharacter) {
+          escapedCSharpStringCharacter = false;
+        } else if (!verbatimCSharpString && current == '\\') {
+          escapedCSharpStringCharacter = true;
+        } else if (current == csharpStringDelimiter) {
+          csharpStringDelimiter = '\0';
+          verbatimCSharpString = false;
+        }
+        state.index++;
+      }
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Starts persistent protected Razor/C# content. C# tokens are recognized only at the markup
+   * depth where the active {@code @{ ... }} block began, not in text rendered by a child element.
+   */
+  private boolean consumePersistentRazorProtectedStart(String text, FragmentScanState state) {
+    if (!razorCodeEnabled) {
+      return false;
+    }
+    if (startsWith(text, state.index, "@*")) {
+      inRazorComment = true;
+      state.index += 2;
+      return true;
+    }
+    if (!isInRazorCodeContext()) {
+      return false;
+    }
+    if (startsWith(text, state.index, "/*")) {
+      inCSharpBlockComment = true;
+      state.index += 2;
+      return true;
+    }
+    if (startsWith(text, state.index, "//")) {
+      inCSharpLineComment = true;
+      state.index += 2;
+      return true;
+    }
+    char current = text.charAt(state.index);
+    if (current == '\'' || current == '"') {
+      csharpStringDelimiter = current;
+      escapedCSharpStringCharacter = false;
+      verbatimCSharpString = current == '"' && state.index > 0 && text.charAt(state.index - 1) == '@';
+      state.index++;
+      return true;
+    }
+    return false;
+  }
+
+  private boolean consumeRazorCodeBlockStart(String text, FragmentScanState state) {
+    if (!razorCodeEnabled || !startsWith(text, state.index, "@{")) {
+      return false;
+    }
+    if (braceBasedTextConditionalDepth > 0) {
+      nestedTextBlockDepth++;
+    }
+    razorCodeBraceDepth++;
+    razorCodeBlocks.push(new RazorCodeBlock(razorCodeBraceDepth, elementDepth));
+    state.index += 2;
+    return true;
+  }
+
+  private boolean consumeCSharpConditionalStart(String text, FragmentScanState state) {
+    if (!isInRazorCodeContext() || !isWordStart(text, state.index)) {
+      return false;
+    }
+    int conditionalStartLength = matchedPrefixLength(CSHARP_BLOCK_START_PATTERN, text, state.index);
+    if (conditionalStartLength == 0) {
+      return false;
+    }
+    textConditionalDepth++;
+    openBraceBasedConditionalInsideHeaderParenthesis();
+    state.index += conditionalStartLength;
+    return true;
+  }
+
+  private boolean isInRazorCodeContext() {
+    return !razorCodeBlocks.isEmpty() && elementDepth == razorCodeBlocks.peek().elementDepth();
+  }
+
+  private boolean isInPersistentRazorComment() {
+    return inRazorComment || inCSharpLineComment || inCSharpBlockComment;
   }
 
   /**
@@ -373,6 +551,9 @@ public final class TemplateConditionalScopeTracker {
     } else if (braceBasedTextConditionalDepth > 0) {
       nestedTextBlockDepth++;
     }
+    if (!razorCodeBlocks.isEmpty()) {
+      razorCodeBraceDepth++;
+    }
     state.index++;
     return true;
   }
@@ -387,11 +568,23 @@ public final class TemplateConditionalScopeTracker {
     if (nestedTextBlockDepth > 0) {
       nestedTextBlockDepth--;
     } else if (continueBraceBasedConditional(text, state)) {
+      closeRazorCodeBrace();
       return;
     } else if (!deferBranchContinuation(text, state)) {
       closeBraceBasedConditional();
     }
+    closeRazorCodeBrace();
     state.index++;
+  }
+
+  private void closeRazorCodeBrace() {
+    if (razorCodeBlocks.isEmpty()) {
+      return;
+    }
+    if (razorCodeBlocks.peek().openingBraceDepth() == razorCodeBraceDepth) {
+      razorCodeBlocks.pop();
+    }
+    razorCodeBraceDepth--;
   }
 
   /**
@@ -422,7 +615,7 @@ public final class TemplateConditionalScopeTracker {
       return;
     }
     pendingBranchContinuation = false;
-    int continuationIndex = conditionalContinuationEndIndex(text, -1);
+    int continuationIndex = conditionalContinuationEndIndex(text, state.index - 1);
     if (continuationIndex >= 0) {
       pendingConditionalBranchOpenings++;
       state.index = continuationIndex;
@@ -727,6 +920,11 @@ public final class TemplateConditionalScopeTracker {
       || (!Character.isLetterOrDigit(text.charAt(index)) && text.charAt(index) != '_');
   }
 
+  private static boolean isWordStart(String text, int index) {
+    return index == 0
+      || (!Character.isLetterOrDigit(text.charAt(index - 1)) && text.charAt(index - 1) != '_');
+  }
+
   private static int skipLeadingTrivia(String text, int index) {
     int current = index;
     boolean advanced = true;
@@ -840,6 +1038,9 @@ public final class TemplateConditionalScopeTracker {
     private FragmentScanState(int index) {
       this.index = index;
     }
+  }
+
+  private record RazorCodeBlock(int openingBraceDepth, int elementDepth) {
   }
 
   private static boolean isLineBreak(char character) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -22,6 +22,7 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.annotation.Nullable;
 import org.sonar.plugins.html.node.DirectiveNode;
 import org.sonar.plugins.html.node.TagNode;
 import org.sonar.plugins.html.node.TextNode;
@@ -142,7 +143,7 @@ public final class TemplateConditionalScopeTracker {
     closeElement(node);
   }
 
-  private void synchronizeOpenElements(TagNode parent) {
+  private void synchronizeOpenElements(@Nullable TagNode parent) {
     if (parent == null) {
       closeAllOpenElements();
     } else if (openElements.contains(parent)) {
@@ -154,7 +155,7 @@ public final class TemplateConditionalScopeTracker {
   }
 
   private void closeElement(TagNode node) {
-    if (!openElements.stream().anyMatch(openElement -> matchesClosingElement(openElement, node))) {
+    if (openElements.stream().noneMatch(openElement -> matchesClosingElement(openElement, node))) {
       return;
     }
     TagNode closedElement;
@@ -196,7 +197,7 @@ public final class TemplateConditionalScopeTracker {
 
   private static boolean matchesClosingElement(TagNode openElement, TagNode closingElement) {
     return closingElement.hasEnd()
-      ? openElement == closingElement
+      ? (openElement == closingElement)
       : openElement.equalsElementName(closingElement.getNodeName());
   }
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -78,6 +78,11 @@ public final class TemplateConditionalScopeTracker {
   private boolean inCSharpBlockComment;
   private boolean escapedCSharpStringCharacter;
   private boolean verbatimCSharpString;
+  private boolean interpolatedCSharpString;
+  private int csharpInterpolationBraceDepth;
+  private char csharpInterpolationStringDelimiter;
+  private boolean escapedCSharpInterpolationStringCharacter;
+  private boolean verbatimCSharpInterpolationString;
   private int csharpRawStringQuoteCount;
   private char csharpStringDelimiter;
   private char csharpGenericTypeOwnerInitial;
@@ -372,12 +377,61 @@ public final class TemplateConditionalScopeTracker {
       consumeCSharpRawStringCharacter(text, state);
       return;
     }
+    if (csharpInterpolationBraceDepth > 0) {
+      consumeCSharpInterpolationCharacter(text, state);
+      return;
+    }
     char current = text.charAt(state.index);
+    if (interpolatedCSharpString && current == '{') {
+      if (startsWith(text, state.index, "{{")) {
+        state.index += 2;
+      } else {
+        csharpInterpolationBraceDepth++;
+        state.index++;
+      }
+      return;
+    }
     if (isEscapedVerbatimQuote(text, state, current)) {
       state.index += 2;
       return;
     }
     updateCSharpStringState(current);
+    state.index++;
+  }
+
+  private void consumeCSharpInterpolationCharacter(String text, FragmentScanState state) {
+    char current = text.charAt(state.index);
+    if (csharpInterpolationStringDelimiter != '\0') {
+      consumeCSharpInterpolationStringCharacter(text, state, current);
+    } else if (current == '\'' || current == '"') {
+      csharpInterpolationStringDelimiter = current;
+      escapedCSharpInterpolationStringCharacter = false;
+      verbatimCSharpInterpolationString = current == '"' && hasVerbatimPrefix(text, state.index);
+      state.index++;
+    } else {
+      if (current == '{') {
+        csharpInterpolationBraceDepth++;
+      } else if (current == '}') {
+        csharpInterpolationBraceDepth--;
+      }
+      state.index++;
+    }
+  }
+
+  private void consumeCSharpInterpolationStringCharacter(String text, FragmentScanState state, char current) {
+    if (verbatimCSharpInterpolationString && current == csharpInterpolationStringDelimiter
+      && state.index + 1 < text.length() && text.charAt(state.index + 1) == csharpInterpolationStringDelimiter) {
+      state.index += 2;
+      return;
+    }
+    if (escapedCSharpInterpolationStringCharacter) {
+      escapedCSharpInterpolationStringCharacter = false;
+    } else if (!verbatimCSharpInterpolationString && current == '\\') {
+      escapedCSharpInterpolationStringCharacter = true;
+    } else if (current == csharpInterpolationStringDelimiter) {
+      csharpInterpolationStringDelimiter = '\0';
+      verbatimCSharpInterpolationString = false;
+    }
     state.index++;
   }
 
@@ -405,6 +459,7 @@ public final class TemplateConditionalScopeTracker {
     } else if (current == csharpStringDelimiter) {
       csharpStringDelimiter = '\0';
       verbatimCSharpString = false;
+      interpolatedCSharpString = false;
     }
   }
 
@@ -445,6 +500,7 @@ public final class TemplateConditionalScopeTracker {
       csharpRawStringQuoteCount = quoteCount;
       escapedCSharpStringCharacter = false;
       verbatimCSharpString = false;
+      interpolatedCSharpString = false;
       state.index += quoteCount;
       return true;
     }
@@ -453,6 +509,7 @@ public final class TemplateConditionalScopeTracker {
       csharpRawStringQuoteCount = 0;
       escapedCSharpStringCharacter = false;
       verbatimCSharpString = current == '"' && hasVerbatimPrefix(text, state.index);
+      interpolatedCSharpString = current == '"' && hasInterpolatedPrefix(text, state.index);
       state.index++;
       return true;
     }
@@ -542,6 +599,17 @@ public final class TemplateConditionalScopeTracker {
     int index = quoteIndex - 1;
     while (index >= 0 && isCSharpStringPrefix(text.charAt(index))) {
       if (text.charAt(index) == '@') {
+        return true;
+      }
+      index--;
+    }
+    return false;
+  }
+
+  private static boolean hasInterpolatedPrefix(String text, int quoteIndex) {
+    int index = quoteIndex - 1;
+    while (index >= 0 && isCSharpStringPrefix(text.charAt(index))) {
+      if (text.charAt(index) == '$') {
         return true;
       }
       index--;
@@ -805,7 +873,7 @@ public final class TemplateConditionalScopeTracker {
    */
   private void consumeClosingBrace(String text, FragmentScanState state) {
     boolean inRazorCodeContext = isInRazorCodeContext();
-    if (consumeRenderedMarkupClosingBrace(state, inRazorCodeContext)) {
+    if (consumeRenderedMarkupClosingBrace(text, state, inRazorCodeContext)) {
       return;
     }
     if (inRazorCodeContext && !conditionalBraces.isEmpty() && nestedTextBlockDepth == 0
@@ -824,7 +892,7 @@ public final class TemplateConditionalScopeTracker {
     state.index++;
   }
 
-  private boolean consumeRenderedMarkupClosingBrace(FragmentScanState state, boolean inRazorCodeContext) {
+  private boolean consumeRenderedMarkupClosingBrace(String text, FragmentScanState state, boolean inRazorCodeContext) {
     if (razorCodeBlocks.isEmpty() || inRazorCodeContext) {
       return false;
     }
@@ -834,7 +902,8 @@ public final class TemplateConditionalScopeTracker {
     } else if (!conditionalBraces.isEmpty() && conditionalBraces.peek().elementDepth() == elementDepth) {
       conditionalBraces.pop();
       return false;
-    } else if (!conditionalBraces.isEmpty() && conditionalBraces.peek().elementDepth() < elementDepth) {
+    } else if (!conditionalBraces.isEmpty() && conditionalBraces.peek().elementDepth() < elementDepth
+      && skipLeadingTrivia(text, state.index + 1) >= text.length()) {
       pendingRenderedClosingBraceDepth = elementDepth;
     }
     state.index++;
@@ -864,6 +933,11 @@ public final class TemplateConditionalScopeTracker {
     inCSharpBlockComment = false;
     escapedCSharpStringCharacter = false;
     verbatimCSharpString = false;
+    interpolatedCSharpString = false;
+    csharpInterpolationBraceDepth = 0;
+    csharpInterpolationStringDelimiter = '\0';
+    escapedCSharpInterpolationStringCharacter = false;
+    verbatimCSharpInterpolationString = false;
     csharpRawStringQuoteCount = 0;
     csharpStringDelimiter = '\0';
   }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/TemplateConditionalScopeTracker.java
@@ -383,7 +383,7 @@ public final class TemplateConditionalScopeTracker {
   private void consumeCSharpRawStringCharacter(String text, FragmentScanState state) {
     int quoteCount = consecutiveQuoteCount(text, state.index);
     if (quoteCount >= csharpRawStringQuoteCount) {
-      state.index += csharpRawStringQuoteCount;
+      state.index += quoteCount;
       csharpRawStringQuoteCount = 0;
       csharpStringDelimiter = '\0';
     } else {
@@ -488,6 +488,7 @@ public final class TemplateConditionalScopeTracker {
   private boolean isCSharpGenericTypeArgument(TagNode node) {
     return csharpGenericTypeArgumentExpected
       && isInRazorCodeContext()
+      && !HtmlConstants.hasKnownHTMLTag(node)
       && CSHARP_GENERIC_ARGUMENT_PATTERN.matcher(node.getCode()).matches();
   }
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheck.java
@@ -48,7 +48,7 @@ public class NoDuplicateIDCheck extends AbstractPageCheck {
   @Override
   public void startDocument(List<Node> nodes) {
     unconditionalIds.clear();
-    conditionalScope.reset();
+    conditionalScope.reset(Helpers.isRazorFile(getHtmlSourceCode()));
   }
 
   @Override
@@ -73,6 +73,9 @@ public class NoDuplicateIDCheck extends AbstractPageCheck {
   }
 
   private void handleIdAttribute(TagNode node) {
+    if (conditionalScope.isInNonRenderedRazorContent()) {
+      return;
+    }
     String idValue = node.getAttribute("id");
     if (shouldIgnoreId(idValue)) {
       return;

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/PageLexer.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/PageLexer.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import org.sonar.plugins.html.api.HtmlConstants;
 import org.sonar.plugins.html.node.Node;
 import org.sonar.plugins.html.node.NodeType;
 import org.sonar.plugins.html.node.TagNode;
@@ -68,13 +69,6 @@ public class PageLexer {
     new NormalElementTokenizer(),
     /* Text (for everything else) */
     new TextTokenizer());
-
-  /**
-   * Void elements can't have any content
-   * See https://html.spec.whatwg.org/multipage/syntax.html#void-elements
-   */
-  static final Set<String> VOID_ELEMENTS = new HashSet<>(Arrays.asList("area", "base", "br", "col", "embed",
-    "hr", "img", "input", "link", "meta", "param", "source", "track", "wbr"));
 
   private static final Set<String> METADATA_CONTENT = new HashSet<>(Arrays.asList("base", "link", "meta", "noscript",
     "script", "style", "template", "title"));
@@ -195,7 +189,7 @@ public class PageLexer {
   }
 
   private static boolean isVoidElement(TagNode parent) {
-    return VOID_ELEMENTS.contains(nodeName(parent));
+    return HtmlConstants.VOID_ELEMENTS.contains(nodeName(parent));
   }
 
   private static boolean isHtmlElement(TagNode parent) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/PhpEmbeddedHtmlExtractor.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/lex/PhpEmbeddedHtmlExtractor.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.sonar.plugins.html.api.HtmlConstants;
 import org.sonar.plugins.html.node.Attribute;
 import org.sonar.plugins.html.node.DirectiveNode;
 import org.sonar.plugins.html.node.Node;
@@ -631,7 +632,7 @@ final class PhpEmbeddedHtmlExtractor {
   }
 
   private static boolean isVoidElement(TagNode tag) {
-    return PageLexer.VOID_ELEMENTS.contains(tag.getNodeName().toLowerCase(Locale.ROOT));
+    return HtmlConstants.VOID_ELEMENTS.contains(tag.getNodeName().toLowerCase(Locale.ROOT));
   }
 
   private static TagNode syntheticEndTag(TagNode open) {

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
@@ -123,6 +123,32 @@ class TemplateConditionalScopeTrackerTest {
   }
 
   @Test
+  void tracks_plain_csharp_conditionals_inside_razor_code_blocks() {
+    List<Node> nodes = parse("""
+      @{
+        if (Model.ShowPrimary)
+        {
+          <div id="choice">First</div>
+        }
+        else if (Model.ShowSecondary)
+        {
+          <div id="choice">Second</div>
+        }
+        else
+        {
+          <div id="choice">Fallback</div>
+        }
+      }
+      <div id="footer">Footer</div>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 4)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 8)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 12)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 15)).isFalse();
+  }
+
+  @Test
   void tracks_jstl_conditional_tags() {
     List<Node> nodes = parse("""
       <c:if test="${cond}">

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
@@ -339,6 +339,60 @@ class TemplateConditionalScopeTrackerTest {
   }
 
   @Test
+  void does_not_start_explicit_razor_text_inside_csharp_line_comments() {
+    List<Node> nodes = parse("""
+      @{
+        // Use @: for explicit Razor text.
+        if (Model.ShowPrimary) {
+          <div id="choice">First</div>
+        } else {
+          <div id="choice">Second</div>
+        }
+      }
+      <div id="footer">Footer</div>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 4)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 6)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 9)).isFalse();
+  }
+
+  @Test
+  void does_not_start_explicit_razor_text_inside_csharp_strings() {
+    List<Node> nodes = parse("""
+      @{
+        var marker = "a@:b";
+        if (Model.ShowPrimary) {
+          <div id="choice">First</div>
+        } else {
+          <div id="choice">Second</div>
+        }
+      }
+      <div id="footer">Footer</div>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 4)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 6)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 9)).isFalse();
+  }
+
+  @Test
+  void closes_csharp_conditionals_when_branch_markup_is_left_open() {
+    List<Node> nodes = parse("""
+      @{
+        if (Model.ShowPrimary) {
+          <div id="choice">First }
+      }
+      <div id="duplicate">First</div>
+      <div id="duplicate">Second</div>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 3)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 5)).isFalse();
+    assertThat(isConditionalAtLine(nodes, "div", 6)).isFalse();
+  }
+
+  @Test
   void requires_razor_code_tracking_to_be_enabled_explicitly() {
     List<Node> nodes = parse("""
       @{

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
@@ -168,6 +168,48 @@ class TemplateConditionalScopeTrackerTest {
   }
 
   @Test
+  void tracks_plain_csharp_conditionals_after_omitted_end_tags() {
+    List<Node> nodes = parse("""
+      @{
+        <ul>
+          <li>First
+          <li>Second
+        </ul>
+        if (Model.ShowPrimary) {
+          <div id="choice">First</div>
+        } else {
+          <div id="choice">Second</div>
+        }
+      }
+      <div id="footer">Footer</div>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 7)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 9)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 12)).isFalse();
+  }
+
+  @Test
+  void does_not_parse_csharp_after_orphan_closing_tags_in_markup() {
+    List<Node> nodes = parse("""
+      <section>
+        @{
+          <article>
+          </div>
+          if (rendered) {
+            <div id="duplicate">First</div>
+            <div id="duplicate">Second</div>
+          }
+          </article>
+        }
+      </section>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 6)).isFalse();
+    assertThat(isConditionalAtLine(nodes, "div", 7)).isFalse();
+  }
+
+  @Test
   void tracks_plain_csharp_conditionals_after_unmatched_comment_tags() {
     List<Node> nodes = parse("""
       <section>
@@ -225,6 +267,25 @@ class TemplateConditionalScopeTrackerTest {
   }
 
   @Test
+  void ignores_unmatched_closing_braces_in_rendered_razor_markup() {
+    List<Node> nodes = parse("""
+      @{
+        if (Model.ShowPrimary) {
+          <code>}</code>
+          <div id="choice">First</div>
+        } else {
+          <div id="choice">Second</div>
+        }
+      }
+      <div id="footer">Footer</div>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 4)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 6)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 9)).isFalse();
+  }
+
+  @Test
   void tracks_nested_razor_conditionals_in_rendered_markup() {
     List<Node> nodes = parse("""
       @{
@@ -264,6 +325,35 @@ class TemplateConditionalScopeTrackerTest {
   }
 
   @Test
+  void treats_explicit_razor_text_as_rendered_content() {
+    List<Node> nodes = parse("""
+      @{
+        @:if (rendered) {
+        <div id="duplicate">First</div>
+        <div id="duplicate">Second</div>
+      }
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 3)).isFalse();
+    assertThat(isConditionalAtLine(nodes, "div", 4)).isFalse();
+  }
+
+  @Test
+  void requires_razor_code_tracking_to_be_enabled_explicitly() {
+    List<Node> nodes = parse("""
+      @{
+        if (Model.ShowPrimary) {
+          <div id="choice">First</div>
+        }
+      }
+      """);
+    TemplateConditionalScopeTracker tracker = new TemplateConditionalScopeTracker();
+    tracker.reset();
+
+    assertThat(isConditional(nodes, findTag(nodes, "div", 3), tracker)).isFalse();
+  }
+
+  @Test
   void tracks_jstl_conditional_tags() {
     List<Node> nodes = parse("""
       <c:if test="${cond}">
@@ -299,6 +389,11 @@ class TemplateConditionalScopeTrackerTest {
 
   private static boolean isConditional(List<Node> nodes, TagNode target) {
     TemplateConditionalScopeTracker tracker = new TemplateConditionalScopeTracker();
+    tracker.reset(true);
+    return isConditional(nodes, target, tracker);
+  }
+
+  private static boolean isConditional(List<Node> nodes, TagNode target, TemplateConditionalScopeTracker tracker) {
     for (Node node : nodes) {
       if (node instanceof TextNode textNode) {
         tracker.visitText(textNode);
@@ -312,6 +407,9 @@ class TemplateConditionalScopeTrackerTest {
           if (tagNode == target) {
             return tracker.isInConditional(tagNode);
           }
+          if (tagNode.hasEnd()) {
+            tracker.endElement(tagNode);
+          }
         }
       }
     }
@@ -320,6 +418,7 @@ class TemplateConditionalScopeTrackerTest {
 
   private static TemplateConditionalScopeTracker scan(List<Node> nodes) {
     TemplateConditionalScopeTracker tracker = new TemplateConditionalScopeTracker();
+    tracker.reset(true);
     for (Node node : nodes) {
       if (node instanceof TextNode textNode) {
         tracker.visitText(textNode);
@@ -330,6 +429,9 @@ class TemplateConditionalScopeTrackerTest {
           tracker.endElement(tagNode);
         } else {
           tracker.startElement(tagNode);
+          if (tagNode.hasEnd()) {
+            tracker.endElement(tagNode);
+          }
         }
       }
     }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
@@ -210,6 +210,24 @@ class TemplateConditionalScopeTrackerTest {
   }
 
   @Test
+  void follows_lexer_hierarchy_when_malformed_markup_contains_custom_elements() {
+    List<Node> nodes = parse("""
+      @{
+        <div>
+          <my-widget>
+        </div>
+        if (rendered) {
+          <span id="duplicate">First</span>
+          <span id="duplicate">Second</span>
+        }
+      }
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "span", 6)).isFalse();
+    assertThat(isConditionalAtLine(nodes, "span", 7)).isFalse();
+  }
+
+  @Test
   void tracks_plain_csharp_conditionals_after_unmatched_comment_tags() {
     List<Node> nodes = parse("""
       <section>
@@ -322,6 +340,44 @@ class TemplateConditionalScopeTrackerTest {
     assertThat(isConditionalAtLine(nodes, "div", 4)).isTrue();
     assertThat(isConditionalAtLine(nodes, "div", 6)).isTrue();
     assertThat(isConditionalAtLine(nodes, "div", 9)).isFalse();
+  }
+
+  @Test
+  void tracks_plain_csharp_conditionals_after_generic_type_arguments() {
+    List<Node> nodes = parse("""
+      @{
+        var items = new List<string>();
+        if (Model.ShowPrimary) {
+          <div id="choice">First</div>
+        } else {
+          <div id="choice">Second</div>
+        }
+      }
+      <div id="footer">Footer</div>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 4)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 6)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 9)).isFalse();
+  }
+
+  @Test
+  void tracks_plain_csharp_conditionals_after_raw_strings() {
+    List<Node> nodes = parse(
+      "@{\n"
+        + "  var markup = \"\"\"a \" <div id=\"not-rendered\">Text</div>\"\"\";\n"
+        + "  if (Model.ShowPrimary) {\n"
+        + "    <div id=\"choice\">First</div>\n"
+        + "  } else {\n"
+        + "    <div id=\"choice\">Second</div>\n"
+        + "  }\n"
+        + "}\n"
+        + "<div id=\"footer\">Footer</div>\n");
+
+    assertThat(isConditionalAtLine(nodes, "div", 4)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 6)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 9)).isFalse();
+    assertThat(scan(nodes).isInNonRenderedRazorContent()).isFalse();
   }
 
   @Test

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
@@ -149,6 +149,112 @@ class TemplateConditionalScopeTrackerTest {
   }
 
   @Test
+  void tracks_plain_csharp_conditionals_after_void_elements() {
+    List<Node> nodes = parse("""
+      @{
+        <input id="filter" type="text">
+        if (Model.ShowPrimary) {
+          <div id="choice">First</div>
+        } else {
+          <div id="choice">Second</div>
+        }
+      }
+      <div id="footer">Footer</div>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 4)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 6)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 9)).isFalse();
+  }
+
+  @Test
+  void tracks_plain_csharp_conditionals_after_unmatched_comment_tags() {
+    List<Node> nodes = parse("""
+      <section>
+        @{
+          // <div id="not-rendered">
+          </div>
+          if (Model.ShowPrimary) {
+            <div id="choice">First</div>
+          } else {
+            <div id="choice">Second</div>
+          }
+        }
+      </section>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 6)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 8)).isTrue();
+  }
+
+  @Test
+  void ignores_unbalanced_braces_in_rendered_razor_markup() {
+    List<Node> nodes = parse("""
+      @{
+        if (Model.ShowPrimary) {
+          <code>if (x) {</code>
+          <div id="choice">First</div>
+        }
+      }
+      Ordinary "quoted text
+      <div id="footer">Footer</div>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 4)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 8)).isFalse();
+    assertThat(scan(nodes).isInNonRenderedRazorContent()).isFalse();
+  }
+
+  @Test
+  void tracks_nested_razor_conditionals_in_rendered_markup() {
+    List<Node> nodes = parse("""
+      @{
+        <section>
+          @if (Model.ShowPrimary) {
+            <div id="choice">First</div>
+          } else {
+            <div id="choice">Second</div>
+          }
+        </section>
+      }
+      <div id="footer">Footer</div>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 4)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 6)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 10)).isFalse();
+  }
+
+  @Test
+  void tracks_plain_csharp_conditionals_after_interpolated_verbatim_strings() {
+    List<Node> nodes = parse("""
+      @{
+        var message = @$"He said ""hi"" }";
+        if (Model.ShowPrimary) {
+          <div id="choice">First</div>
+        } else {
+          <div id="choice">Second</div>
+        }
+      }
+      <div id="footer">Footer</div>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 4)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 6)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 9)).isFalse();
+  }
+
+  @Test
+  void recognizes_verbatim_string_prefix_across_fragments() {
+    TemplateConditionalScopeTracker tracker = new TemplateConditionalScopeTracker();
+
+    tracker.visitText(textNode("@{ var message = @$"));
+    tracker.visitText(textNode("\"He said \"\"hi\"\" }\"; if (Model.ShowPrimary) {"));
+
+    assertThat(tracker.isInConditional(new TagNode())).isTrue();
+  }
+
+  @Test
   void tracks_jstl_conditional_tags() {
     List<Node> nodes = parse("""
       <c:if test="${cond}">
@@ -178,6 +284,12 @@ class TemplateConditionalScopeTrackerTest {
     return new PageLexer().parse(new StringReader(content));
   }
 
+  private static TextNode textNode(String content) {
+    TextNode node = new TextNode();
+    node.setCode(content);
+    return node;
+  }
+
   private static boolean isConditionalAtLine(List<Node> nodes, String tagName, int startLine) {
     return isConditional(nodes, findTag(nodes, tagName, startLine));
   }
@@ -201,6 +313,24 @@ class TemplateConditionalScopeTrackerTest {
       }
     }
     throw new IllegalArgumentException("Target tag was not encountered during scan");
+  }
+
+  private static TemplateConditionalScopeTracker scan(List<Node> nodes) {
+    TemplateConditionalScopeTracker tracker = new TemplateConditionalScopeTracker();
+    for (Node node : nodes) {
+      if (node instanceof TextNode textNode) {
+        tracker.visitText(textNode);
+      } else if (node instanceof DirectiveNode directiveNode) {
+        tracker.visitDirective(directiveNode);
+      } else if (node instanceof TagNode tagNode) {
+        if (tagNode.isEndElement()) {
+          tracker.endElement(tagNode);
+        } else {
+          tracker.startElement(tagNode);
+        }
+      }
+    }
+    return tracker;
   }
 
   private static TagNode findTag(List<Node> nodes, String tagName, int startLine) {

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
@@ -347,6 +347,7 @@ class TemplateConditionalScopeTrackerTest {
     List<Node> nodes = parse("""
       @{
         var items = new List<string>();
+        var objects = new List<object>();
         if (Model.ShowPrimary) {
           <div id="choice">First</div>
         } else {
@@ -356,9 +357,9 @@ class TemplateConditionalScopeTrackerTest {
       <div id="footer">Footer</div>
       """);
 
-    assertThat(isConditionalAtLine(nodes, "div", 4)).isTrue();
-    assertThat(isConditionalAtLine(nodes, "div", 6)).isTrue();
-    assertThat(isConditionalAtLine(nodes, "div", 9)).isFalse();
+    assertThat(isConditionalAtLine(nodes, "div", 5)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 7)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 10)).isFalse();
   }
 
   @Test
@@ -403,6 +404,26 @@ class TemplateConditionalScopeTrackerTest {
     List<Node> nodes = parse("""
       @{
         var message = \"\"\"He said \"hi\"\"\"\";
+        if (Model.ShowPrimary) {
+          <div id="choice">First</div>
+        } else {
+          <div id="choice">Second</div>
+        }
+      }
+      <div id="footer">Footer</div>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 4)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 6)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 9)).isFalse();
+    assertThat(scan(nodes).isInNonRenderedRazorContent()).isFalse();
+  }
+
+  @Test
+  void recognizes_empty_raw_strings() {
+    List<Node> nodes = parse("""
+      @{
+        var value = \"\"\"\"\"\";
         if (Model.ShowPrimary) {
           <div id="choice">First</div>
         } else {

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
@@ -326,6 +326,27 @@ class TemplateConditionalScopeTrackerTest {
   }
 
   @Test
+  void closes_rendered_csharp_branches_before_trailing_else_content() {
+    List<Node> nodes = parse("""
+      @{
+        if (Model.ShowPrimary) {
+          <div id="choice">First
+        } else {
+          <div id="choice">Second</div>
+        }
+      }
+      </div>
+      Ordinary "quoted text
+      <div id="footer">Footer</div>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 3)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 5)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 10)).isFalse();
+    assertThat(scan(nodes).isInNonRenderedRazorContent()).isFalse();
+  }
+
+  @Test
   void tracks_nested_razor_conditionals_in_rendered_markup() {
     List<Node> nodes = parse("""
       @{
@@ -369,6 +390,44 @@ class TemplateConditionalScopeTrackerTest {
     List<Node> nodes = parse("""
       @{
         var marker = $"{(true ? "}" : "{")}";
+        if (Model.ShowPrimary) {
+          <div id="choice">First</div>
+        } else {
+          <div id="choice">Second</div>
+        }
+      }
+      <div id="footer">Footer</div>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 4)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 6)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 9)).isFalse();
+  }
+
+  @Test
+  void tracks_plain_csharp_conditionals_after_nested_interpolated_strings() {
+    List<Node> nodes = parse("""
+      @{
+        var marker = $"{$"{(true ? "}" : "")}"}";
+        if (Model.ShowPrimary) {
+          <div id="choice">First</div>
+        } else {
+          <div id="choice">Second</div>
+        }
+      }
+      <div id="footer">Footer</div>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 4)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 6)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 9)).isFalse();
+  }
+
+  @Test
+  void tracks_plain_csharp_conditionals_after_nested_strings_in_verbatim_interpolation_holes() {
+    List<Node> nodes = parse("""
+      @{
+        var marker = $@"{(true ? ""}"" : "")}";
         if (Model.ShowPrimary) {
           <div id="choice">First</div>
         } else {

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
@@ -347,6 +347,31 @@ class TemplateConditionalScopeTrackerTest {
   }
 
   @Test
+  void does_not_use_literal_markup_braces_as_pending_razor_code_block_closings() {
+    List<Node> nodes = parse("""
+      @{
+        if (Model.ShowPrimary) {
+          <div>First
+        } else {
+          <div>Second</div>
+        }
+        </div>
+        <p>literal { brace }</p>
+        if (Model.ShowDetails) {
+          <div id="choice">Details</div>
+        } else {
+          <div id="choice">Summary</div>
+        }
+      }
+      <div id="footer">Footer</div>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 10)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 12)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 15)).isFalse();
+  }
+
+  @Test
   void tracks_nested_razor_conditionals_in_rendered_markup() {
     List<Node> nodes = parse("""
       @{

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
@@ -362,10 +362,47 @@ class TemplateConditionalScopeTrackerTest {
   }
 
   @Test
+  void does_not_treat_known_html_elements_as_generic_type_arguments() {
+    List<Node> nodes = parse("""
+      @{
+        label<div>
+          if (rendered) {
+            <span id="duplicate">First</span>
+            <span id="duplicate">Second</span>
+          }
+        </div>
+      }
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "span", 4)).isFalse();
+    assertThat(isConditionalAtLine(nodes, "span", 5)).isFalse();
+  }
+
+  @Test
   void tracks_plain_csharp_conditionals_after_raw_strings() {
     List<Node> nodes = parse("""
       @{
         var markup = \"""a " <div id="not-rendered">Text</div>\""";
+        if (Model.ShowPrimary) {
+          <div id="choice">First</div>
+        } else {
+          <div id="choice">Second</div>
+        }
+      }
+      <div id="footer">Footer</div>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 4)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 6)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 9)).isFalse();
+    assertThat(scan(nodes).isInNonRenderedRazorContent()).isFalse();
+  }
+
+  @Test
+  void consumes_complete_raw_string_terminating_quote_run() {
+    List<Node> nodes = parse("""
+      @{
+        var message = \"\"\"He said \"hi\"\"\"\";
         if (Model.ShowPrimary) {
           <div id="choice">First</div>
         } else {

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
@@ -306,6 +306,26 @@ class TemplateConditionalScopeTrackerTest {
   }
 
   @Test
+  void ignores_literal_closing_braces_before_child_elements_in_rendered_razor_markup() {
+    List<Node> nodes = parse("""
+      @{
+        @if (Model.ShowPrimary) {
+          <div>Total is 100} percent
+            <span id="choice">First</span>
+          </div>
+        } else {
+          <span id="choice">Second</span>
+        }
+      }
+      <div id="footer">Footer</div>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "span", 4)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "span", 7)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 10)).isFalse();
+  }
+
+  @Test
   void tracks_nested_razor_conditionals_in_rendered_markup() {
     List<Node> nodes = parse("""
       @{
@@ -330,6 +350,25 @@ class TemplateConditionalScopeTrackerTest {
     List<Node> nodes = parse("""
       @{
         var message = @$"He said ""hi"" }";
+        if (Model.ShowPrimary) {
+          <div id="choice">First</div>
+        } else {
+          <div id="choice">Second</div>
+        }
+      }
+      <div id="footer">Footer</div>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 4)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 6)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 9)).isFalse();
+  }
+
+  @Test
+  void tracks_plain_csharp_conditionals_after_interpolated_strings_with_nested_strings() {
+    List<Node> nodes = parse("""
+      @{
+        var marker = $"{(true ? "}" : "{")}";
         if (Model.ShowPrimary) {
           <div id="choice">First</div>
         } else {

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
@@ -206,6 +206,25 @@ class TemplateConditionalScopeTrackerTest {
   }
 
   @Test
+  void ignores_balanced_braces_in_rendered_razor_markup() {
+    List<Node> nodes = parse("""
+      @{
+        if (Model.ShowPrimary) {
+          <script>function value() { return 1; }</script>
+          <div id="choice">First</div>
+        } else {
+          <div id="choice">Second</div>
+        }
+      }
+      <div id="footer">Footer</div>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 4)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 6)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 9)).isFalse();
+  }
+
+  @Test
   void tracks_nested_razor_conditionals_in_rendered_markup() {
     List<Node> nodes = parse("""
       @{
@@ -245,16 +264,6 @@ class TemplateConditionalScopeTrackerTest {
   }
 
   @Test
-  void recognizes_verbatim_string_prefix_across_fragments() {
-    TemplateConditionalScopeTracker tracker = new TemplateConditionalScopeTracker();
-
-    tracker.visitText(textNode("@{ var message = @$"));
-    tracker.visitText(textNode("\"He said \"\"hi\"\" }\"; if (Model.ShowPrimary) {"));
-
-    assertThat(tracker.isInConditional(new TagNode())).isTrue();
-  }
-
-  @Test
   void tracks_jstl_conditional_tags() {
     List<Node> nodes = parse("""
       <c:if test="${cond}">
@@ -282,12 +291,6 @@ class TemplateConditionalScopeTrackerTest {
 
   private static List<Node> parse(String content) {
     return new PageLexer().parse(new StringReader(content));
-  }
-
-  private static TextNode textNode(String content) {
-    TextNode node = new TextNode();
-    node.setCode(content);
-    return node;
   }
 
   private static boolean isConditionalAtLine(List<Node> nodes, String tagName, int startLine) {

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
@@ -363,16 +363,17 @@ class TemplateConditionalScopeTrackerTest {
 
   @Test
   void tracks_plain_csharp_conditionals_after_raw_strings() {
-    List<Node> nodes = parse(
-      "@{\n"
-        + "  var markup = \"\"\"a \" <div id=\"not-rendered\">Text</div>\"\"\";\n"
-        + "  if (Model.ShowPrimary) {\n"
-        + "    <div id=\"choice\">First</div>\n"
-        + "  } else {\n"
-        + "    <div id=\"choice\">Second</div>\n"
-        + "  }\n"
-        + "}\n"
-        + "<div id=\"footer\">Footer</div>\n");
+    List<Node> nodes = parse("""
+      @{
+        var markup = \"""a " <div id="not-rendered">Text</div>\""";
+        if (Model.ShowPrimary) {
+          <div id="choice">First</div>
+        } else {
+          <div id="choice">Second</div>
+        }
+      }
+      <div id="footer">Footer</div>
+      """);
 
     assertThat(isConditionalAtLine(nodes, "div", 4)).isTrue();
     assertThat(isConditionalAtLine(nodes, "div", 6)).isTrue();

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
@@ -21,6 +21,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.StringReader;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.sonar.plugins.html.lex.PageLexer;
 import org.sonar.plugins.html.node.DirectiveNode;
 import org.sonar.plugins.html.node.Node;
@@ -379,11 +381,16 @@ class TemplateConditionalScopeTrackerTest {
     assertThat(isConditionalAtLine(nodes, "span", 5)).isFalse();
   }
 
-  @Test
-  void tracks_plain_csharp_conditionals_after_raw_strings() {
+  @ParameterizedTest
+  @ValueSource(strings = {
+    "var markup = \"\"\"a \" <div id=\"not-rendered\">Text</div>\"\"\";",
+    "var message = \"\"\"He said \"hi\"\"\"\";",
+    "var value = \"\"\"\"\"\";"
+  })
+  void tracks_plain_csharp_conditionals_after_raw_strings(String declaration) {
     List<Node> nodes = parse("""
       @{
-        var markup = \"""a " <div id="not-rendered">Text</div>\""";
+        %s
         if (Model.ShowPrimary) {
           <div id="choice">First</div>
         } else {
@@ -391,47 +398,7 @@ class TemplateConditionalScopeTrackerTest {
         }
       }
       <div id="footer">Footer</div>
-      """);
-
-    assertThat(isConditionalAtLine(nodes, "div", 4)).isTrue();
-    assertThat(isConditionalAtLine(nodes, "div", 6)).isTrue();
-    assertThat(isConditionalAtLine(nodes, "div", 9)).isFalse();
-    assertThat(scan(nodes).isInNonRenderedRazorContent()).isFalse();
-  }
-
-  @Test
-  void consumes_complete_raw_string_terminating_quote_run() {
-    List<Node> nodes = parse("""
-      @{
-        var message = \"\"\"He said \"hi\"\"\"\";
-        if (Model.ShowPrimary) {
-          <div id="choice">First</div>
-        } else {
-          <div id="choice">Second</div>
-        }
-      }
-      <div id="footer">Footer</div>
-      """);
-
-    assertThat(isConditionalAtLine(nodes, "div", 4)).isTrue();
-    assertThat(isConditionalAtLine(nodes, "div", 6)).isTrue();
-    assertThat(isConditionalAtLine(nodes, "div", 9)).isFalse();
-    assertThat(scan(nodes).isInNonRenderedRazorContent()).isFalse();
-  }
-
-  @Test
-  void recognizes_empty_raw_strings() {
-    List<Node> nodes = parse("""
-      @{
-        var value = \"\"\"\"\"\";
-        if (Model.ShowPrimary) {
-          <div id="choice">First</div>
-        } else {
-          <div id="choice">Second</div>
-        }
-      }
-      <div id="footer">Footer</div>
-      """);
+      """.formatted(declaration));
 
     assertThat(isConditionalAtLine(nodes, "div", 4)).isTrue();
     assertThat(isConditionalAtLine(nodes, "div", 6)).isTrue();

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/TemplateConditionalScopeTrackerTest.java
@@ -385,7 +385,9 @@ class TemplateConditionalScopeTrackerTest {
   @ValueSource(strings = {
     "var markup = \"\"\"a \" <div id=\"not-rendered\">Text</div>\"\"\";",
     "var message = \"\"\"He said \"hi\"\"\"\";",
-    "var value = \"\"\"\"\"\";"
+    "var value = \"\"\"\"\"\";",
+    "var longerValue = \"\"\"\"\"\"\"\";",
+    "var length = \"\"\"\"\"\".Length;"
   })
   void tracks_plain_csharp_conditionals_after_raw_strings(String declaration) {
     List<Node> nodes = parse("""
@@ -403,6 +405,28 @@ class TemplateConditionalScopeTrackerTest {
     assertThat(isConditionalAtLine(nodes, "div", 4)).isTrue();
     assertThat(isConditionalAtLine(nodes, "div", 6)).isTrue();
     assertThat(isConditionalAtLine(nodes, "div", 9)).isFalse();
+    assertThat(scan(nodes).isInNonRenderedRazorContent()).isFalse();
+  }
+
+  @Test
+  void protects_multiline_raw_string_content_starting_with_an_operator() {
+    List<Node> nodes = parse("""
+      @{
+        var value = \"\"\"\"\"\"
+        - if (ignored) {
+        \"\"\"\"\"\";
+        if (Model.ShowPrimary) {
+          <div id="choice">First</div>
+        } else {
+          <div id="choice">Second</div>
+        }
+      }
+      <div id="footer">Footer</div>
+      """);
+
+    assertThat(isConditionalAtLine(nodes, "div", 6)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 8)).isTrue();
+    assertThat(isConditionalAtLine(nodes, "div", 11)).isFalse();
     assertThat(scan(nodes).isInNonRenderedRazorContent()).isFalse();
   }
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/coding/NoDuplicateIDCheckTest.java
@@ -254,6 +254,40 @@ class NoDuplicateIDCheckTest {
   }
 
   @Test
+  void plainCSharpConditionalBlocksInsideRazorCode() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+        new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksPlainCSharp.cshtml"),
+        new NoDuplicateIDCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+        .next().atLine(42).withMessage("Duplicate id \"footer\" found. First occurrence was on line 41.")
+        .noMore();
+  }
+
+  @Test
+  void htmlLikeTagsInsideRazorAndCSharpComments() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+        new File("src/test/resources/checks/NoDuplicateIDCheck/commentsInsideRazorCode.cshtml"),
+        new NoDuplicateIDCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+        .next().atLine(34).withMessage("Duplicate id \"footer\" found. First occurrence was on line 33.")
+        .noMore();
+  }
+
+  @Test
+  void razorTokensInPlainHtml() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+        new File("src/test/resources/checks/NoDuplicateIDCheck/razorTokensInPlainHtml.html"),
+        new NoDuplicateIDCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+        .next().atLine(4).withMessage("Duplicate id \"code-block\" found. First occurrence was on line 3.")
+        .next().atLine(8).withMessage("Duplicate id \"comment\" found. First occurrence was on line 7.")
+        .noMore();
+  }
+
+  @Test
   void razorConditionalBlocksWithScriptTemplateLiteral() {
     HtmlSourceCode sourceCode = TestHelper.scan(
         new File("src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksScriptTemplateLiteral.cshtml"),

--- a/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/commentsInsideRazorCode.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/commentsInsideRazorCode.cshtml
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+@{
+    if (Model.ShowMessage)
+    {
+        var closingBrace = "}";
+        // A comment containing } must not close the branch.
+        <div id="message">Message</div>
+    }
+    /* <div id="between-branches">Not rendered }</div> */
+    else
+    {
+        <div id="message">Fallback</div>
+    }
+
+    // <div id="line-comment">Not rendered }</div>
+    /*
+       <div id="block-comment">Not rendered }</div>
+    */
+}
+
+@*
+  <div id="razor-comment">Not rendered</div>
+*@
+
+<div id="line-comment">Rendered once</div>
+<div id="block-comment">Rendered once</div>
+<div id="between-branches">Rendered once</div>
+<div id="razor-comment">Rendered once</div>
+
+<div id="footer">One</div>
+<div id="footer">Two</div>
+
+</body>
+</html>

--- a/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksPlainCSharp.cshtml
+++ b/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/conditionalBlocksPlainCSharp.cshtml
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+@{
+    if (Model.ShowPrimary)
+    {
+        <section id="panel">Primary</section>
+        if (Model.ShowDetails)
+        {
+            <span id="details">Full details</span>
+        }
+        else
+        {
+            <span id="details">Summary</span>
+        }
+    }
+    else if (Model.ShowSecondary)
+    {
+        <section id="panel">Secondary</section>
+    }
+    else
+    {
+        <section id="panel">Fallback</section>
+    }
+
+    switch (Model.Layout)
+    {
+        case "compact":
+            <aside id="layout">Compact</aside>
+            break;
+        case "wide":
+            <aside id="layout">Wide</aside>
+            break;
+        default:
+            <aside id="layout">Default</aside>
+            break;
+    }
+}
+
+<div id="footer">One</div>
+<div id="footer">Two</div>
+
+</body>
+</html>

--- a/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/razorTokensInPlainHtml.html
+++ b/sonar-html-plugin/src/test/resources/checks/NoDuplicateIDCheck/razorTokensInPlainHtml.html
@@ -1,0 +1,8 @@
+@{
+  if (condition) {
+    <div id="code-block">One</div>
+    <div id="code-block">Two</div>
+  }
+}
+@* <div id="comment">One</div> *@
+<div id="comment">Two</div>


### PR DESCRIPTION
Part of [SONARHTML-472](https://sonarsource.atlassian.net/browse/SONARHTML-472)

## Summary
- recognize plain C# if / else if / else and switch branches inside Razor code blocks
- preserve branch scope across nested braces, strings, line comments, block comments, and Razor comments
- ignore HTML-like tags in non-rendered Razor/C# content while keeping the behavior limited to Razor files
- add regression coverage for nested and chained conditionals, switch branches, comments, and genuine duplicates

## Testing
- mvn verify (689 tests)

[SONARHTML-472]: https://sonarsource.atlassian.net/browse/SONARHTML-472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ