### PR TITLE
SONARHTML-455 Update RSPEC before 3.32 release

### DIFF
--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/MouseEventWithoutKeyboardEquivalentCheck.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/MouseEventWithoutKeyboardEquivalentCheck.html
@@ -62,9 +62,10 @@ the platform:</p>
   <li><code>&lt;a&gt;</code>,</li>
   <li><code>&lt;summary&gt;</code>.</li>
 </ul>
-<p>Native controls with an implicit <code>textbox</code>, <code>checkbox</code>, <code>radio</code>, or <code>listbox</code> role are also skipped.
-This includes text inputs, <code>&lt;textarea&gt;</code>, <code>&lt;input type="checkbox"&gt;</code>, <code>&lt;input type="radio"&gt;</code>, and
-<code>&lt;select&gt;</code>.</p>
+<p>Native controls with an implicit <code>textbox</code>, <code>checkbox</code>, <code>radio</code>, <code>combobox</code>, or <code>listbox</code>
+role are also skipped. This includes text inputs, <code>&lt;textarea&gt;</code>, <code>&lt;input type="checkbox"&gt;</code>, <code>&lt;input
+type="radio"&gt;</code>, and <code>&lt;select&gt;</code>. A <code>&lt;select&gt;</code> has the implicit <code>combobox</code> role by default and the
+<code>listbox</code> role when it has the <code>multiple</code> attribute or a <code>size</code> greater than 1.</p>
 <p>Be aware that the anchor exception is broad: only an <code>&lt;a&gt;</code> with an <code>href</code> attribute is actually focusable and activated
 by Enter — an <code>&lt;a onClick&gt;</code> without <code>href</code> behaves like inert text from the keyboard. For button-like actions inside the
 page, prefer <code>&lt;button&gt;</code> over a bare <code>&lt;a&gt;</code>.</p>

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S7930.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S7930.html
@@ -13,6 +13,19 @@
 <h3>What is the potential impact?</h3>
 <p>Duplicate <code>id</code> attributes can break JavaScript functionality, cause inconsistent styling, and create accessibility barriers. Users may
 be unable to interact with certain page elements, and assistive technologies may not work correctly.</p>
+<h3>Exceptions</h3>
+<p>ASP.NET WebForms server controls are exempt when their effective <code>ClientIDMode</code> is <code>AutoID</code> or <code>Predictable</code>.
+Naming containers and data-bound templates prefix the declared <code>ID</code> at runtime, so equal declared IDs that render in separate runtime
+scopes do not produce duplicate HTML IDs.</p>
+<pre>
+&lt;asp:Repeater ID="first" runat="server"&gt;
+  &lt;ItemTemplate&gt;&lt;asp:Label ID="status" runat="server" /&gt;&lt;/ItemTemplate&gt;
+&lt;/asp:Repeater&gt;
+&lt;asp:Repeater ID="second" runat="server"&gt;
+  &lt;ItemTemplate&gt;&lt;asp:Label ID="status" runat="server" /&gt;&lt;/ItemTemplate&gt;
+&lt;/asp:Repeater&gt;
+</pre>
+<p>With <code>ClientIDMode="Static"</code>, the declared <code>ID</code> is rendered unchanged, so it must still be unique across the document.</p>
 <h2>How to fix it</h2>
 <p>Ensure each element has a unique <code>id</code> value. You can remove unnecessary <code>id</code> attributes or rename them to be unique.</p>
 <h3>Code examples</h3>

--- a/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S9379.html
+++ b/sonar-html-plugin/src/main/resources/org/sonar/l10n/web/rules/Web/S9379.html
@@ -1,11 +1,11 @@
 <h2>Why is this an issue?</h2>
-<p>Automatically moving keyboard focus to an element as soon as the page loads, before users have had a chance to get their bearings, can disorient
+<p>Automatically moving keyboard focus to an element when it is rendered or shown, before users have had a chance to get their bearings, can disorient
 or actively harm them:</p>
 <ul>
-  <li>Screen reader users lose the natural reading order: the screen reader jumps straight to the focused element and starts announcing from
-  there, skipping page landmarks, headings, and any content that precedes it.</li>
-  <li>Keyboard and switch-device users cannot navigate to the focused element in a controlled way and may have to navigate backwards through
-  earlier content to understand where they landed.</li>
+  <li>Screen reader users lose the natural reading order: the screen reader jumps straight to the focused element and starts announcing from there,
+  skipping page landmarks, headings, and any content that precedes it.</li>
+  <li>Keyboard and switch-device users cannot navigate to the focused element in a controlled way and may have to navigate backwards through earlier
+  content to understand where they landed.</li>
   <li>Users who need extra time to process a page, for example due to cognitive impairments, can lose their context when focus jumps unexpectedly,
   especially if it also triggers a viewport scroll.</li>
   <li>On touch devices, autofocusing a text input can open the on-screen keyboard unexpectedly and reflow the page.</li>
@@ -13,10 +13,9 @@ or actively harm them:</p>
 <p>Autofocusing a <code>dialog</code> element, an element with a <code>popover</code> attribute, an element with an ARIA <code>dialog</code> or
 <code>alertdialog</code> role, or any element inside one of these, does not raise this issue: moving focus into a freshly opened modal or popover is
 expected, and the dialog/popover element itself is a valid autofocus target when it should receive focus as soon as it opens.</p>
-<h2>How to fix it</h2>
 <p>Remove the attribute that autofocuses the element, and let the browser’s default focus behavior apply. If an element genuinely needs to receive
 focus in response to a user action, for example a form opened on demand, move it into a <code>dialog</code> element or a <code>popover</code>
-container instead of autofocusing it directly on page load.</p>
+container instead of autofocusing it directly when it is rendered or shown.</p>
 <h3>Code examples</h3>
 <h4>Noncompliant code example</h4>
 <pre data-diff-id="1" data-diff-type="noncompliant">
@@ -42,9 +41,9 @@ container instead of autofocusing it directly on page load.</p>
   &lt;input autofocus /&gt;
 &lt;/div&gt;
 </pre>
-<p>An <code>autofocus</code> attribute on a tag that is not a recognized native HTML element (a Vue or Angular component, or a custom element, in
-PascalCase or kebab-case) is not flagged, since the analyzer cannot resolve how such a tag renders. Frameworks like Vue pass undeclared attributes
-through to the component’s root element by default, so such code can still autofocus an element:</p>
+<p>In Vue templates, an <code>autofocus</code> attribute on a PascalCase or kebab-case tag is not flagged, since such tags are component references
+whose rendering the analyzer cannot resolve. Vue passes undeclared attributes through to the component’s root element by default, so such code can
+still autofocus an element:</p>
 <pre>
 &lt;CustomInput autofocus /&gt;
 &lt;custom-input autofocus /&gt;
@@ -61,3 +60,4 @@ through to the component’s root element by default, so such code can still aut
   <li>Bruce Lawson - <a href="https://www.brucelawson.co.uk/2009/the-accessibility-of-html-5-autofocus/">The accessibility of HTML 5
   autofocus</a></li>
 </ul>
+

--- a/sonarpedia.json
+++ b/sonarpedia.json
@@ -3,7 +3,7 @@
   "languages": [
     "HTML"
   ],
-  "latest-update": "2026-07-14T12:31:42.630722Z",
+  "latest-update": "2026-09-11T13:37:55.802964Z",
   "options": {
     "no-language-in-filenames": true,
     "preserve-filenames": true


### PR DESCRIPTION
## Summary
Synchronizes SonarHTML’s generated rule documentation with the current RSPEC sources for the 3.32 release.

## Changes
- Refresh S1082 guidance for native controls
- Document WebForms client-ID behavior for S7930
- Align S9379 autofocusing guidance with RSPEC