### PR TITLE
SONARHTML-470 Update rule S9379 to cover Vue corner cases

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
@@ -137,19 +137,6 @@ public class Helpers {
   }
 
   /**
-   * Returns true when {@code name} looks like a component/custom-element reference rather than a
-   * native HTML tag: PascalCase or kebab-case. Check this ahead of any known-tag whitelist, since
-   * a component can share its name with a native tag case-insensitively
-   * (e.g. Vue's {@code <Input>}, Ant Design's {@code Input} component).
-   *
-   * @param name the tag name to test
-   * @return true if the name is a component reference
-   */
-  public static boolean isComponentReference(String name) {
-    return startsWithUpperCase(name) || isKebabCase(name);
-  }
-
-  /**
    * Returns true if any ancestor of {@code node} satisfies {@code predicate}.
    *
    * @param node the tag node whose ancestors are inspected

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
@@ -129,11 +129,6 @@ public class Helpers {
     return false;
   }
 
-  /** Checks if a tag name uses kebab-case; native HTML element names never contain a hyphen, so this always indicates a component. */
-  public static boolean isKebabCase(String name) {
-    return name.indexOf('-') >= 0;
-  }
-
   /**
    * Returns true if any ancestor of {@code node} satisfies {@code predicate}.
    *

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
@@ -114,6 +114,27 @@ public class Helpers {
   }
 
   /**
+   * Checks if a tag name uses PascalCase (has an uppercase letter after the first character).
+   * In Vue templates, PascalCase indicates a component reference, not an HTML element.
+   *
+   * @param name the tag name to test
+   * @return true if the name is PascalCase
+   */
+  public static boolean isPascalCase(String name) {
+    for (int i = 1; i < name.length(); i++) {
+      if (Character.isUpperCase(name.charAt(i))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Checks if a tag name uses kebab-case; native HTML element names never contain a hyphen, so this always indicates a component. */
+  public static boolean isKebabCase(String name) {
+    return name.indexOf('-') >= 0;
+  }
+
+  /**
    * Returns true if any ancestor of {@code node} satisfies {@code predicate}.
    *
    * @param node the tag node whose ancestors are inspected

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
@@ -114,19 +114,39 @@ public class Helpers {
   }
 
   /**
-   * Checks if a tag name uses PascalCase (has an uppercase letter after the first character).
-   * In Vue templates, PascalCase indicates a component reference, not an HTML element.
+   * Returns true when {@code name} starts with an uppercase letter, the convention Vue (and other
+   * frameworks) use to write a PascalCase component reference in a template.
    *
    * @param name the tag name to test
-   * @return true if the name is PascalCase
+   * @return true if the first character is uppercase
    */
-  public static boolean isPascalCase(String name) {
-    for (int i = 1; i < name.length(); i++) {
-      if (Character.isUpperCase(name.charAt(i))) {
-        return true;
-      }
-    }
-    return false;
+  public static boolean startsWithUpperCase(String name) {
+    return !name.isEmpty() && Character.isUpperCase(name.charAt(0));
+  }
+
+  /**
+   * Returns true when {@code name} contains a hyphen. No native HTML tag name has one, so a
+   * hyphen marks a custom element or component reference (Vue kebab-case, Angular/Web Components
+   * selectors).
+   *
+   * @param name the tag name to test
+   * @return true if the name contains a hyphen
+   */
+  public static boolean isKebabCase(String name) {
+    return name.indexOf('-') >= 0;
+  }
+
+  /**
+   * Returns true when {@code name} looks like a component/custom-element reference rather than a
+   * native HTML tag: PascalCase or kebab-case. Check this ahead of any known-tag whitelist, since
+   * a component can share its name with a native tag case-insensitively
+   * (e.g. Vue's {@code <Input>}, Ant Design's {@code Input} component).
+   *
+   * @param name the tag name to test
+   * @return true if the name is a component reference
+   */
+  public static boolean isComponentReference(String name) {
+    return startsWithUpperCase(name) || isKebabCase(name);
   }
 
   /**

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheck.java
@@ -36,8 +36,12 @@ public class NoAutofocusCheck extends AbstractPageCheck {
     if (autofocusProperty == null) {
       return;
     }
-    // Components/custom elements use `autofocus` as a prop, not the DOM attribute; checked before the tag whitelist since names can collide case-insensitively, e.g. Vue's <Input>.
-    if (Helpers.isComponentReference(node.getNodeName()) || !hasKnownHTMLTag(node)) {
+    // Kebab-case is always a custom element (no native tag has a hyphen); PascalCase only means a
+    // component in Vue, since HTML tag names are otherwise case-insensitive, e.g. plain <BUTTON>.
+    String nodeName = node.getNodeName();
+    boolean componentReference = Helpers.isKebabCase(nodeName)
+      || (Helpers.isVueFile(getHtmlSourceCode()) && Helpers.startsWithUpperCase(nodeName));
+    if (componentReference || !hasKnownHTMLTag(node)) {
       return;
     }
     // A DOM-property binding (`:x`, `v-bind:x`, `[x]`) bound to literal false never sets the property, unlike a static "false" string.

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheck.java
@@ -17,9 +17,12 @@
 package org.sonar.plugins.html.checks.accessibility;
 
 import java.util.Arrays;
+import java.util.List;
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.api.Helpers;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
+import org.sonar.plugins.html.node.Attribute;
+import org.sonar.plugins.html.node.Node;
 import org.sonar.plugins.html.node.TagNode;
 
 @Rule(key = "S9379")
@@ -27,15 +30,40 @@ public class NoAutofocusCheck extends AbstractPageCheck {
 
   private static final String MESSAGE = "Remove this \"autofocus\" attribute, as it can reduce usability and accessibility for users.";
 
+  private boolean isVueFile;
+
+  @Override
+  public void startDocument(List<Node> nodes) {
+    isVueFile = Helpers.isVueFile(getHtmlSourceCode());
+  }
+
   @Override
   public void startElement(TagNode node) {
-    if (!node.hasProperty("autofocus")) {
+    Attribute autofocusProperty = node.getProperty("autofocus");
+    if (autofocusProperty == null) {
+      return;
+    }
+    // In Vue files, PascalCase/kebab-case tags are components: `autofocus` there is a prop, not the DOM attribute.
+    if (isVueFile && (Helpers.isPascalCase(node.getNodeName()) || Helpers.isKebabCase(node.getNodeName()))) {
+      return;
+    }
+    // DOM-property bindings (`:x`, `v-bind:x`, `[x]`) bound to literal false never set the property, unlike a static "false" string.
+    if (isDomPropertyBoundToFalse(autofocusProperty)) {
       return;
     }
     if (isDialogOrPopover(node) || Helpers.hasAncestorMatching(node, NoAutofocusCheck::isDialogOrPopover)) {
       return;
     }
     createViolation(node, MESSAGE);
+  }
+
+  private static boolean isDomPropertyBoundToFalse(Attribute property) {
+    String value = property.getValue();
+    if (value == null || !"false".equals(value.trim())) {
+      return false;
+    }
+    return TagNode.domPropertyBindingNames("autofocus").stream()
+      .anyMatch(name -> name.equalsIgnoreCase(property.getName()));
   }
 
   private static boolean isDialogOrPopover(TagNode node) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheck.java
@@ -17,25 +17,18 @@
 package org.sonar.plugins.html.checks.accessibility;
 
 import java.util.Arrays;
-import java.util.List;
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.api.Helpers;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
 import org.sonar.plugins.html.node.Attribute;
-import org.sonar.plugins.html.node.Node;
 import org.sonar.plugins.html.node.TagNode;
+
+import static org.sonar.plugins.html.api.HtmlConstants.hasKnownHTMLTag;
 
 @Rule(key = "S9379")
 public class NoAutofocusCheck extends AbstractPageCheck {
 
   private static final String MESSAGE = "Remove this \"autofocus\" attribute, as it can reduce usability and accessibility for users.";
-
-  private boolean isVueFile;
-
-  @Override
-  public void startDocument(List<Node> nodes) {
-    isVueFile = Helpers.isVueFile(getHtmlSourceCode());
-  }
 
   @Override
   public void startElement(TagNode node) {
@@ -43,8 +36,8 @@ public class NoAutofocusCheck extends AbstractPageCheck {
     if (autofocusProperty == null) {
       return;
     }
-    // In Vue files, PascalCase/kebab-case tags are components: `autofocus` there is a prop, not the DOM attribute.
-    if (isVueFile && (Helpers.isPascalCase(node.getNodeName()) || Helpers.isKebabCase(node.getNodeName()))) {
+    // Components and custom elements are skipped: `autofocus` there is a prop, not the DOM attribute.
+    if (!hasKnownHTMLTag(node)) {
       return;
     }
     // DOM-property bindings (`:x`, `v-bind:x`, `[x]`) bound to literal false never set the property, unlike a static "false" string.

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheck.java
@@ -36,18 +36,15 @@ public class NoAutofocusCheck extends AbstractPageCheck {
     if (autofocusProperty == null) {
       return;
     }
-    // Components and custom elements are skipped: `autofocus` there is a prop, not the DOM attribute.
-    if (!hasKnownHTMLTag(node)) {
+    // Components/custom elements use `autofocus` as a prop, not the DOM attribute; checked before the tag whitelist since names can collide case-insensitively, e.g. Vue's <Input>.
+    if (Helpers.isComponentReference(node.getNodeName()) || !hasKnownHTMLTag(node)) {
       return;
     }
-    // DOM-property bindings (`:x`, `v-bind:x`, `[x]`) bound to literal false never set the property, unlike a static "false" string.
-    if (isDomPropertyBoundToFalse(autofocusProperty)) {
-      return;
+    // A DOM-property binding (`:x`, `v-bind:x`, `[x]`) bound to literal false never sets the property, unlike a static "false" string.
+    if (!isDomPropertyBoundToFalse(autofocusProperty) && !isDialogOrPopover(node)
+        && !Helpers.hasAncestorMatching(node, NoAutofocusCheck::isDialogOrPopover)) {
+      createViolation(node, MESSAGE);
     }
-    if (isDialogOrPopover(node) || Helpers.hasAncestorMatching(node, NoAutofocusCheck::isDialogOrPopover)) {
-      return;
-    }
-    createViolation(node, MESSAGE);
   }
 
   private static boolean isDomPropertyBoundToFalse(Attribute property) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheck.java
@@ -17,10 +17,12 @@
 package org.sonar.plugins.html.checks.accessibility;
 
 import java.util.Arrays;
+import java.util.List;
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.api.Helpers;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
 import org.sonar.plugins.html.node.Attribute;
+import org.sonar.plugins.html.node.Node;
 import org.sonar.plugins.html.node.TagNode;
 
 import static org.sonar.plugins.html.api.HtmlConstants.hasKnownHTMLTag;
@@ -29,6 +31,13 @@ import static org.sonar.plugins.html.api.HtmlConstants.hasKnownHTMLTag;
 public class NoAutofocusCheck extends AbstractPageCheck {
 
   private static final String MESSAGE = "Remove this \"autofocus\" attribute, as it can reduce usability and accessibility for users.";
+
+  private boolean isVueFile;
+
+  @Override
+  public void startDocument(List<Node> nodes) {
+    isVueFile = Helpers.isVueFile(getHtmlSourceCode());
+  }
 
   @Override
   public void startElement(TagNode node) {
@@ -40,7 +49,7 @@ public class NoAutofocusCheck extends AbstractPageCheck {
     // component in Vue, since HTML tag names are otherwise case-insensitive, e.g. plain <BUTTON>.
     String nodeName = node.getNodeName();
     boolean componentReference = Helpers.isKebabCase(nodeName)
-      || (Helpers.isVueFile(getHtmlSourceCode()) && Helpers.startsWithUpperCase(nodeName));
+      || (isVueFile && Helpers.startsWithUpperCase(nodeName));
     if (componentReference || !hasKnownHTMLTag(node)) {
       return;
     }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/UnsupportedTagsInHtml5Check.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/UnsupportedTagsInHtml5Check.java
@@ -16,7 +16,6 @@
  */
 package org.sonar.plugins.html.checks.sonar;
 
-import java.util.Locale;
 import java.util.Set;
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.api.Helpers;
@@ -72,11 +71,11 @@ public class UnsupportedTagsInHtml5Check extends AbstractPageCheck {
 
     // In Vue files, PascalCase tags are components, not HTML elements
     // e.g., <BLink> is a Vue Bootstrap component, not the deprecated <blink> tag
-    if (isVueFile && Helpers.isPascalCase(nodeName)) {
+    if (isVueFile && Helpers.startsWithUpperCase(nodeName)) {
       return false;
     }
 
-    return UNSUPPORTED_TAGS.contains(nodeName.toUpperCase(Locale.ENGLISH));
+    return UNSUPPORTED_TAGS.stream().anyMatch(nodeName::equalsIgnoreCase);
   }
 
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/UnsupportedTagsInHtml5Check.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/UnsupportedTagsInHtml5Check.java
@@ -72,24 +72,11 @@ public class UnsupportedTagsInHtml5Check extends AbstractPageCheck {
 
     // In Vue files, PascalCase tags are components, not HTML elements
     // e.g., <BLink> is a Vue Bootstrap component, not the deprecated <blink> tag
-    if (isVueFile && isPascalCase(nodeName)) {
+    if (isVueFile && Helpers.isPascalCase(nodeName)) {
       return false;
     }
 
     return UNSUPPORTED_TAGS.contains(nodeName.toUpperCase(Locale.ENGLISH));
-  }
-
-  /**
-   * Checks if a tag name uses PascalCase (has uppercase letter after the first character).
-   * In Vue templates, PascalCase indicates a component reference.
-   */
-  private static boolean isPascalCase(String name) {
-    for (int i = 1; i < name.length(); i++) {
-      if (Character.isUpperCase(name.charAt(i))) {
-        return true;
-      }
-    }
-    return false;
   }
 
 }

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S9379.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S9379.html
@@ -42,6 +42,13 @@ container instead of autofocusing it directly on page load.</p>
   &lt;input autofocus /&gt;
 &lt;/div&gt;
 </pre>
+<p>In Vue templates, an <code>autofocus</code> attribute on a PascalCase or kebab-case tag is not flagged: the analyzer cannot determine how the
+component renders, so it cannot tell whether the attribute reaches a real DOM element. Note that Vue passes undeclared attributes through to the
+component’s root element by default, so such code can still autofocus an element:</p>
+<pre>
+&lt;CustomInput autofocus /&gt;
+&lt;custom-input autofocus /&gt;
+</pre>
 <h2>Resources</h2>
 <h3>Documentation</h3>
 <ul>

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S9379.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S9379.html
@@ -42,9 +42,9 @@ container instead of autofocusing it directly on page load.</p>
   &lt;input autofocus /&gt;
 &lt;/div&gt;
 </pre>
-<p>In Vue templates, an <code>autofocus</code> attribute on a PascalCase or kebab-case tag is not flagged: the analyzer cannot determine how the
-component renders, so it cannot tell whether the attribute reaches a real DOM element. Note that Vue passes undeclared attributes through to the
-component’s root element by default, so such code can still autofocus an element:</p>
+<p>An <code>autofocus</code> attribute on a tag that is not a recognized native HTML element (a Vue or Angular component, or a custom element, in
+PascalCase or kebab-case) is not flagged, since the analyzer cannot resolve how such a tag renders. Frameworks like Vue pass undeclared attributes
+through to the component’s root element by default, so such code can still autofocus an element:</p>
 <pre>
 &lt;CustomInput autofocus /&gt;
 &lt;custom-input autofocus /&gt;

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/HelpersTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/HelpersTest.java
@@ -111,11 +111,4 @@ class HelpersTest {
     assertThat(Helpers.isServerSideFile(sourceCode("page.xml"))).isFalse();
   }
 
-  @Test
-  void is_kebab_case_detects_hyphenated_names_only() {
-    assertThat(Helpers.isKebabCase("custom-input")).isTrue();
-    assertThat(Helpers.isKebabCase("my-custom-element")).isTrue();
-    assertThat(Helpers.isKebabCase("input")).isFalse();
-    assertThat(Helpers.isKebabCase("CustomInput")).isFalse();
-  }
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/HelpersTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/HelpersTest.java
@@ -112,14 +112,29 @@ class HelpersTest {
   }
 
   @Test
-  void is_pascal_case_detects_uppercase_after_first_character() {
-    assertThat(Helpers.isPascalCase("CustomInput")).isTrue();
-    assertThat(Helpers.isPascalCase("BLink")).isTrue();
-    // matches any uppercase after index 0, so camelCase also returns true despite the name
-    assertThat(Helpers.isPascalCase("customInput")).isTrue();
-    assertThat(Helpers.isPascalCase("input")).isFalse();
-    assertThat(Helpers.isPascalCase("Input")).isFalse();
-    assertThat(Helpers.isPascalCase("")).isFalse();
+  void starts_with_upper_case_detects_first_character_only() {
+    assertThat(Helpers.startsWithUpperCase("CustomInput")).isTrue();
+    assertThat(Helpers.startsWithUpperCase("BLink")).isTrue();
+    assertThat(Helpers.startsWithUpperCase("Input")).isTrue();
+    // camelCase is not PascalCase: the uppercase letter is not the first character
+    assertThat(Helpers.startsWithUpperCase("customInput")).isFalse();
+    assertThat(Helpers.startsWithUpperCase("input")).isFalse();
+    assertThat(Helpers.startsWithUpperCase("")).isFalse();
+  }
+
+  @Test
+  void is_kebab_case_detects_hyphen() {
+    assertThat(Helpers.isKebabCase("custom-input")).isTrue();
+    assertThat(Helpers.isKebabCase("input")).isFalse();
+    assertThat(Helpers.isKebabCase("")).isFalse();
+  }
+
+  @Test
+  void is_component_reference_detects_pascal_or_kebab_case() {
+    assertThat(Helpers.isComponentReference("CustomInput")).isTrue();
+    assertThat(Helpers.isComponentReference("Input")).isTrue();
+    assertThat(Helpers.isComponentReference("custom-input")).isTrue();
+    assertThat(Helpers.isComponentReference("input")).isFalse();
   }
 
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/HelpersTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/HelpersTest.java
@@ -111,4 +111,15 @@ class HelpersTest {
     assertThat(Helpers.isServerSideFile(sourceCode("page.xml"))).isFalse();
   }
 
+  @Test
+  void is_pascal_case_detects_uppercase_after_first_character() {
+    assertThat(Helpers.isPascalCase("CustomInput")).isTrue();
+    assertThat(Helpers.isPascalCase("BLink")).isTrue();
+    // matches any uppercase after index 0, so camelCase also returns true despite the name
+    assertThat(Helpers.isPascalCase("customInput")).isTrue();
+    assertThat(Helpers.isPascalCase("input")).isFalse();
+    assertThat(Helpers.isPascalCase("Input")).isFalse();
+    assertThat(Helpers.isPascalCase("")).isFalse();
+  }
+
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/HelpersTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/HelpersTest.java
@@ -129,12 +129,4 @@ class HelpersTest {
     assertThat(Helpers.isKebabCase("")).isFalse();
   }
 
-  @Test
-  void is_component_reference_detects_pascal_or_kebab_case() {
-    assertThat(Helpers.isComponentReference("CustomInput")).isTrue();
-    assertThat(Helpers.isComponentReference("Input")).isTrue();
-    assertThat(Helpers.isComponentReference("custom-input")).isTrue();
-    assertThat(Helpers.isComponentReference("input")).isFalse();
-  }
-
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/HelpersTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/HelpersTest.java
@@ -110,4 +110,12 @@ class HelpersTest {
     assertThat(Helpers.isServerSideFile(sourceCode("page.htm"))).isFalse();
     assertThat(Helpers.isServerSideFile(sourceCode("page.xml"))).isFalse();
   }
+
+  @Test
+  void is_kebab_case_detects_hyphenated_names_only() {
+    assertThat(Helpers.isKebabCase("custom-input")).isTrue();
+    assertThat(Helpers.isKebabCase("my-custom-element")).isTrue();
+    assertThat(Helpers.isKebabCase("input")).isFalse();
+    assertThat(Helpers.isKebabCase("CustomInput")).isFalse();
+  }
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheckTest.java
@@ -61,14 +61,16 @@ class NoAutofocusCheckTest {
 
   @Test
   void vueComponentPropShouldNotBeFlagged() {
-    // CustomInput / custom-input are Vue components; autofocus there is a prop, not the DOM attribute
+    // CustomInput / custom-input / Input are Vue components; autofocus there is a prop, not the
+    // DOM attribute - Input collides case-insensitively with the native <input> tag but must
+    // still be treated as a component
     HtmlSourceCode sourceCode = TestHelper.scan(
       new File("src/test/resources/checks/NoAutofocusCheck/VueComponents.vue"),
       new NoAutofocusCheck());
 
     checkMessagesVerifier.verify(sourceCode.getIssues())
       // Only the native <input> should be flagged
-      .next().atLine(10)
+      .next().atLine(14)
       .noMore();
   }
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheckTest.java
@@ -71,4 +71,17 @@ class NoAutofocusCheckTest {
       .next().atLine(10)
       .noMore();
   }
+
+  @Test
+  void customElementPropInNonVueFileShouldNotBeFlagged() {
+    // The exemption is not gated on the .vue extension: a custom tag is never a known HTML element
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/NoAutofocusCheck/CustomElementInHtmlFile.html"),
+      new NoAutofocusCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      // Only the native <input> should be flagged
+      .next().atLine(6)
+      .noMore();
+  }
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheckTest.java
@@ -76,14 +76,16 @@ class NoAutofocusCheckTest {
 
   @Test
   void customElementPropInNonVueFileShouldNotBeFlagged() {
-    // The exemption is not gated on the .vue extension: a custom tag is never a known HTML element
+    // The kebab-case/unknown-tag exemption is not gated on the .vue extension, but PascalCase is:
+    // outside Vue, a known HTML tag typed in caps (e.g. <BUTTON>) is still just the native tag.
     HtmlSourceCode sourceCode = TestHelper.scan(
       new File("src/test/resources/checks/NoAutofocusCheck/CustomElementInHtmlFile.html"),
       new NoAutofocusCheck());
 
     checkMessagesVerifier.verify(sourceCode.getIssues())
-      // Only the native <input> should be flagged
       .next().atLine(6)
+      .next().atLine(9)
+      .next().atLine(10)
       .noMore();
   }
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheckTest.java
@@ -54,6 +54,21 @@ class NoAutofocusCheckTest {
       .next().atLine(10)
       .next().atLine(11)
       .next().atLine(13)
+      .next().atLine(15)
+      .next().atLine(16)
+      .noMore();
+  }
+
+  @Test
+  void vueComponentPropShouldNotBeFlagged() {
+    // CustomInput / custom-input are Vue components; autofocus there is a prop, not the DOM attribute
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/NoAutofocusCheck/VueComponents.vue"),
+      new NoAutofocusCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      // Only the native <input> should be flagged
+      .next().atLine(10)
       .noMore();
   }
 }

--- a/sonar-html-plugin/src/test/resources/checks/NoAutofocusCheck/CustomElementInHtmlFile.html
+++ b/sonar-html-plugin/src/test/resources/checks/NoAutofocusCheck/CustomElementInHtmlFile.html
@@ -4,3 +4,7 @@
 
 <!-- Native input - SHOULD still be flagged -->
 <input autofocus />
+
+<!-- HTML tag names are case-insensitive outside Vue - these are still the native tags and SHOULD be flagged -->
+<BUTTON autofocus></BUTTON>
+<INPUT AUTOFOCUS />

--- a/sonar-html-plugin/src/test/resources/checks/NoAutofocusCheck/CustomElementInHtmlFile.html
+++ b/sonar-html-plugin/src/test/resources/checks/NoAutofocusCheck/CustomElementInHtmlFile.html
@@ -1,0 +1,6 @@
+<!-- Custom element / component in a plain .html file - autofocus here is a prop, not the DOM attribute -->
+<custom-input autofocus></custom-input>
+<CustomInput autofocus></CustomInput>
+
+<!-- Native input - SHOULD still be flagged -->
+<input autofocus />

--- a/sonar-html-plugin/src/test/resources/checks/NoAutofocusCheck/VueComponents.vue
+++ b/sonar-html-plugin/src/test/resources/checks/NoAutofocusCheck/VueComponents.vue
@@ -1,0 +1,12 @@
+<template>
+  <div>
+    <!-- Vue component (PascalCase) - autofocus is a prop, not the DOM attribute, so should NOT be flagged -->
+    <CustomInput autofocus />
+
+    <!-- Vue component (kebab-case) - same as above, should NOT be flagged -->
+    <custom-input autofocus />
+
+    <!-- Native input - SHOULD still be flagged -->
+    <input autofocus />
+  </div>
+</template>

--- a/sonar-html-plugin/src/test/resources/checks/NoAutofocusCheck/VueComponents.vue
+++ b/sonar-html-plugin/src/test/resources/checks/NoAutofocusCheck/VueComponents.vue
@@ -6,6 +6,10 @@
     <!-- Vue component (kebab-case) - same as above, should NOT be flagged -->
     <custom-input autofocus />
 
+    <!-- Vue component whose name collides with a known HTML tag case-insensitively
+         (e.g. Ant Design's Input) - PascalCase still wins over the tag whitelist, so should NOT be flagged -->
+    <Input autofocus />
+
     <!-- Native input - SHOULD still be flagged -->
     <input autofocus />
   </div>

--- a/sonar-html-plugin/src/test/resources/checks/NoAutofocusCheck/invalid.html
+++ b/sonar-html-plugin/src/test/resources/checks/NoAutofocusCheck/invalid.html
@@ -12,3 +12,5 @@
 <div role="tooltip">
   <input autofocus />
 </div>
+<input [attr.autofocus]="false" />
+<input attr.autofocus="false" />

--- a/sonar-html-plugin/src/test/resources/checks/NoAutofocusCheck/valid.html
+++ b/sonar-html-plugin/src/test/resources/checks/NoAutofocusCheck/valid.html
@@ -31,3 +31,6 @@
     <input autofocus />
   </div>
 </div>
+<input :autofocus="false" />
+<input v-bind:autofocus="false" />
+<input [autofocus]="false" />


### PR DESCRIPTION
----
## Summary by Gitar

- **Rule updates:**
    - Updated `NoAutofocusCheck` to ignore unknown tags, kebab-case tags, and Vue PascalCase components.
    - Added support for ignoring DOM property bindings set to false like `:autofocus="false"`.
- **Helper additions:**
    - Added `startsWithUpperCase` and `isKebabCase` helpers in `Helpers.java` for tag name analysis.

<sub>This will update automatically on new commits.</sub>