### PR TITLE
SONARHTML-478 Implement rule S9384: no identical lnks

### DIFF
--- a/its/ruling/src/test/resources/expected/Web-S9384.json
+++ b/its/ruling/src/test/resources/expected/Web-S9384.json
@@ -1,0 +1,101 @@
+{
+"project:Silverpeas-Core-master/lib-core/src/test/resources/com/silverpeas/wysiwyg/dynamicvalue/test-without_keys.html": [
+33
+],
+"project:Silverpeas-Core-master/lib-core/src/test/resources/com/silverpeas/wysiwyg/dynamicvalue/test.html": [
+33
+],
+"project:Silverpeas-Core-master/war-core/src/main/webapp/selection/jsp/userpanel.jsp": [
+941
+],
+"project:Silverpeas-Core-master/war-core/src/main/webapp/wysiwyg/jsp/ckeditor/INSTALL.html": [
+84
+],
+"project:Silverpeas-Core-master/war-core/src/main/webapp/wysiwyg/jsp/ckeditor/plugins/media/mediaplayer-5.9/readme.html": [
+81
+],
+"project:external_webkit-jb-mr1/PerformanceTests/Parser/resources/html5.html": [
+234,
+2584,
+6803,
+84117
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/indexeddb-persists.html": [
+11
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/localstorage-empty-database.html": [
+11
+],
+"project:external_webkit-jb-mr1/Source/WebCore/manual-tests/spatial-navigation/spatial-navigation-test-cases.html": [
+94
+],
+"project:phpMyAdmin-4.0.4-english/doc/html/faq.html": [
+1609
+],
+"project:phpMyAdmin-4.0.4-english/doc/html/genindex.html": [
+493,
+493,
+505,
+525,
+525,
+587,
+595,
+595,
+611,
+615,
+643,
+647,
+647,
+651,
+667,
+927,
+951,
+955,
+959,
+987,
+991,
+991,
+1246,
+1650,
+1650,
+1662,
+1682,
+1682,
+1794,
+1802,
+1802,
+1814,
+1830,
+1886,
+1890,
+1890,
+1894,
+1906,
+2082,
+2106,
+2110,
+2114,
+2142,
+2146,
+2146,
+2170,
+2199,
+2449,
+2489,
+3103,
+3115,
+3135,
+3139,
+3333,
+3393,
+3397,
+3689
+],
+"project:phpMyAdmin-4.0.4-english/doc/html/glossary.html": [
+292,
+614
+],
+"project:phpMyAdmin-4.0.4-english/doc/html/index.html": [
+114
+]
+}

--- a/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/IdenticalLinksDifferentDestinationsCheck.java
+++ b/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/IdenticalLinksDifferentDestinationsCheck.java
@@ -1,0 +1,258 @@
+/*
+ * SonarQube HTML
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.html.checks.accessibility;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.sonar.check.Rule;
+import org.sonar.plugins.html.api.Helpers;
+import org.sonar.plugins.html.api.HtmlConstants;
+import org.sonar.plugins.html.api.accessibility.AccessibilityUtils;
+import org.sonar.plugins.html.checks.AbstractPageCheck;
+import org.sonar.plugins.html.node.DirectiveNode;
+import org.sonar.plugins.html.node.ExpressionNode;
+import org.sonar.plugins.html.node.Node;
+import org.sonar.plugins.html.node.TagNode;
+import org.sonar.plugins.html.node.TextNode;
+
+@Rule(key = "S9384")
+public class IdenticalLinksDifferentDestinationsCheck extends AbstractPageCheck {
+
+  private static final String MESSAGE = "This link has the same text as the one on line %d, but points to a different destination.";
+  private static final String HTTPS_SCHEME = "https://";
+
+  private final Map<String, LinkRecord> linksByName = new HashMap<>();
+
+  private boolean inLink;
+  private TagNode currentLinkNode;
+  private String hrefRaw;
+  private boolean hrefDynamic;
+  private boolean ariaLabelledbyPresent;
+  private String ariaLabelRaw;
+  private String titleRaw;
+  private final StringBuilder content = new StringBuilder();
+  private boolean nameDynamic;
+  private int hiddenDepth;
+
+  @Override
+  public void startDocument(List<Node> nodes) {
+    linksByName.clear();
+    inLink = false;
+    hiddenDepth = 0;
+  }
+
+  @Override
+  public void endDocument() {
+    linksByName.clear();
+  }
+
+  @Override
+  public void startElement(TagNode node) {
+    if (isLinkWithHref(node)) {
+      startLink(node);
+    } else if (inLink) {
+      boolean hidden = AccessibilityUtils.isHiddenFromScreenReader(node);
+      if (isVoidElement(node)) {
+        // Void elements never affect hiddenDepth: no children, and endElement may never fire.
+        if (hiddenDepth == 0 && !hidden) {
+          contributeDescendant(node);
+        }
+      } else if (hiddenDepth > 0) {
+        // Already hidden: every open/close pair balances back to 0 at the hiding ancestor's close.
+        hiddenDepth++;
+      } else if (hidden) {
+        hiddenDepth = 1;
+      } else {
+        contributeDescendant(node);
+      }
+    }
+  }
+
+  @Override
+  public void endElement(TagNode node) {
+    if (inLink && isA(node)) {
+      finalizeLink();
+      inLink = false;
+    } else if (inLink && !isVoidElement(node) && hiddenDepth > 0) {
+      hiddenDepth--;
+    }
+  }
+
+  @Override
+  public void characters(TextNode textNode) {
+    if (inLink && hiddenDepth == 0) {
+      appendContent(textNode.getCode());
+    }
+  }
+
+  @Override
+  public void expression(ExpressionNode node) {
+    if (inLink && hiddenDepth == 0) {
+      nameDynamic = true;
+    }
+  }
+
+  @Override
+  public void directive(DirectiveNode node) {
+    if (inLink && hiddenDepth == 0) {
+      nameDynamic = true;
+    }
+  }
+
+  private void startLink(TagNode node) {
+    inLink = true;
+    currentLinkNode = node;
+    hrefRaw = node.getAttribute("href");
+    hrefDynamic = isDynamic(hrefRaw);
+    ariaLabelledbyPresent = isNonBlank(node.getAttribute("aria-labelledby"));
+    ariaLabelRaw = node.getAttribute("aria-label");
+    titleRaw = node.getAttribute("title");
+    content.setLength(0);
+    nameDynamic = false;
+    hiddenDepth = 0;
+  }
+
+  private void contributeDescendant(TagNode node) {
+    if (isImg(node)) {
+      String alt = node.getAttribute("alt");
+      if (isNonBlank(alt)) {
+        appendContent(alt);
+      }
+    }
+    String templateText = AccessibilityUtils.getTemplateTextValue(node);
+    if (templateText != null) {
+      appendContent(templateText);
+    }
+  }
+
+  private void appendContent(String text) {
+    content.append(text);
+    if (isDynamic(text)) {
+      nameDynamic = true;
+    }
+  }
+
+  private void finalizeLink() {
+    if (!hrefDynamic && isNonBlank(hrefRaw)) {
+      String name = resolveAccessibleName();
+      if (name != null) {
+        String normalizedName = normalize(name);
+        if (!normalizedName.isEmpty()) {
+          compareAndReport(normalizedName, normalizeDestination(hrefRaw.trim()));
+        }
+      }
+    }
+    currentLinkNode = null;
+  }
+
+  private String resolveAccessibleName() {
+    if (ariaLabelledbyPresent) {
+      return null;
+    }
+    if (isNonBlank(ariaLabelRaw)) {
+      return isDynamic(ariaLabelRaw) ? null : ariaLabelRaw;
+    }
+    if (nameDynamic) {
+      return null;
+    }
+    String contentText = content.toString();
+    if (!contentText.trim().isEmpty()) {
+      return contentText;
+    }
+    if (isNonBlank(titleRaw)) {
+      return isDynamic(titleRaw) ? null : titleRaw;
+    }
+    return null;
+  }
+
+  private void compareAndReport(String normalizedName, String destination) {
+    LinkRecord existing = linksByName.get(normalizedName);
+    if (existing == null) {
+      linksByName.put(normalizedName, new LinkRecord(currentLinkNode.getStartLinePosition(), destination));
+    } else if (!existing.destination.equals(destination)) {
+      createViolation(currentLinkNode, String.format(MESSAGE, existing.line));
+      linksByName.put(normalizedName, new LinkRecord(currentLinkNode.getStartLinePosition(), destination));
+    }
+  }
+
+  private boolean isDynamic(@Nullable String value) {
+    return value != null && Helpers.containsDynamicValue(value, getHtmlSourceCode());
+  }
+
+  private static boolean isLinkWithHref(TagNode node) {
+    return isA(node) && node.hasAttribute("href");
+  }
+
+  private static boolean isA(TagNode node) {
+    return "a".equalsIgnoreCase(node.getNodeName());
+  }
+
+  private static boolean isImg(TagNode node) {
+    return "img".equalsIgnoreCase(node.getNodeName());
+  }
+
+  private static boolean isVoidElement(TagNode node) {
+    return HtmlConstants.VOID_ELEMENTS.contains(node.getNodeName().toLowerCase(Locale.ROOT));
+  }
+
+  private static boolean isNonBlank(@Nullable String value) {
+    return value != null && !value.trim().isEmpty();
+  }
+
+  private static String normalize(String text) {
+    return text.trim().replaceAll("\\s+", " ").toLowerCase(Locale.ROOT);
+  }
+
+  private static String normalizeDestination(String href) {
+    int hashIndex = href.indexOf('#');
+    String base = hashIndex >= 0 ? href.substring(0, hashIndex) : href;
+    String fragment = hashIndex >= 0 ? href.substring(hashIndex) : "";
+    String normalizedBase = normalizeScheme(base);
+    return isRoutingFragment(fragment) ? (normalizedBase + fragment) : normalizedBase;
+  }
+
+  private static boolean isRoutingFragment(String fragment) {
+    if (fragment.length() < 2) {
+      return false;
+    }
+    String rest = fragment.substring(1);
+    return rest.startsWith("/") || rest.startsWith("!/");
+  }
+
+  private static String normalizeScheme(String value) {
+    if (value.regionMatches(true, 0, "http://", 0, 7)) {
+      return HTTPS_SCHEME + value.substring(7);
+    }
+    if (value.regionMatches(true, 0, HTTPS_SCHEME, 0, HTTPS_SCHEME.length())) {
+      return HTTPS_SCHEME + value.substring(HTTPS_SCHEME.length());
+    }
+    return value;
+  }
+
+  private static final class LinkRecord {
+    private final int line;
+    private final String destination;
+
+    private LinkRecord(int line, String destination) {
+      this.line = line;
+      this.destination = destination;
+    }
+  }
+}

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S9384.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S9384.html
@@ -1,0 +1,43 @@
+<h2>Why is this an issue?</h2>
+<p>Some screen reader users navigate a page through a list of all its links, read out of context by their accessible name alone. When two links
+share the same accessible name but point to different destinations, these users have no way to tell them apart or to predict where each one leads
+before activating it.</p>
+<p>This rule raises an issue when two links share the same accessible name, normalized by trimming whitespace, collapsing repeated spaces and
+ignoring letter case, but resolve to different destinations. Destinations are compared on their scheme (<code>http</code> and <code>https</code>
+are treated as equivalent), path and query string; an in-page fragment such as <code>#section2</code> is discarded before comparing, since it does
+not change the destination, but a routing-style fragment such as <code>#/profile</code> or <code>#!/profile</code> is kept, since single-page
+applications commonly rely on it to identify a distinct destination.</p>
+<p>Links whose destination cannot be resolved statically are not checked, since it is not possible to reliably tell whether they share a
+destination with another link. Links with no accessible name at all are not flagged by this rule either; that case already raises an issue under
+rule S6827.</p>
+<p>Give each destination its own distinct, descriptive accessible name, so that a user reading only the link text, without any surrounding content,
+can predict where it leads.</p>
+<p>This rule only considers <code>a</code> elements with an <code>href</code> attribute; <code>area</code> elements and elements using
+<code>role="link"</code> are not covered. Comparison is scoped to a single HTML document. Only links whose <code>href</code> is a static attribute
+value are compared; links whose <code>href</code> contains a server-side directive or expression are ignored, as their destination cannot be
+resolved statically.</p>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+&lt;p&gt;See the &lt;a href="/pricing/enterprise"&gt;learn more&lt;/a&gt; about Enterprise.&lt;/p&gt;
+&lt;p&gt;See the &lt;a href="/pricing/starter"&gt;learn more&lt;/a&gt; about Starter.&lt;/p&gt; &lt;!-- Noncompliant: same text, different destination --&gt;
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+&lt;p&gt;See the &lt;a href="/pricing/enterprise"&gt;Enterprise plan details&lt;/a&gt;.&lt;/p&gt;
+&lt;p&gt;See the &lt;a href="/pricing/starter"&gt;Starter plan details&lt;/a&gt;.&lt;/p&gt;
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li>MDN web docs - <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a">&lt;a&gt;: The Anchor element</a></li>
+</ul>
+<h3>Standards</h3>
+<ul>
+  <li>W3C - <a href="https://www.w3.org/WAI/WCAG22/Understanding/link-purpose-link-only">WCAG 2.2 - 2.4.9 Link Purpose (Link Only)</a></li>
+</ul>
+<h3>Related rules</h3>
+<ul>
+  <li>axe-core identical-links-same-purpose - <a href="https://dequeuniversity.com/rules/axe/4.10/identical-links-same-purpose">Ensure that links
+  with the same accessible name serve a similar purpose</a></li>
+</ul>

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S9384.json
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S9384.json
@@ -1,0 +1,25 @@
+{
+  "title": "Links with the same accessible name should lead to the same destination",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5min"
+  },
+  "tags": [
+    "accessibility"
+  ],
+  "defaultSeverity": "Minor",
+  "ruleSpecification": "RSPEC-9384",
+  "sqKey": "S9384",
+  "scope": "All",
+  "defaultQualityProfiles": ["Sonar way"],
+  "quickfix": "infeasible",
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "LOW",
+      "RELIABILITY": "LOW"
+    },
+    "attribute": "CONVENTIONAL"
+  }
+}

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/Sonar_way_profile.json
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/Sonar_way_profile.json
@@ -59,6 +59,7 @@
     "S8720",
     "S8732",
     "S9379",
+    "S9384",
     "TableHeaderHasIdOrScopeCheck",
     "UnsupportedTagsInHtml5Check"
   ]

--- a/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/IdenticalLinksDifferentDestinationsCheckTest.java
+++ b/sonar-html-plugin/src/test/java/org/sonar/plugins/html/checks/accessibility/IdenticalLinksDifferentDestinationsCheckTest.java
@@ -1,0 +1,48 @@
+/*
+ * SonarQube HTML
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.html.checks.accessibility;
+
+import java.io.File;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.sonar.plugins.html.checks.CheckMessagesVerifierRule;
+import org.sonar.plugins.html.checks.TestHelper;
+import org.sonar.plugins.html.visitor.HtmlSourceCode;
+
+class IdenticalLinksDifferentDestinationsCheckTest {
+
+  @RegisterExtension
+  public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
+
+  @Test
+  void html() {
+    HtmlSourceCode sourceCode = TestHelper.scan(
+      new File("src/test/resources/checks/IdenticalLinksDifferentDestinationsCheck.html"),
+      new IdenticalLinksDifferentDestinationsCheck());
+
+    checkMessagesVerifier.verify(sourceCode.getIssues())
+      .next().atLine(6).withMessage("This link has the same text as the one on line 5, but points to a different destination.")
+      .next().atLine(14)
+      .next().atLine(22)
+      .next().atLine(46)
+      .next().atLine(55)
+      .next().atLine(59)
+      .next().atLine(69)
+      .next().atLine(70)
+      .noMore();
+  }
+}

--- a/sonar-html-plugin/src/test/resources/checks/IdenticalLinksDifferentDestinationsCheck.html
+++ b/sonar-html-plugin/src/test/resources/checks/IdenticalLinksDifferentDestinationsCheck.html
@@ -1,0 +1,73 @@
+<html lang="en">
+<body>
+
+<!-- 1. RSPEC example: same accessible name, different destination -->
+<p>See the <a href="/pricing/enterprise">learn more</a> about Enterprise.</p>
+<p>See the <a href="/pricing/starter">learn more</a> about Starter.</p> <!-- Noncompliant -->
+
+<!-- 2. Same accessible name, same destination: compliant -->
+<p><a href="/pricing/enterprise">Enterprise plan details</a></p>
+<p><a href="/pricing/enterprise">Enterprise plan details</a></p>
+
+<!-- 3. Case-insensitive, whitespace-collapsed name matching -->
+<a href="/a">View   Details</a>
+<a href="/b">view details</a> <!-- Noncompliant -->
+
+<!-- 4. In-page fragment ignored: compliant -->
+<a href="/docs#intro">Documentation</a>
+<a href="/docs#usage">Documentation</a>
+
+<!-- 5. Routing-style fragment kept: noncompliant -->
+<a href="/app#/profile">Account</a>
+<a href="/app#/settings">Account</a> <!-- Noncompliant -->
+
+<!-- 6. Matching routing-style fragment: compliant -->
+<a href="/app#!/profile">Account details</a>
+<a href="/app#!/profile">Account details</a>
+
+<!-- 7. http/https scheme equivalence: compliant -->
+<a href="http://example.com/help">Help</a>
+<a href="https://example.com/help">Help</a>
+
+<!-- 8. Dynamic href: skipped even though names match -->
+<a href="/download/one">Download</a>
+<a href="<%= url %>">Download</a>
+
+<!-- 9. Dynamic accessible name: skipped -->
+<a href="/item/1">{{ item.name }}</a>
+<a href="/item/2">{{ item.name }}</a>
+
+<!-- 10. No accessible name at all: not this rule's concern (S6827) -->
+<a href="/empty-one"></a>
+<a href="/empty-two"></a>
+
+<!-- 11. aria-label based accessible name -->
+<a href="/settings" aria-label="Account Settings">Settings</a>
+<a href="/preferences" aria-label="Account Settings">Prefs</a> <!-- Noncompliant -->
+
+<!-- 12. aria-labelledby present: skipped, not resolved -->
+<span id="lbl1">Read more</span>
+<a href="/one" aria-labelledby="lbl1">x</a>
+<a href="/two" aria-labelledby="lbl1">y</a>
+
+<!-- 13. Icon-only links named through descendant img alt text -->
+<a href="/profile"><img src="user.png" alt="View profile"></a>
+<a href="/settings2"><img src="user.png" alt="View profile"></a> <!-- Noncompliant -->
+
+<!-- 14. title fallback when content is empty -->
+<a href="/contact" title="Contact us"></a>
+<a href="/support" title="Contact us"></a> <!-- Noncompliant -->
+
+<!-- 15. area and role="link" are not covered by this rule -->
+<area href="/area-one" alt="Zone" shape="rect" coords="0,0,10,10">
+<area href="/area-two" alt="Zone" shape="rect" coords="0,0,10,10">
+<span role="link" onclick="go('/one')">Proceed</span>
+<span role="link" onclick="go('/two')">Proceed</span>
+
+<!-- 16. Three links, rolling baseline: each consecutive conflict flagged -->
+<a href="/x/1">Proceed</a>
+<a href="/x/2">Proceed</a> <!-- Noncompliant -->
+<a href="/x/1">Proceed</a> <!-- Noncompliant -->
+
+</body>
+</html>


### PR DESCRIPTION
----
## Summary by Gitar

- **New checks:**
    - Implemented accessibility rule `S9384` to detect identical links with different destinations
    - Added `IdenticalLinksDifferentDestinationsCheck` with unit tests and ruling metadata

<sub>This will update automatically on new commits.</sub>