### PR TITLE
SONARHTML-488 Recognize camelCase Vue components and match template extensions case-insensitively

### DIFF
--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
@@ -106,11 +106,11 @@ public class Helpers {
   }
 
   public static boolean isCshtmlFile(HtmlSourceCode code) {
-    return code.inputFile().filename().endsWith(".cshtml");
+    return normalizedFilename(code).endsWith(".cshtml");
   }
 
   public static boolean isVueFile(HtmlSourceCode code) {
-    return code.inputFile().filename().endsWith(".vue");
+    return normalizedFilename(code).endsWith(".vue");
   }
 
   /** Returns whether an element is explicitly marked as an ASP.NET server control. */
@@ -139,6 +139,28 @@ public class Helpers {
    */
   public static boolean isKebabCase(String name) {
     return name.indexOf('-') >= 0;
+  }
+
+  /**
+   * Returns true when Vue resolves {@code name} as a component rather than as a native HTML element.
+   *
+   * <p>Vue's template compiler treats a tag as a component when its first character is uppercase,
+   * and otherwise whenever the name is not a known native tag. Native tag names are only ever
+   * spelled in lowercase, so for any spelling of a native tag it is the presence of an uppercase
+   * character anywhere that makes the name a component reference: {@code <Table>}, {@code <TABLE>}
+   * and {@code <tAble>} all resolve to a component, while {@code <table>} is the native element.
+   * This is broader than {@link #startsWithUpperCase(String)}, which misses camelCase names.
+   *
+   * @param name the tag name to test
+   * @return true if Vue would resolve the name as a component
+   */
+  public static boolean isVueComponentName(String name) {
+    for (int i = 0; i < name.length(); i++) {
+      if (Character.isUpperCase(name.charAt(i))) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**
@@ -202,7 +224,7 @@ public class Helpers {
    * @return true if the file is a Razor view, false otherwise
    */
   public static boolean isRazorFile(HtmlSourceCode code) {
-    String filename = code.inputFile().filename();
+    String filename = normalizedFilename(code);
     return filename.endsWith(".cshtml") || filename.endsWith(".vbhtml");
   }
 
@@ -213,7 +235,7 @@ public class Helpers {
    * @return true if the file is a WebForms page or user control, false otherwise
    */
   public static boolean isWebFormsFile(HtmlSourceCode code) {
-    String filename = code.inputFile().filename().toLowerCase(Locale.ROOT);
+    String filename = normalizedFilename(code);
     return filename.endsWith(".aspx") || filename.endsWith(".ascx");
   }
 
@@ -247,12 +269,16 @@ public class Helpers {
   }
   
   public static boolean isServerSideFile(HtmlSourceCode code) {
-    String filename = code.inputFile().filename();
+    String filename = normalizedFilename(code);
     for (String suffix : SERVER_SIDE_SUFFIXES) {
       if (filename.endsWith(suffix)) {
         return true;
       }
     }
     return false;
+  }
+
+  private static String normalizedFilename(HtmlSourceCode code) {
+    return code.inputFile().filename().toLowerCase(Locale.ROOT);
   }
 }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/api/Helpers.java
@@ -142,17 +142,20 @@ public class Helpers {
   }
 
   /**
-   * Returns true when Vue resolves {@code name} as a component rather than as a native HTML element.
+   * Returns true when {@code name} carries an uppercase character, so it cannot be the native
+   * spelling of an HTML element in a Vue template.
    *
    * <p>Vue's template compiler treats a tag as a component when its first character is uppercase,
-   * and otherwise whenever the name is not a known native tag. Native tag names are only ever
-   * spelled in lowercase, so for any spelling of a native tag it is the presence of an uppercase
-   * character anywhere that makes the name a component reference: {@code <Table>}, {@code <TABLE>}
-   * and {@code <tAble>} all resolve to a component, while {@code <table>} is the native element.
-   * This is broader than {@link #startsWithUpperCase(String)}, which misses camelCase names.
+   * and otherwise whenever the name is not a known native tag; native tag names are only ever
+   * spelled in lowercase. So {@code <Table>}, {@code <TABLE>} and {@code <tAble>} all resolve to a
+   * component, while {@code <table>} is the native element. This is broader than
+   * {@link #startsWithUpperCase(String)}, which misses camelCase names.
+   *
+   * <p>It is not a complete component test: hyphenated names are all-lowercase yet still
+   * components, so combine it with {@link #isKebabCase(String)} when a full test is needed.
    *
    * @param name the tag name to test
-   * @return true if Vue would resolve the name as a component
+   * @return true if the name contains an uppercase character
    */
   public static boolean isVueComponentName(String name) {
     for (int i = 0; i < name.length(); i++) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheck.java
@@ -45,11 +45,12 @@ public class NoAutofocusCheck extends AbstractPageCheck {
     if (autofocusProperty == null) {
       return;
     }
-    // Kebab-case is always a custom element (no native tag has a hyphen); PascalCase only means a
-    // component in Vue, since HTML tag names are otherwise case-insensitive, e.g. plain <BUTTON>.
+    // Kebab-case is always a custom element (no native tag has a hyphen). Any other casing only
+    // means a component in Vue, since HTML tag names are otherwise case-insensitive, e.g. plain
+    // <BUTTON>.
     String nodeName = node.getNodeName();
     boolean componentReference = Helpers.isKebabCase(nodeName)
-      || (isVueFile && Helpers.startsWithUpperCase(nodeName));
+      || (isVueFile && Helpers.isVueComponentName(nodeName));
     if (componentReference || !hasKnownHTMLTag(node)) {
       return;
     }

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheck.java
@@ -98,10 +98,16 @@ public class TableWithoutHeaderCheck extends AbstractPageCheck {
   }
 
   private boolean isTable(TagNode node) {
-    return isVueFile ? "table".equals(node.getNodeName()) : TABLE_TAG.equalsIgnoreCase(node.getNodeName());
+    String nodeName = node.getNodeName();
+    // A native table is only ever spelled in lowercase, so in a Vue file any other casing names a
+    // component. This mirrors how UnsupportedTagsInHtml5Check classifies deprecated tag names.
+    return TABLE_TAG.equalsIgnoreCase(nodeName)
+      && !(isVueFile && Helpers.isVueComponentName(nodeName));
   }
 
-  private static boolean isTableScope(TagNode node) {
+  private static boolean isNestedTableBoundary(TagNode node) {
+    // A Vue <Table> component is not itself checked as a native table, but its slot content must
+    // not provide a header for an outer native table, so every case variant remains a boundary.
     return TABLE_TAG.equalsIgnoreCase(node.getNodeName());
   }
 
@@ -117,7 +123,7 @@ public class TableWithoutHeaderCheck extends AbstractPageCheck {
 
   private static boolean hasHeader(TagNode node) {
     return node.getChildren().stream().anyMatch(TableWithoutHeaderCheck::isTableHeader) ||
-      node.getChildren().stream().filter(child -> !isTableScope(child)).anyMatch(TableWithoutHeaderCheck::hasHeader);
+      node.getChildren().stream().filter(child -> !isNestedTableBoundary(child)).anyMatch(TableWithoutHeaderCheck::hasHeader);
   }
 
   private static boolean isTableHeader(TagNode node) {

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/UnsupportedTagsInHtml5Check.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/UnsupportedTagsInHtml5Check.java
@@ -69,9 +69,9 @@ public class UnsupportedTagsInHtml5Check extends AbstractPageCheck {
   private boolean isUnsupportedTag(TagNode node) {
     String nodeName = node.getNodeName();
 
-    // In Vue files, PascalCase tags are components, not HTML elements
-    // e.g., <BLink> is a Vue Bootstrap component, not the deprecated <blink> tag
-    if (isVueFile && Helpers.startsWithUpperCase(nodeName)) {
+    // In Vue files any tag name carrying an uppercase character is a component, not an HTML
+    // element, e.g. both <BLink> and <bLink> are Vue Bootstrap components rather than <blink>.
+    if (isVueFile && Helpers.isVueComponentName(nodeName)) {
       return false;
     }
 

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlSensor.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/core/HtmlSensor.java
@@ -45,6 +45,7 @@ import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.plugins.html.analyzers.ComplexityVisitor;
 import org.sonar.plugins.html.analyzers.PageCountLines;
+import org.sonar.plugins.html.api.Helpers;
 import org.sonar.plugins.html.api.HtmlConstants;
 import org.sonar.plugins.html.checks.AbstractPageCheck;
 import org.sonar.plugins.html.checks.HtmlIssue;
@@ -121,7 +122,7 @@ public final class HtmlSensor implements Sensor {
       HtmlSourceCode sourceCode = new HtmlSourceCode(inputFile);
 
       try (Reader reader = new InputStreamReader(inputFile.inputStream(), inputFile.charset())) {
-        PageLexer lexer = inputFile.filename().endsWith(".vue") ? new VueLexer() : new PageLexer();
+        PageLexer lexer = Helpers.isVueFile(sourceCode) ? new VueLexer() : new PageLexer();
         scanner.scan(lexer.parse(reader), sourceCode);
         saveMetrics(sensorContext, sourceCode);
         saveLineLevelMeasures(inputFile, sourceCode);

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/HelpersTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/api/HelpersTest.java
@@ -82,7 +82,32 @@ class HelpersTest {
   @Test
   void is_vue_file_recognizes_vue_suffix() {
     assertThat(Helpers.isVueFile(sourceCode("component.vue"))).isTrue();
+    assertThat(Helpers.isVueFile(sourceCode("component.VUE"))).isTrue();
     assertThat(Helpers.isVueFile(sourceCode("component.html"))).isFalse();
+  }
+
+  @Test
+  void identifies_vue_component_names() {
+    // Vue resolves a tag as a component unless it is the all-lowercase native spelling.
+    assertThat(Helpers.isVueComponentName("Blink")).isTrue();
+    assertThat(Helpers.isVueComponentName("BLink")).isTrue();
+    assertThat(Helpers.isVueComponentName("bLink")).isTrue();
+    assertThat(Helpers.isVueComponentName("MARQUEE")).isTrue();
+    assertThat(Helpers.isVueComponentName("Table")).isTrue();
+    assertThat(Helpers.isVueComponentName("TABLE")).isTrue();
+    assertThat(Helpers.isVueComponentName("blink")).isFalse();
+    assertThat(Helpers.isVueComponentName("table")).isFalse();
+    assertThat(Helpers.isVueComponentName("b-link")).isFalse();
+    assertThat(Helpers.isVueComponentName("")).isFalse();
+  }
+
+  @Test
+  void file_suffixes_are_matched_ignoring_case() {
+    assertThat(Helpers.isRazorFile(sourceCode("view.CSHTML"))).isTrue();
+    assertThat(Helpers.isRazorFile(sourceCode("view.VBHTML"))).isTrue();
+    assertThat(Helpers.isRazorFile(sourceCode("view.html"))).isFalse();
+    assertThat(Helpers.isCshtmlFile(sourceCode("view.CSHTML"))).isTrue();
+    assertThat(Helpers.isServerSideFile(sourceCode("page.ASPX"))).isTrue();
   }
 
   @Test

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/TestHelper.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/TestHelper.java
@@ -25,6 +25,7 @@ import org.sonar.api.batch.fs.InputFile;
 import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import org.sonar.plugins.html.analyzers.ComplexityVisitor;
 import org.sonar.plugins.html.analyzers.PageCountLines;
+import org.sonar.plugins.html.api.Helpers;
 import org.sonar.plugins.html.api.HtmlConstants;
 import org.sonar.plugins.html.lex.PageLexer;
 import org.sonar.plugins.html.lex.VueLexer;
@@ -55,7 +56,8 @@ public class TestHelper {
     );
 
     HtmlAstScanner walker = new HtmlAstScanner(List.of(new PageCountLines(), new ComplexityVisitor()));
-    PageLexer lexer = file.getName().endsWith(".vue") ? new VueLexer() : new PageLexer();
+    // Same predicate as HtmlSensor, so fixtures are parsed through the production lexer choice.
+    PageLexer lexer = Helpers.isVueFile(result) ? new VueLexer() : new PageLexer();
     walker.addVisitor(visitor);
     walker.scan(
       lexer.parse(fileReader),

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/NoAutofocusCheckTest.java
@@ -61,16 +61,16 @@ class NoAutofocusCheckTest {
 
   @Test
   void vueComponentPropShouldNotBeFlagged() {
-    // CustomInput / custom-input / Input are Vue components; autofocus there is a prop, not the
-    // DOM attribute - Input collides case-insensitively with the native <input> tag but must
-    // still be treated as a component
+    // CustomInput / custom-input / Input / textArea are Vue components; autofocus there is a prop,
+    // not the DOM attribute - Input and textArea collide case-insensitively with the native
+    // <input>/<textarea> tags but must still be treated as components
     HtmlSourceCode sourceCode = TestHelper.scan(
       new File("src/test/resources/checks/NoAutofocusCheck/VueComponents.vue"),
       new NoAutofocusCheck());
 
     checkMessagesVerifier.verify(sourceCode.getIssues())
       // Only the native <input> should be flagged
-      .next().atLine(14)
+      .next().atLine(18)
       .noMore();
   }
 

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/sonar/TableWithoutHeaderCheckTest.java
@@ -58,6 +58,19 @@ class TableWithoutHeaderCheckTest {
   }
 
   @Test
+  void only_lowercase_table_is_native_in_vue_files() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/TableWithoutHeaderCheck/native-tables.VUE"),
+      new TableWithoutHeaderCheck());
+
+    // Only <table> is the native element; <TABLE>, <Table> and <tAble> resolve to components.
+    // The uppercase file extension must still be recognized as Vue.
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(2).withMessage("Add \"<th>\" headers to this \"<table>\".")
+      .noMore();
+  }
+
+  @Test
   void table_tag_remains_case_insensitive_outside_vue() {
     HtmlSourceCode sourceCode = TestHelper.scan(
       new File("src/test/resources/checks/TableWithoutHeaderCheck/mixed-case.html"),

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlSensorTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/core/HtmlSensorTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
@@ -278,9 +279,11 @@ class HtmlSensorTest {
     assertThat(tester.measures(componentKey)).isEmpty();
   }
 
-  @Test
-  void vue_file_should_be_analyzed() throws IOException {
-    DefaultInputFile inputFile = createInputFile(TEST_DIR, "foo.vue");
+  @ParameterizedTest
+  @ValueSource(strings = {"foo.vue", "foo.VUE"})
+  void vue_file_should_be_analyzed(String filename) throws IOException {
+    String contents = new String(Files.readAllBytes(TEST_DIR.resolve("foo.vue")), StandardCharsets.UTF_8);
+    DefaultInputFile inputFile = createInputFile(filename, contents);
     tester.fileSystem().add(inputFile);
 
     sensor.execute(tester);

--- a/sonar-html-plugin/src/test/resources/checks/NoAutofocusCheck/VueComponents.vue
+++ b/sonar-html-plugin/src/test/resources/checks/NoAutofocusCheck/VueComponents.vue
@@ -10,6 +10,10 @@
          (e.g. Ant Design's Input) - PascalCase still wins over the tag whitelist, so should NOT be flagged -->
     <Input autofocus />
 
+    <!-- Vue component (camelCase) - Vue resolves it as a component because no native tag is
+         spelled that way, so should NOT be flagged -->
+    <textArea autofocus />
+
     <!-- Native input - SHOULD still be flagged -->
     <input autofocus />
   </div>

--- a/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/native-tables.VUE
+++ b/sonar-html-plugin/src/test/resources/checks/TableWithoutHeaderCheck/native-tables.VUE
@@ -1,0 +1,6 @@
+<template>
+  <table><tr><td>Name</td></tr></table>
+  <TABLE><tr><td>Name</td></tr></TABLE>
+  <Table><TableRow /></Table>
+  <tAble><tr><td>Name</td></tr></tAble>
+</template>

--- a/sonar-html-plugin/src/test/resources/checks/UnsupportedTagsInHtml5Check/VueComponents.vue
+++ b/sonar-html-plugin/src/test/resources/checks/UnsupportedTagsInHtml5Check/VueComponents.vue
@@ -13,5 +13,11 @@
 
     <!-- kebab-case Vue components - should NOT be flagged -->
     <b-link to="/home">Home</b-link>
+
+    <!-- camelCase is not a native tag spelling either - should NOT be flagged -->
+    <bLink to="/home">Home</bLink>
+
+    <!-- all-uppercase starts with a capital, so Vue resolves it as a component too -->
+    <MARQUEE>Scrolling</MARQUEE>
   </div>
 </template>


### PR DESCRIPTION
Rebased onto master and reduced in scope: master's #815 (SONARHTML-470) landed `Helpers.startsWithUpperCase` and already exempts PascalCase tags in `.vue` files, so the bulk of the original diff here is now redundant. What remains is the gap that rule leaves, plus the file-extension casing.

## Why

Vue's template compiler classifies a tag as a component when `isUpperCase(tag.charCodeAt(0))`, and otherwise whenever `!isNativeTag(tag)`. `isNativeTag` matches a case-sensitive map of lowercase names, so a native element is only ever spelled in lowercase — which means **any** uppercase character makes the name a component reference, not just a leading one. `startsWithUpperCase` therefore misses camelCase.

## What

`Helpers.isVueComponentName` encodes that rule, and both Vue-aware checks now share it so they agree on the same tag shape:

| Tag in a `.vue` file | Before | After |
|---|---|---|
| `<bLink>` | reported as deprecated `blink` | component, not reported |
| `<BLink>`, `<Blink>`, `<MARQUEE>` | already exempt via `startsWithUpperCase` | unchanged |
| `<TABLE>`, `<Table>`, `<tAble>` | not checked as a native table | unchanged (now via the shared helper) |
| `<table>` | native table | unchanged |

`TableWithoutHeaderCheck` previously carried its own `"table".equals(nodeName)` special case for Vue; it now uses the shared helper and reaches the same verdicts, with `isTableScope` renamed to `isNestedTableBoundary` to say what it actually does (a `<Table>` component still bounds an outer table's header search).

Also matches template file extensions case-insensitively, so `.VUE` and `.CSHTML` behave like their lowercase spellings, and routes the sensor's lexer choice through `Helpers.isVueFile` instead of a literal `.vue` suffix test.

## Gitar findings

All three from the previous revision are addressed:

1. **Inconsistent ALL-CAPS classification** — resolved by deferring to Vue's actual rule. `<TABLE>` is a component in *both* checks now, and the `|| TABLE_TAG.equals(nodeName)` escape hatch (whose comment claimed the opposite) is gone.
2. **PascalCase exclusion drops true positives** — no longer this PR's decision; master made it in #815. This PR only extends the same rule to camelCase, where Vue equally never renders the native element.
3. **TestHelper used a case-sensitive `.vue` test** — `TestHelper.scan` now uses `Helpers.isVueFile`, the same predicate as `HtmlSensor`, so the `native-tables.VUE` fixture parses through `VueLexer` exactly as production would.

## Testing

`mvn test -pl sonar-html-plugin` green (742 tests). New coverage: `Helpers.isVueComponentName` unit cases, `native-tables.VUE` for the four table spellings, `<bLink>`/`<MARQUEE>` in `VueComponents.vue`, a parameterized `.vue`/`.VUE` sensor case, and extension-casing assertions.