### PR TITLE
SONARHTML-470 Create rule S9379: DOM elements should not use the "autofocus" attribute

### DIFF
--- a/its/ruling/src/test/resources/expected/Web-S9379.json
+++ b/its/ruling/src/test/resources/expected/Web-S9379.json
@@ -1,0 +1,47 @@
+{
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/autofill-popup-location.html": [
+18
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/dashboards/_create_form.html.erb": [
+19
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/dashboards/_edit_form.html.erb": [
+18
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/issue/_comment_form.html.erb": [
+7
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/issue/_edit_comment_form.html.erb": [
+6
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/issue/_issue.html.erb": [
+66
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/issue/_severity_form.html.erb": [
+7
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/issue/_show_modal.html.erb": [
+5
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/issues/_shared_form.html.erb": [
+5
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/measures/_copy_form.html.erb": [
+13
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/measures/_edit_form.html.erb": [
+13
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/measures/_save_as_form.html.erb": [
+15
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/profiles/_copy_form.html.erb": [
+17
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/profiles/_create_form.html.erb": [
+17
+],
+"project:sonar-master/sonar-server/src/main/webapp/WEB-INF/app/views/profiles/_rename_form.html.erb": [
+16
+]
+}

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheck.java
@@ -31,14 +31,14 @@ public class NoAutofocusCheck extends AbstractPageCheck {
     if (!node.hasProperty("autofocus")) {
       return;
     }
-    if (Helpers.hasAncestorMatching(node, NoAutofocusCheck::isExemptAncestor)) {
+    if (isDialogOrPopover(node) || Helpers.hasAncestorMatching(node, NoAutofocusCheck::isDialogOrPopover)) {
       return;
     }
     createViolation(node, MESSAGE);
   }
 
-  private static boolean isExemptAncestor(TagNode ancestor) {
-    return "dialog".equalsIgnoreCase(ancestor.getNodeName()) || ancestor.hasProperty("popover");
+  private static boolean isDialogOrPopover(TagNode node) {
+    return "dialog".equalsIgnoreCase(node.getNodeName()) || node.hasProperty("popover");
   }
 
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheck.java
@@ -1,0 +1,44 @@
+/*
+ * SonarQube HTML
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.html.checks.accessibility;
+
+import org.sonar.check.Rule;
+import org.sonar.plugins.html.api.Helpers;
+import org.sonar.plugins.html.checks.AbstractPageCheck;
+import org.sonar.plugins.html.node.TagNode;
+
+@Rule(key = "S9379")
+public class NoAutofocusCheck extends AbstractPageCheck {
+
+  private static final String MESSAGE = "Remove this \"autofocus\" attribute.";
+
+  @Override
+  public void startElement(TagNode node) {
+    if (!node.hasProperty("autofocus")) {
+      return;
+    }
+    if (Helpers.hasAncestorMatching(node, NoAutofocusCheck::isExemptAncestor)) {
+      return;
+    }
+    createViolation(node, MESSAGE);
+  }
+
+  private static boolean isExemptAncestor(TagNode ancestor) {
+    return "dialog".equalsIgnoreCase(ancestor.getNodeName()) || ancestor.hasProperty("popover");
+  }
+
+}

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheck.java
@@ -24,7 +24,7 @@ import org.sonar.plugins.html.node.TagNode;
 @Rule(key = "S9379")
 public class NoAutofocusCheck extends AbstractPageCheck {
 
-  private static final String MESSAGE = "Remove this \"autofocus\" attribute.";
+  private static final String MESSAGE = "The autoFocus prop should not be used, as it can reduce usability and accessibility for users.";
 
   @Override
   public void startElement(TagNode node) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheck.java
@@ -24,7 +24,7 @@ import org.sonar.plugins.html.node.TagNode;
 @Rule(key = "S9379")
 public class NoAutofocusCheck extends AbstractPageCheck {
 
-  private static final String MESSAGE = "The autoFocus prop should not be used, as it can reduce usability and accessibility for users.";
+  private static final String MESSAGE = "Remove this \"autofocus\" attribute, as it can reduce usability and accessibility for users.";
 
   @Override
   public void startElement(TagNode node) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheck.java
@@ -38,7 +38,11 @@ public class NoAutofocusCheck extends AbstractPageCheck {
   }
 
   private static boolean isDialogOrPopover(TagNode node) {
-    return "dialog".equalsIgnoreCase(node.getNodeName()) || node.hasProperty("popover");
+    if ("dialog".equalsIgnoreCase(node.getNodeName()) || node.hasProperty("popover")) {
+      return true;
+    }
+    String role = node.getPropertyValue("role");
+    return "dialog".equalsIgnoreCase(role) || "alertdialog".equalsIgnoreCase(role);
   }
 
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheck.java
@@ -16,6 +16,7 @@
  */
 package org.sonar.plugins.html.checks.accessibility;
 
+import java.util.Arrays;
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.api.Helpers;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
@@ -41,8 +42,13 @@ public class NoAutofocusCheck extends AbstractPageCheck {
     if ("dialog".equalsIgnoreCase(node.getNodeName()) || node.hasProperty("popover")) {
       return true;
     }
-    String role = node.getPropertyValue("role");
-    return "dialog".equalsIgnoreCase(role) || "alertdialog".equalsIgnoreCase(role);
+    String role = node.getAttribute("role");
+    if (role == null) {
+      // static role absent: a bound role (:role/[role]) cannot be resolved, do not report
+      return node.getProperty("role") != null;
+    }
+    return Arrays.stream(role.trim().split("\\s+"))
+      .anyMatch(token -> "dialog".equalsIgnoreCase(token) || "alertdialog".equalsIgnoreCase(token));
   }
 
 }

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S9379.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S9379.html
@@ -10,9 +10,9 @@ or actively harm them:</p>
   especially if it also triggers a viewport scroll.</li>
   <li>On touch devices, autofocusing a text input can open the on-screen keyboard unexpectedly and reflow the page.</li>
 </ul>
-<p>Autofocusing a <code>dialog</code> element, an element with a <code>popover</code> attribute, or any element inside either, does not raise this
-issue: moving focus into a freshly opened modal or popover is expected, and the <code>dialog</code>/<code>popover</code> element itself is a valid
-autofocus target when it should receive focus as soon as it opens.</p>
+<p>Autofocusing a <code>dialog</code> element, an element with a <code>popover</code> attribute, an element with an ARIA <code>dialog</code> or
+<code>alertdialog</code> role, or any element inside one of these, does not raise this issue: moving focus into a freshly opened modal or popover is
+expected, and the dialog/popover element itself is a valid autofocus target when it should receive focus as soon as it opens.</p>
 <h2>How to fix it</h2>
 <p>Remove the attribute that autofocuses the element, and let the browser’s default focus behavior apply. If an element genuinely needs to receive
 focus in response to a user action, for example a form opened on demand, move it into a <code>dialog</code> element or a <code>popover</code>
@@ -36,11 +36,18 @@ container instead of autofocusing it directly on page load.</p>
 <pre>
 &lt;dialog autofocus&gt;&lt;/dialog&gt;
 </pre>
+<p>Autofocusing an element with an ARIA <code>dialog</code> or <code>alertdialog</code> role, or an element inside one, is compliant too:</p>
+<pre>
+&lt;div role="dialog" aria-modal="true"&gt;
+  &lt;input autofocus /&gt;
+&lt;/div&gt;
+</pre>
 <h2>Resources</h2>
 <h3>Documentation</h3>
 <ul>
   <li>MDN web docs - <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input#autofocus">autofocus attribute</a></li>
   <li>WHATWG HTML Standard - <a href="https://html.spec.whatwg.org/multipage/interaction.html#attr-fe-autofocus">The autofocus attribute</a></li>
+  <li>W3C - <a href="https://www.w3.org/TR/wai-aria-1.2/#dialog">WAI-ARIA 1.2 - <code>dialog</code> role</a></li>
 </ul>
 <h3>Articles &amp; blog posts</h3>
 <ul>

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S9379.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S9379.html
@@ -10,8 +10,9 @@ or actively harm them:</p>
   especially if it also triggers a viewport scroll.</li>
   <li>On touch devices, autofocusing a text input can open the on-screen keyboard unexpectedly and reflow the page.</li>
 </ul>
-<p>Autofocusing an element inside a <code>dialog</code> element, or an element with a <code>popover</code> attribute, does not raise this issue:
-moving focus into a freshly opened modal or popover is expected, since it only affects the user who just triggered it to open.</p>
+<p>Autofocusing a <code>dialog</code> element, an element with a <code>popover</code> attribute, or any element inside either, does not raise this
+issue: moving focus into a freshly opened modal or popover is expected, and the <code>dialog</code>/<code>popover</code> element itself is a valid
+autofocus target when it should receive focus as soon as it opens.</p>
 <h2>How to fix it</h2>
 <p>Remove the attribute that autofocuses the element, and let the browser’s default focus behavior apply. If an element genuinely needs to receive
 focus in response to a user action, for example a form opened on demand, move it into a <code>dialog</code> element or a <code>popover</code>
@@ -30,6 +31,10 @@ container instead of autofocusing it directly on page load.</p>
 &lt;dialog&gt;
   &lt;input autofocus /&gt;
 &lt;/dialog&gt;
+</pre>
+<p>Autofocusing the <code>dialog</code> or <code>popover</code> element itself is also compliant:</p>
+<pre>
+&lt;dialog autofocus&gt;&lt;/dialog&gt;
 </pre>
 <h2>Resources</h2>
 <h3>Documentation</h3>

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S9379.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S9379.html
@@ -1,0 +1,44 @@
+<h2>Why is this an issue?</h2>
+<p>Automatically moving keyboard focus to an element as soon as the page loads, before users have had a chance to get their bearings, can disorient
+or actively harm them:</p>
+<ul>
+  <li>Screen reader users lose the natural reading order: the screen reader jumps straight to the focused element and starts announcing from
+  there, skipping page landmarks, headings, and any content that precedes it.</li>
+  <li>Keyboard and switch-device users cannot navigate to the focused element in a controlled way and may have to navigate backwards through
+  earlier content to understand where they landed.</li>
+  <li>Users who need extra time to process a page, for example due to cognitive impairments, can lose their context when focus jumps unexpectedly,
+  especially if it also triggers a viewport scroll.</li>
+  <li>On touch devices, autofocusing a text input can open the on-screen keyboard unexpectedly and reflow the page.</li>
+</ul>
+<p>Autofocusing an element inside a <code>dialog</code> element, or an element with a <code>popover</code> attribute, does not raise this issue:
+moving focus into a freshly opened modal or popover is expected, since it only affects the user who just triggered it to open.</p>
+<h2>How to fix it</h2>
+<p>Remove the attribute that autofocuses the element, and let the browser’s default focus behavior apply. If an element genuinely needs to receive
+focus in response to a user action, for example a form opened on demand, move it into a <code>dialog</code> element or a <code>popover</code>
+container instead of autofocusing it directly on page load.</p>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+&lt;input autofocus /&gt;
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+&lt;input /&gt;
+</pre>
+<p>Autofocusing an element inside a <code>dialog</code> or a <code>popover</code> is compliant:</p>
+<pre>
+&lt;dialog&gt;
+  &lt;input autofocus /&gt;
+&lt;/dialog&gt;
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li>MDN web docs - <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input#autofocus">autofocus attribute</a></li>
+  <li>WHATWG HTML Standard - <a href="https://html.spec.whatwg.org/multipage/interaction.html#attr-fe-autofocus">The autofocus attribute</a></li>
+</ul>
+<h3>Articles &amp; blog posts</h3>
+<ul>
+  <li>Bruce Lawson - <a href="https://www.brucelawson.co.uk/2009/the-accessibility-of-html-5-autofocus/">The accessibility of HTML 5
+  autofocus</a></li>
+</ul>

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S9379.json
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S9379.json
@@ -1,0 +1,24 @@
+{
+  "title": "DOM elements should not use the \"autofocus\" attribute",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5min"
+  },
+  "tags": [
+    "accessibility"
+  ],
+  "defaultSeverity": "Major",
+  "ruleSpecification": "RSPEC-9379",
+  "sqKey": "S9379",
+  "scope": "All",
+  "quickfix": "infeasible",
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "LOW",
+      "RELIABILITY": "MEDIUM"
+    },
+    "attribute": "CONVENTIONAL"
+  }
+}

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/Sonar_way_profile.json
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/Sonar_way_profile.json
@@ -58,6 +58,7 @@
     "S8697",
     "S8720",
     "S8732",
+    "S9379",
     "TableHeaderHasIdOrScopeCheck",
     "UnsupportedTagsInHtml5Check"
   ]

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheckTest.java
@@ -44,7 +44,7 @@ class NoAutofocusCheckTest {
       new NoAutofocusCheck());
 
     checkMessagesVerifier.verify(sourceCode.getIssues())
-      .next().atLine(1).withMessage("Remove this \"autofocus\" attribute.")
+      .next().atLine(1).withMessage("The autoFocus prop should not be used, as it can reduce usability and accessibility for users.")
       .next().atLine(2)
       .next().atLine(3)
       .next().atLine(4)

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheckTest.java
@@ -1,0 +1,58 @@
+/*
+ * SonarQube HTML
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.html.checks.accessibility;
+
+import java.io.File;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.sonar.plugins.html.checks.CheckMessagesVerifierRule;
+import org.sonar.plugins.html.checks.TestHelper;
+import org.sonar.plugins.html.visitor.HtmlSourceCode;
+
+class NoAutofocusCheckTest {
+  @RegisterExtension
+  public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
+
+  @Test
+  void valid() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/NoAutofocusCheck/valid.html"),
+      new NoAutofocusCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .noMore();
+  }
+
+  @Test
+  void invalid() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/NoAutofocusCheck/invalid.html"),
+      new NoAutofocusCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(1).withMessage("Remove this \"autofocus\" attribute.")
+      .next().atLine(2)
+      .next().atLine(3)
+      .next().atLine(4)
+      .next().atLine(5)
+      .next().atLine(7)
+      .next().atLine(9)
+      .next().atLine(10)
+      .next().atLine(11)
+      .noMore();
+  }
+}

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheckTest.java
@@ -44,7 +44,7 @@ class NoAutofocusCheckTest {
       new NoAutofocusCheck());
 
     checkMessagesVerifier.verify(sourceCode.getIssues())
-      .next().atLine(1).withMessage("The autoFocus prop should not be used, as it can reduce usability and accessibility for users.")
+      .next().atLine(1).withMessage("Remove this \"autofocus\" attribute, as it can reduce usability and accessibility for users.")
       .next().atLine(2)
       .next().atLine(3)
       .next().atLine(4)

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheckTest.java
@@ -53,6 +53,7 @@ class NoAutofocusCheckTest {
       .next().atLine(9)
       .next().atLine(10)
       .next().atLine(11)
+      .next().atLine(13)
       .noMore();
   }
 }

--- a/sonar-html-plugin/src/test/resources/checks/NoAutofocusCheck/invalid.html
+++ b/sonar-html-plugin/src/test/resources/checks/NoAutofocusCheck/invalid.html
@@ -1,0 +1,11 @@
+<input autofocus />
+<input autofocus="autofocus" />
+<input autofocus="" />
+<input autofocus="true" />
+<button autofocus="false" />
+<div>
+  <input autofocus />
+</div>
+<input :autofocus="isFirstField" />
+<input v-bind:autofocus="isFirstField" />
+<input [autofocus]="isFirstField" />

--- a/sonar-html-plugin/src/test/resources/checks/NoAutofocusCheck/invalid.html
+++ b/sonar-html-plugin/src/test/resources/checks/NoAutofocusCheck/invalid.html
@@ -9,3 +9,6 @@
 <input :autofocus="isFirstField" />
 <input v-bind:autofocus="isFirstField" />
 <input [autofocus]="isFirstField" />
+<div role="tooltip">
+  <input autofocus />
+</div>

--- a/sonar-html-plugin/src/test/resources/checks/NoAutofocusCheck/valid.html
+++ b/sonar-html-plugin/src/test/resources/checks/NoAutofocusCheck/valid.html
@@ -1,0 +1,19 @@
+<input />
+<button />
+<dialog>
+  <input autofocus />
+</dialog>
+<dialog>
+  <div>
+    <input autofocus />
+  </div>
+</dialog>
+<div popover>
+  <input autofocus />
+</div>
+<div id="my-popover" popover="auto">
+  <button autofocus></button>
+</div>
+<div :popover="isMenuMode">
+  <input autofocus />
+</div>

--- a/sonar-html-plugin/src/test/resources/checks/NoAutofocusCheck/valid.html
+++ b/sonar-html-plugin/src/test/resources/checks/NoAutofocusCheck/valid.html
@@ -17,3 +17,5 @@
 <div :popover="isMenuMode">
   <input autofocus />
 </div>
+<dialog autofocus></dialog>
+<div popover autofocus></div>

--- a/sonar-html-plugin/src/test/resources/checks/NoAutofocusCheck/valid.html
+++ b/sonar-html-plugin/src/test/resources/checks/NoAutofocusCheck/valid.html
@@ -19,3 +19,15 @@
 </div>
 <dialog autofocus></dialog>
 <div popover autofocus></div>
+<div role="dialog">
+  <input autofocus />
+</div>
+<div role="alertdialog">
+  <input autofocus />
+</div>
+<div role="dialog" autofocus></div>
+<div role="dialog">
+  <div>
+    <input autofocus />
+  </div>
+</div>


### PR DESCRIPTION
----
## Summary by Gitar

- **New checks:**
    - Added `NoAutofocusCheck` rule `S9379` to flag `autofocus` attributes on DOM elements
- **Rule definition:**
    - Created rule documentation and JSON metadata for `S9379`
- **Quality profile:**
    - Added rule `S9379` to the Sonar way profile

<sub>This will update automatically on new commits.</sub>