### PR TITLE
SONARHTML-471 Implement rule S9380: The "scope" attribute should only be used on "th" elements- #7876

### DIFF
--- a/its/ruling/src/test/resources/expected/Web-S9380.json
+++ b/its/ruling/src/test/resources/expected/Web-S9380.json
@@ -1,0 +1,1046 @@
+{
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLCollection01.html": [
+32
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLCollection02.html": [
+32
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLCollection03.html": [
+32
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLCollection04.html": [
+32
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLCollection05.html": [
+32
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLCollection06.html": [
+32
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLCollection07.html": [
+32
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLCollection08.html": [
+32
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLCollection09.html": [
+32
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLCollection10.html": [
+32
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLCollection11.html": [
+32
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLCollection12.html": [
+32
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement01.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement02.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement03.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement04.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement05.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement06.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement07.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement08.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement09.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement10.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement11.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement12.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement13.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement14.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement15.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement16.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement17.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement18.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement19.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement20.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement21.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement22.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement23.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement24.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement25.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement26.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement27.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement28.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement29.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableCellElement30.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement01.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement02.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement03.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement04.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement05.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement06.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement07.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement08.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement09.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement10.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement11.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement12.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement13.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement14.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement15.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement16.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement17.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement18.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement19.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement20.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement21.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement22.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement23.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement24.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement25.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement26.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement27.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement28.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement29.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement30.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement32.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement33.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement34.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement35.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement36.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement37.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement38.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement39.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableElement40.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableRowElement01.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableRowElement02.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableRowElement03.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableRowElement04.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableRowElement05.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableRowElement06.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableRowElement07.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableRowElement08.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableRowElement09.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableRowElement10.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableRowElement11.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableRowElement12.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableRowElement13.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableRowElement14.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableRowElement15.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableRowElement16.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableRowElement17.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableRowElement18.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableRowElement19.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableRowElement20.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableRowElement21.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement01.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement02.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement03.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement04.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement05.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement06.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement07.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement08.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement09.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement10.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement11.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement12.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement13.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement14.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement15.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement16.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement17.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement18.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement19.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement20.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement21.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement22.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement23.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement24.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement25.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement26.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement27.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement28.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement29.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement30.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/HTMLTableSectionElement31.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table02.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table03.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table04.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table06.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table07.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table08.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table09.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table10.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table12.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table15.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table17.html": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table18.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table19.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table20.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table21.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table22.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table23.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table24.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table25.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table26.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table27.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table28.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table29.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table30.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table31.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table32.html": [
+17
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table33.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table34.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table35.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table36.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table37.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table38.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table39.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table40.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table41.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table42.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table43.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table44.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table45.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table46.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/html/level2/html/table47.html": [
+40
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLCollection01.xhtml": [
+34
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLCollection02.xhtml": [
+34
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLCollection03.xhtml": [
+34
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLCollection04.xhtml": [
+34
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLCollection05.xhtml": [
+34
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLCollection06.xhtml": [
+34
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLCollection07.xhtml": [
+34
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLCollection08.xhtml": [
+34
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLCollection09.xhtml": [
+34
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLCollection10.xhtml": [
+34
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLCollection11.xhtml": [
+34
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLCollection12.xhtml": [
+34
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement01.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement02.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement03.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement04.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement05.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement06.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement07.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement08.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement09.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement10.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement11.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement12.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement13.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement14.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement15.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement16.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement17.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement18.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement19.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement20.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement21.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement22.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement23.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement24.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement25.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement26.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement27.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement28.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement29.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableCellElement30.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement01.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement02.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement03.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement04.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement05.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement06.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement07.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement08.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement09.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement10.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement11.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement12.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement13.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement14.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement15.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement16.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement17.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement18.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement19.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement20.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement21.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement22.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement23.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement24.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement25.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement26.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement27.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement28.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement29.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement30.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement32.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement33.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement34.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement35.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement36.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement37.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement38.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement39.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableElement40.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableRowElement01.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableRowElement02.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableRowElement03.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableRowElement04.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableRowElement05.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableRowElement06.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableRowElement07.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableRowElement08.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableRowElement09.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableRowElement10.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableRowElement11.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableRowElement12.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableRowElement13.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableRowElement14.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableRowElement15.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableRowElement16.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableRowElement17.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableRowElement18.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableRowElement19.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableRowElement20.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableRowElement21.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement01.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement02.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement03.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement04.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement05.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement06.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement07.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement08.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement09.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement10.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement11.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement12.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement13.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement14.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement15.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement16.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement17.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement18.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement19.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement20.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement21.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement22.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement23.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement24.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement25.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement26.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement27.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement28.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement29.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement30.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/HTMLTableSectionElement31.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table02.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table03.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table04.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table06.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table07.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table08.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table09.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table10.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table12.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table15.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table17.xhtml": [
+44
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table18.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table19.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table20.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table21.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table22.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table23.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table24.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table25.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table26.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table27.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table28.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table29.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table30.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table31.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table32.xhtml": [
+19
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table33.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table34.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table35.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table36.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table37.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table38.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table39.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table40.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table41.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table42.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table43.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table44.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table45.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table46.xhtml": [
+42
+],
+"project:external_webkit-jb-mr1/LayoutTests/dom/xhtml/level2/html/table47.xhtml": [
+42
+]
+}

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ScopeAttributeOnlyOnThCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ScopeAttributeOnlyOnThCheck.java
@@ -41,7 +41,8 @@ public class ScopeAttributeOnlyOnThCheck extends AbstractPageCheck implements Em
 
   @Override
   public void startElement(TagNode node) {
-    if (!hasScopeAttribute(node) || "th".equalsIgnoreCase(node.getNodeName()) || isTemplateTag(node)) {
+    // Vue 2.0-2.4 scoped slots use a bare "scope" attribute on <template>, unrelated to table headers.
+    if (!hasScopeAttribute(node) || "th".equalsIgnoreCase(node.getNodeName()) || Helpers.isTemplateLikeTag(node)) {
       return;
     }
     // A custom component or unknown tag: "scope" may be an arbitrary prop, unrelated to table headers.
@@ -54,11 +55,6 @@ public class ScopeAttributeOnlyOnThCheck extends AbstractPageCheck implements Em
   private static boolean hasScopeAttribute(TagNode node) {
     return node.getAttributes().stream()
       .anyMatch(a -> SCOPE_ATTRIBUTE_NAMES.contains(a.getName().toLowerCase(Locale.ROOT)));
-  }
-
-  private static boolean isTemplateTag(TagNode node) {
-    // Vue 2.0-2.4 scoped slots use a bare "scope" attribute on <template>, unrelated to table headers.
-    return "template".equalsIgnoreCase(node.getNodeName());
   }
 
   private boolean isComponentReference(TagNode node) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ScopeAttributeOnlyOnThCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ScopeAttributeOnlyOnThCheck.java
@@ -16,6 +16,10 @@
  */
 package org.sonar.plugins.html.checks.accessibility;
 
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.api.Helpers;
 import org.sonar.plugins.html.api.HtmlConstants;
@@ -28,9 +32,16 @@ public class ScopeAttributeOnlyOnThCheck extends AbstractPageCheck implements Em
 
   private static final String MESSAGE = "Move this \"scope\" attribute to a \"th\" element, or remove it.";
 
+  // Spellings of a "scope" attribute; excludes Vue's ":[scope]" dynamic argument, whose target is only known at runtime.
+  private static final Set<String> SCOPE_ATTRIBUTE_NAMES = Stream.concat(
+      Stream.of("scope", "[attr.scope]", "attr.scope"),
+      TagNode.domPropertyBindingNames("scope").stream())
+    .map(name -> name.toLowerCase(Locale.ROOT))
+    .collect(Collectors.toUnmodifiableSet());
+
   @Override
   public void startElement(TagNode node) {
-    if (!node.hasProperty("scope") || "th".equalsIgnoreCase(node.getNodeName()) || isTemplateTag(node)) {
+    if (!hasScopeAttribute(node) || "th".equalsIgnoreCase(node.getNodeName()) || isTemplateTag(node)) {
       return;
     }
     // A custom component or unknown tag: "scope" may be an arbitrary prop, unrelated to table headers.
@@ -38,6 +49,11 @@ public class ScopeAttributeOnlyOnThCheck extends AbstractPageCheck implements Em
       return;
     }
     createViolation(node, MESSAGE);
+  }
+
+  private static boolean hasScopeAttribute(TagNode node) {
+    return node.getAttributes().stream()
+      .anyMatch(a -> SCOPE_ATTRIBUTE_NAMES.contains(a.getName().toLowerCase(Locale.ROOT)));
   }
 
   private static boolean isTemplateTag(TagNode node) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ScopeAttributeOnlyOnThCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ScopeAttributeOnlyOnThCheck.java
@@ -1,0 +1,62 @@
+/*
+ * SonarQube HTML
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.html.checks.accessibility;
+
+import org.sonar.check.Rule;
+import org.sonar.plugins.html.api.Helpers;
+import org.sonar.plugins.html.api.HtmlConstants;
+import org.sonar.plugins.html.checks.AbstractPageCheck;
+import org.sonar.plugins.html.checks.EmbeddedHtmlCheck;
+import org.sonar.plugins.html.node.TagNode;
+
+@Rule(key = "S9380")
+public class ScopeAttributeOnlyOnThCheck extends AbstractPageCheck implements EmbeddedHtmlCheck {
+
+  private static final String MESSAGE = "Move this \"scope\" attribute to a \"th\" element, or remove it.";
+
+  @Override
+  public void startElement(TagNode node) {
+    if (!node.hasProperty("scope") || "th".equalsIgnoreCase(node.getNodeName()) || isTemplateTag(node)) {
+      return;
+    }
+    // A custom component or unknown tag: "scope" may be an arbitrary prop, unrelated to table headers.
+    if (isComponentReference(node) || !HtmlConstants.hasKnownHTMLTag(node)) {
+      return;
+    }
+    createViolation(node, MESSAGE);
+  }
+
+  private static boolean isTemplateTag(TagNode node) {
+    // Vue 2.0-2.4 scoped slots use a bare "scope" attribute on <template>, unrelated to table headers.
+    return "template".equalsIgnoreCase(node.getNodeName());
+  }
+
+  private boolean isComponentReference(TagNode node) {
+    String nodeName = node.getNodeName();
+    // Kebab-case is always a custom element; PascalCase only means a component in Vue files.
+    return isKebabCase(nodeName) || (Helpers.isVueFile(getHtmlSourceCode()) && startsWithUpperCase(nodeName));
+  }
+
+  private static boolean isKebabCase(String name) {
+    return name.indexOf('-') >= 0;
+  }
+
+  private static boolean startsWithUpperCase(String name) {
+    return !name.isEmpty() && Character.isUpperCase(name.charAt(0));
+  }
+
+}

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ScopeAttributeOnlyOnThCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ScopeAttributeOnlyOnThCheck.java
@@ -25,6 +25,7 @@ import org.sonar.plugins.html.api.Helpers;
 import org.sonar.plugins.html.api.HtmlConstants;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
 import org.sonar.plugins.html.checks.EmbeddedHtmlCheck;
+import org.sonar.plugins.html.node.Attribute;
 import org.sonar.plugins.html.node.TagNode;
 
 @Rule(key = "S9380")
@@ -53,8 +54,22 @@ public class ScopeAttributeOnlyOnThCheck extends AbstractPageCheck implements Em
   }
 
   private static boolean hasScopeAttribute(TagNode node) {
-    return node.getAttributes().stream()
-      .anyMatch(a -> SCOPE_ATTRIBUTE_NAMES.contains(a.getName().toLowerCase(Locale.ROOT)));
+    return node.getAttributes().stream().anyMatch(ScopeAttributeOnlyOnThCheck::isEffectiveScopeAttribute);
+  }
+
+  private static boolean isEffectiveScopeAttribute(Attribute attribute) {
+    return SCOPE_ATTRIBUTE_NAMES.contains(attribute.getName().toLowerCase(Locale.ROOT))
+      && !isDomPropertyBoundToNullish(attribute);
+  }
+
+  // A DOM-property binding (`:scope`, `v-bind:scope`, `[scope]`) bound to literal null/undefined never sets the attribute.
+  private static boolean isDomPropertyBoundToNullish(Attribute property) {
+    String value = property.getValue();
+    if (value == null || !("null".equals(value.trim()) || "undefined".equals(value.trim()))) {
+      return false;
+    }
+    return TagNode.domPropertyBindingNames("scope").stream()
+      .anyMatch(name -> name.equalsIgnoreCase(property.getName()));
   }
 
   private boolean isComponentReference(TagNode node) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ScopeAttributeOnlyOnThCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ScopeAttributeOnlyOnThCheck.java
@@ -41,6 +41,13 @@ public class ScopeAttributeOnlyOnThCheck extends AbstractPageCheck implements Em
     .map(name -> name.toLowerCase(Locale.ROOT))
     .collect(Collectors.toUnmodifiableSet());
 
+  // A binding (`:scope`, `v-bind:scope`, `[scope]`, `[attr.scope]`) bound to literal null/undefined never sets the attribute.
+  private static final Set<String> NULLISH_AWARE_BINDINGS = Stream.concat(
+      Stream.of("[attr." + SCOPE + "]"),
+      TagNode.domPropertyBindingNames(SCOPE).stream())
+    .map(name -> name.toLowerCase(Locale.ROOT))
+    .collect(Collectors.toUnmodifiableSet());
+
   @Override
   public void startElement(TagNode node) {
     // Vue 2.0-2.4 scoped slots use a bare "scope" attribute on <template>, unrelated to table headers.
@@ -63,14 +70,14 @@ public class ScopeAttributeOnlyOnThCheck extends AbstractPageCheck implements Em
       && !isDomPropertyBoundToNullish(attribute);
   }
 
-  // A DOM-property binding (`:scope`, `v-bind:scope`, `[scope]`) bound to literal null/undefined never sets the attribute.
   private static boolean isDomPropertyBoundToNullish(Attribute property) {
     String value = property.getValue();
-    if (value == null || !("null".equals(value.trim()) || "undefined".equals(value.trim()))) {
+    if (value == null) {
       return false;
     }
-    return TagNode.domPropertyBindingNames(SCOPE).stream()
-      .anyMatch(name -> name.equalsIgnoreCase(property.getName()));
+    String trimmed = value.trim();
+    return ("null".equals(trimmed) || "undefined".equals(trimmed))
+      && NULLISH_AWARE_BINDINGS.contains(property.getName().toLowerCase(Locale.ROOT));
   }
 
   private boolean isComponentReference(TagNode node) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ScopeAttributeOnlyOnThCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ScopeAttributeOnlyOnThCheck.java
@@ -75,15 +75,7 @@ public class ScopeAttributeOnlyOnThCheck extends AbstractPageCheck implements Em
   private boolean isComponentReference(TagNode node) {
     String nodeName = node.getNodeName();
     // Kebab-case is always a custom element; PascalCase only means a component in Vue files.
-    return isKebabCase(nodeName) || (Helpers.isVueFile(getHtmlSourceCode()) && startsWithUpperCase(nodeName));
-  }
-
-  private static boolean isKebabCase(String name) {
-    return name.indexOf('-') >= 0;
-  }
-
-  private static boolean startsWithUpperCase(String name) {
-    return !name.isEmpty() && Character.isUpperCase(name.charAt(0));
+    return Helpers.isKebabCase(nodeName) || (Helpers.isVueFile(getHtmlSourceCode()) && Helpers.startsWithUpperCase(nodeName));
   }
 
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ScopeAttributeOnlyOnThCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/ScopeAttributeOnlyOnThCheck.java
@@ -31,12 +31,13 @@ import org.sonar.plugins.html.node.TagNode;
 @Rule(key = "S9380")
 public class ScopeAttributeOnlyOnThCheck extends AbstractPageCheck implements EmbeddedHtmlCheck {
 
+  private static final String SCOPE = "scope";
   private static final String MESSAGE = "Move this \"scope\" attribute to a \"th\" element, or remove it.";
 
   // Spellings of a "scope" attribute; excludes Vue's ":[scope]" dynamic argument, whose target is only known at runtime.
   private static final Set<String> SCOPE_ATTRIBUTE_NAMES = Stream.concat(
-      Stream.of("scope", "[attr.scope]", "attr.scope"),
-      TagNode.domPropertyBindingNames("scope").stream())
+      Stream.of(SCOPE, "[attr.scope]", "attr.scope"),
+      TagNode.domPropertyBindingNames(SCOPE).stream())
     .map(name -> name.toLowerCase(Locale.ROOT))
     .collect(Collectors.toUnmodifiableSet());
 
@@ -68,7 +69,7 @@ public class ScopeAttributeOnlyOnThCheck extends AbstractPageCheck implements Em
     if (value == null || !("null".equals(value.trim()) || "undefined".equals(value.trim()))) {
       return false;
     }
-    return TagNode.domPropertyBindingNames("scope").stream()
+    return TagNode.domPropertyBindingNames(SCOPE).stream()
       .anyMatch(name -> name.equalsIgnoreCase(property.getName()));
   }
 

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S9380.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S9380.html
@@ -1,0 +1,51 @@
+<h2>Why is this an issue?</h2>
+<p>The <code>scope</code> attribute tells assistive technology which cells a table header labels: it associates a <code>th</code> cell with the row(s)
+or column(s) it applies to, so a screen reader can announce the correct header when a user navigates through the data cells.</p>
+<p>The HTML specification only defines <code>scope</code> on the <code>th</code> element: it is, in the words of the specification itself, "only
+conforming for th elements". Placing it on any other element does not associate that cell with anything, so users relying on assistive technology
+get no benefit from it, and the markup becomes invalid.</p>
+<p>The <code>td</code> element is a special case: HTML4 allowed <code>scope</code> on a data cell, but HTML5 deprecated that usage, keeping
+<code>scope</code> valid only on <code>th</code>. Code that still carries <code>scope</code> on a <code>td</code> is most likely leftover from that
+older practice.</p>
+<h2>How to fix it</h2>
+<p>Move the <code>scope</code> attribute to the <code>th</code> element that acts as the header for the row, column, row group, or column group, or
+remove the attribute if the element is not a table header.</p>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+&lt;table&gt;
+  &lt;tr&gt;
+    &lt;td scope="row"&gt;Total&lt;/td&gt;
+    &lt;td&gt;42&lt;/td&gt;
+  &lt;/tr&gt;
+&lt;/table&gt;
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+&lt;table&gt;
+  &lt;tr&gt;
+    &lt;th scope="row"&gt;Total&lt;/th&gt;
+    &lt;td&gt;42&lt;/td&gt;
+  &lt;/tr&gt;
+&lt;/table&gt;
+</pre>
+<p>A <code>scope</code> attribute on a tag that is not a recognized native HTML element (a Vue or Angular component, or a custom element, in
+PascalCase or kebab-case) is not flagged: on a custom component, <code>scope</code> may be an arbitrary prop unrelated to table headers, and the
+analyzer cannot resolve what it is actually used for.</p>
+<pre>
+&lt;HeaderCell scope="row"&gt;Total&lt;/HeaderCell&gt;
+&lt;header-cell scope="row"&gt;Total&lt;/header-cell&gt;
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li>MDN web docs - <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/th#scope">th: scope attribute</a></li>
+  <li>WHATWG HTML Standard - <a href="https://html.spec.whatwg.org/multipage/tables.html#attr-th-scope">The scope attribute</a></li>
+  <li>WCAG - <a href="https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html">Understanding Success Criterion 1.3.1: Info and
+  Relationships</a></li>
+  <li>WCAG - <a href="https://www.w3.org/WAI/WCAG22/Understanding/parsing.html">Understanding Success Criterion 4.1.1: Parsing</a></li>
+</ul>
+<h3>Related rules</h3>
+<ul>
+  <li>{rule:Web:S1827} - Attributes deprecated in HTML5 should not be used</li>
+</ul>

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S9380.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S9380.html
@@ -10,6 +10,9 @@ older practice.</p>
 <h2>How to fix it</h2>
 <p>Move the <code>scope</code> attribute to the <code>th</code> element that acts as the header for the row, column, row group, or column group, or
 remove the attribute if the element is not a table header.</p>
+<p>Custom elements and components (kebab-case tags, PascalCase Vue components) are not flagged, since <code>scope</code> may be an arbitrary prop
+unrelated to the native HTML attribute. The bare <code>scope</code> attribute on Vue’s <code>&lt;template&gt;</code> (2.x scoped slots) is also
+excluded, as it is unrelated to table headers.</p>
 <h3>Code examples</h3>
 <h4>Noncompliant code example</h4>
 <pre data-diff-id="1" data-diff-type="noncompliant">
@@ -28,13 +31,6 @@ remove the attribute if the element is not a table header.</p>
     &lt;td&gt;42&lt;/td&gt;
   &lt;/tr&gt;
 &lt;/table&gt;
-</pre>
-<p>A <code>scope</code> attribute on a tag that is not a recognized native HTML element (a Vue or Angular component, or a custom element, in
-PascalCase or kebab-case) is not flagged: on a custom component, <code>scope</code> may be an arbitrary prop unrelated to table headers, and the
-analyzer cannot resolve what it is actually used for.</p>
-<pre>
-&lt;HeaderCell scope="row"&gt;Total&lt;/HeaderCell&gt;
-&lt;header-cell scope="row"&gt;Total&lt;/header-cell&gt;
 </pre>
 <h2>Resources</h2>
 <h3>Documentation</h3>

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S9380.json
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S9380.json
@@ -1,0 +1,24 @@
+{
+  "title": "The \"scope\" attribute should only be used on \"th\" elements",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant/Issue",
+    "constantCost": "5min"
+  },
+  "tags": [
+    "accessibility"
+  ],
+  "defaultSeverity": "Major",
+  "ruleSpecification": "RSPEC-9380",
+  "sqKey": "S9380",
+  "scope": "All",
+  "quickfix": "infeasible",
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "LOW",
+      "RELIABILITY": "MEDIUM"
+    },
+    "attribute": "CONVENTIONAL"
+  }
+}

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/Sonar_way_profile.json
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/Sonar_way_profile.json
@@ -59,6 +59,7 @@
     "S8720",
     "S8732",
     "S9379",
+    "S9380",
     "TableHeaderHasIdOrScopeCheck",
     "UnsupportedTagsInHtml5Check"
   ]

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ScopeAttributeOnlyOnThCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ScopeAttributeOnlyOnThCheckTest.java
@@ -1,0 +1,66 @@
+/*
+ * SonarQube HTML
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.html.checks.accessibility;
+
+import java.io.File;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.sonar.plugins.html.checks.CheckMessagesVerifierRule;
+import org.sonar.plugins.html.checks.TestHelper;
+import org.sonar.plugins.html.visitor.HtmlSourceCode;
+
+class ScopeAttributeOnlyOnThCheckTest {
+  @RegisterExtension
+  public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
+
+  @Test
+  void valid() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/ScopeAttributeOnlyOnThCheck/valid.html"),
+      new ScopeAttributeOnlyOnThCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .noMore();
+  }
+
+  @Test
+  void invalid() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/ScopeAttributeOnlyOnThCheck/invalid.html"),
+      new ScopeAttributeOnlyOnThCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(1).withMessage("Move this \"scope\" attribute to a \"th\" element, or remove it.")
+      .next().atLine(2)
+      .next().atLine(3)
+      .next().atLine(4)
+      .next().atLine(6)
+      .next().atLine(8)
+      .next().atLine(11)
+      .noMore();
+  }
+
+  @Test
+  void vueComponents() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/ScopeAttributeOnlyOnThCheck/example.vue"),
+      new ScopeAttributeOnlyOnThCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .noMore();
+  }
+}

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ScopeAttributeOnlyOnThCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ScopeAttributeOnlyOnThCheckTest.java
@@ -61,6 +61,7 @@ class ScopeAttributeOnlyOnThCheckTest {
       new ScopeAttributeOnlyOnThCheck());
 
     checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(17)
       .noMore();
   }
 }

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ScopeAttributeOnlyOnThCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ScopeAttributeOnlyOnThCheckTest.java
@@ -52,6 +52,8 @@ class ScopeAttributeOnlyOnThCheckTest {
       .next().atLine(8)
       .next().atLine(10)
       .next().atLine(12)
+      .next().atLine(14)
+      .next().atLine(15)
       .noMore();
   }
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ScopeAttributeOnlyOnThCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ScopeAttributeOnlyOnThCheckTest.java
@@ -50,8 +50,8 @@ class ScopeAttributeOnlyOnThCheckTest {
       .next().atLine(4)
       .next().atLine(6)
       .next().atLine(8)
-      .next().atLine(11)
-      .next().atLine(13)
+      .next().atLine(10)
+      .next().atLine(12)
       .noMore();
   }
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ScopeAttributeOnlyOnThCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ScopeAttributeOnlyOnThCheckTest.java
@@ -54,6 +54,7 @@ class ScopeAttributeOnlyOnThCheckTest {
       .next().atLine(12)
       .next().atLine(14)
       .next().atLine(15)
+      .next().atLine(17)
       .noMore();
   }
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ScopeAttributeOnlyOnThCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/ScopeAttributeOnlyOnThCheckTest.java
@@ -51,6 +51,7 @@ class ScopeAttributeOnlyOnThCheckTest {
       .next().atLine(6)
       .next().atLine(8)
       .next().atLine(11)
+      .next().atLine(13)
       .noMore();
   }
 

--- a/sonar-html-plugin/src/test/resources/checks/ScopeAttributeOnlyOnThCheck/example.vue
+++ b/sonar-html-plugin/src/test/resources/checks/ScopeAttributeOnlyOnThCheck/example.vue
@@ -12,4 +12,7 @@
   <todo-list>
     <template scope="props">{{ props.text }}</template>
   </todo-list>
+
+  <!-- Native tag inside a Vue template is still flagged -->
+  <td scope="row">Total</td>
 </template>

--- a/sonar-html-plugin/src/test/resources/checks/ScopeAttributeOnlyOnThCheck/example.vue
+++ b/sonar-html-plugin/src/test/resources/checks/ScopeAttributeOnlyOnThCheck/example.vue
@@ -1,0 +1,15 @@
+<template>
+  <!-- Matches "th" by name before the component checks below even run, so no violation either way (possible false negative if this is a component) -->
+  <Th scope="row">Total</Th>
+
+  <!-- Unresolved custom component: "scope" may be an arbitrary prop unrelated to table headers, so not flagged -->
+  <HeaderCell scope="row">Total</HeaderCell>
+
+  <!-- PascalCase wins over a tag-name collision: "Caption" is a Vue component here, not the native <caption> tag -->
+  <Caption scope="row">Total</Caption>
+
+  <!-- Vue 2.0-2.4 legacy scoped slot syntax: "scope" here is unrelated to table headers -->
+  <todo-list>
+    <template scope="props">{{ props.text }}</template>
+  </todo-list>
+</template>

--- a/sonar-html-plugin/src/test/resources/checks/ScopeAttributeOnlyOnThCheck/invalid.html
+++ b/sonar-html-plugin/src/test/resources/checks/ScopeAttributeOnlyOnThCheck/invalid.html
@@ -1,0 +1,11 @@
+<td scope="row">Total</td>
+<td scope="col">Total</td>
+<div scope="row"></div>
+<span :scope="dynamicScope"></span>
+<div>
+  <td scope="rowgroup">Total</td>
+</div>
+<TD SCOPE="colgroup">Total</TD>
+<Th scope="row">Total</Th>
+<!-- Outside Vue, PascalCase doesn't signal a component: this is still the native <caption> tag -->
+<Caption scope="row">Total</Caption>

--- a/sonar-html-plugin/src/test/resources/checks/ScopeAttributeOnlyOnThCheck/invalid.html
+++ b/sonar-html-plugin/src/test/resources/checks/ScopeAttributeOnlyOnThCheck/invalid.html
@@ -10,3 +10,6 @@
 <Caption scope="row">Total</Caption>
 <!-- Unlike null/undefined, a DOM-property binding of literal "false" still sets the (non-boolean) attribute -->
 <span :scope="false"></span>
+<!-- Angular attribute binding syntax -->
+<div [attr.scope]="dynamicScope"></div>
+<div attr.scope="row"></div>

--- a/sonar-html-plugin/src/test/resources/checks/ScopeAttributeOnlyOnThCheck/invalid.html
+++ b/sonar-html-plugin/src/test/resources/checks/ScopeAttributeOnlyOnThCheck/invalid.html
@@ -9,3 +9,5 @@
 <Th scope="row">Total</Th>
 <!-- Outside Vue, PascalCase doesn't signal a component: this is still the native <caption> tag -->
 <Caption scope="row">Total</Caption>
+<!-- Unlike null/undefined, a DOM-property binding of literal "false" still sets the (non-boolean) attribute -->
+<span :scope="false"></span>

--- a/sonar-html-plugin/src/test/resources/checks/ScopeAttributeOnlyOnThCheck/invalid.html
+++ b/sonar-html-plugin/src/test/resources/checks/ScopeAttributeOnlyOnThCheck/invalid.html
@@ -6,7 +6,6 @@
   <td scope="rowgroup">Total</td>
 </div>
 <TD SCOPE="colgroup">Total</TD>
-<Th scope="row">Total</Th>
 <!-- Outside Vue, PascalCase doesn't signal a component: this is still the native <caption> tag -->
 <Caption scope="row">Total</Caption>
 <!-- Unlike null/undefined, a DOM-property binding of literal "false" still sets the (non-boolean) attribute -->

--- a/sonar-html-plugin/src/test/resources/checks/ScopeAttributeOnlyOnThCheck/invalid.html
+++ b/sonar-html-plugin/src/test/resources/checks/ScopeAttributeOnlyOnThCheck/invalid.html
@@ -13,3 +13,5 @@
 <!-- Angular attribute binding syntax -->
 <div [attr.scope]="dynamicScope"></div>
 <div attr.scope="row"></div>
+<!-- Unlike the bracketed binding, this is a literal attribute value, not a null/undefined expression -->
+<div attr.scope="null"></div>

--- a/sonar-html-plugin/src/test/resources/checks/ScopeAttributeOnlyOnThCheck/valid.html
+++ b/sonar-html-plugin/src/test/resources/checks/ScopeAttributeOnlyOnThCheck/valid.html
@@ -1,0 +1,16 @@
+<table>
+  <tr>
+    <th scope="row">Total</th>
+    <td>42</td>
+  </tr>
+</table>
+<th scope="col">Total</th>
+<TH SCOPE="rowgroup">Total</TH>
+<Th scope="row">Total</Th>
+<th></th>
+<div></div>
+<td>Total</td>
+<th [scope]="computedScope"></th>
+<div :data-scope="x"></div>
+<!-- Kebab-case is always a custom element, even outside Vue files -->
+<data-th scope="row">Total</data-th>

--- a/sonar-html-plugin/src/test/resources/checks/ScopeAttributeOnlyOnThCheck/valid.html
+++ b/sonar-html-plugin/src/test/resources/checks/ScopeAttributeOnlyOnThCheck/valid.html
@@ -12,5 +12,7 @@
 <td>Total</td>
 <th [scope]="computedScope"></th>
 <div :data-scope="x"></div>
+<!-- Vue dynamic argument: the bound attribute name comes from the runtime value of "x", not from "scope" -->
+<div :[scope]="x"></div>
 <!-- Kebab-case is always a custom element, even outside Vue files -->
 <data-th scope="row">Total</data-th>

--- a/sonar-html-plugin/src/test/resources/checks/ScopeAttributeOnlyOnThCheck/valid.html
+++ b/sonar-html-plugin/src/test/resources/checks/ScopeAttributeOnlyOnThCheck/valid.html
@@ -16,3 +16,7 @@
 <div :[scope]="x"></div>
 <!-- Kebab-case is always a custom element, even outside Vue files -->
 <data-th scope="row">Total</data-th>
+<!-- A DOM-property binding bound to literal null/undefined never sets the attribute at runtime -->
+<div :scope="null"></div>
+<div v-bind:scope="undefined"></div>
+<div [scope]=" null "></div>

--- a/sonar-html-plugin/src/test/resources/checks/ScopeAttributeOnlyOnThCheck/valid.html
+++ b/sonar-html-plugin/src/test/resources/checks/ScopeAttributeOnlyOnThCheck/valid.html
@@ -20,3 +20,6 @@
 <div :scope="null"></div>
 <div v-bind:scope="undefined"></div>
 <div [scope]=" null "></div>
+<!-- Angular attribute binding bound to literal null/undefined also removes the attribute entirely -->
+<div [attr.scope]="null"></div>
+<div [attr.scope]="undefined"></div>


### PR DESCRIPTION
Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

## Disclaimer
- This PR contains the helpers pending to be merged in this other [PR](https://github.com/SonarSource/sonar-html/pull/815).

----
## Summary by Gitar

- **New accessibility rule:**
    - Implemented rule `S9380` to ensure the `scope` attribute is only used on `th` elements.

<sub>This will update automatically on new commits.</sub>